### PR TITLE
feat(admin): review assignment — self-assign, unassigned filter, 3-way queue filter (#78)

### DIFF
--- a/backend/src/admin/router.py
+++ b/backend/src/admin/router.py
@@ -520,11 +520,27 @@ async def assign(
     version_id: str,
     body: AssignRequest,
     request: Request,
-    admin: Annotated[dict, Depends(_require("review:assign"))],
+    admin: Annotated[dict, Depends(_require("review:annotate"))],
 ) -> AssignResponse:
-    """Assign (or unassign when admin_id is null) a version to a reviewer."""
+    """Assign (or unassign when admin_id is null) a version to a reviewer.
+
+    Self-assign and unassign require only ``review:annotate``.
+    Assigning to a *different* admin requires ``review:assign`` (product_admin+).
+    """
+    caller_id = _admin_id(admin)
+    if body.admin_id is not None and body.admin_id != caller_id:
+        perms = ROLE_PERMISSIONS.get(admin.get("role", ""), set())
+        if "*" not in perms and "review:assign" not in perms:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "forbidden",
+                    "detail": "Assigning to another admin requires 'review:assign' permission.",
+                    "correlation_id": getattr(request.state, "correlation_id", ""),
+                },
+            )
     async with get_db(request) as conn:
-        result = await assign_version(conn, version_id, body.admin_id, _admin_id(admin))
+        result = await assign_version(conn, version_id, body.admin_id, caller_id)
     if not result:
         raise HTTPException(status_code=404, detail="Version not found")
     return AssignResponse(**result)
@@ -536,7 +552,7 @@ async def assign(
 @router.get("/admin/users", response_model=AdminUsersResponse)
 async def admin_users(
     request: Request,
-    admin: Annotated[dict, Depends(_require("review:assign"))],
+    admin: Annotated[dict, Depends(_require("review:annotate"))],
 ) -> AdminUsersResponse:
     """List all active admin accounts (for assignment dropdowns)."""
     async with get_db(request) as conn:

--- a/backend/src/admin/service.py
+++ b/backend/src/admin/service.py
@@ -71,8 +71,12 @@ async def list_review_queue(
         params.append(curriculum_id)
         filters.append(f"csv.curriculum_id = ${len(params)}")
     if assigned_to_admin_id:
-        params.append(uuid.UUID(assigned_to_admin_id))
-        filters.append(f"csv.assigned_to_admin_id = ${len(params)}")
+        if assigned_to_admin_id == "unassigned":
+            # Special sentinel: return only versions with no assignee
+            filters.append("csv.assigned_to_admin_id IS NULL")
+        else:
+            params.append(uuid.UUID(assigned_to_admin_id))
+            filters.append(f"csv.assigned_to_admin_id = ${len(params)}")
 
     where = " AND ".join(filters)
 

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -525,7 +525,7 @@ async def test_assign_version_404_on_unknown(client, db_conn):
 
 @pytest.mark.asyncio
 async def test_assign_version_requires_permission(client, db_conn):
-    """developer role lacks review:assign — must get 403."""
+    """developer role lacks review:annotate — must get 403 even for self-assign."""
     version_id = await _insert_version(
         client, subject=f"AssignPerm-{uuid.uuid4().hex[:6]}", status="pending"
     )
@@ -535,6 +535,73 @@ async def test_assign_version_requires_permission(client, db_conn):
         headers=_admin_headers(role="developer"),
     )
     assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_self_assign_allowed_for_annotate_role(client, db_conn):
+    """tester role (has review:annotate) can assign the version to themselves."""
+    version_id = await _insert_version(
+        client, subject=f"SelfAssign-{uuid.uuid4().hex[:6]}", status="pending"
+    )
+    await _insert_admin(client)
+
+    with patch("src.core.events.write_audit_log"):
+        r = await client.post(
+            f"/api/v1/admin/content/review/{version_id}/assign",
+            # Assigning to the same admin_id as the JWT (self-assign)
+            json={"admin_id": _TEST_ADMIN_ID},
+            headers=_admin_headers(role="tester"),
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["assigned_to_admin_id"] == _TEST_ADMIN_ID
+
+
+@pytest.mark.asyncio
+async def test_assign_other_requires_assign_permission(client, db_conn):
+    """tester cannot assign to a *different* admin — requires review:assign."""
+    version_id = await _insert_version(
+        client, subject=f"AssignOther-{uuid.uuid4().hex[:6]}", status="pending"
+    )
+    other_admin_id = str(uuid.uuid4())
+    r = await client.post(
+        f"/api/v1/admin/content/review/{version_id}/assign",
+        json={"admin_id": other_admin_id},
+        headers=_admin_headers(role="tester"),
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_queue_unassigned_filter(client, db_conn):
+    """assigned_to=unassigned returns only versions with no assignee."""
+    curriculum_id = f"default-2026-g{uuid.uuid4().hex[:4]}"
+    await _insert_admin(client)
+
+    unassigned_vid = await _insert_version(
+        client, curriculum_id=curriculum_id,
+        subject=f"Unassigned-{uuid.uuid4().hex[:6]}", status="pending",
+    )
+    assigned_vid = await _insert_version(
+        client, curriculum_id=curriculum_id,
+        subject=f"Assigned-{uuid.uuid4().hex[:6]}", status="pending",
+    )
+    # Assign one of them
+    with patch("src.core.events.write_audit_log"):
+        await client.post(
+            f"/api/v1/admin/content/review/{assigned_vid}/assign",
+            json={"admin_id": _TEST_ADMIN_ID},
+            headers=_admin_headers(),
+        )
+
+    r = await client.get(
+        "/api/v1/admin/content/review/queue",
+        params={"curriculum_id": curriculum_id, "assigned_to": "unassigned"},
+        headers=_admin_headers(),
+    )
+    assert r.status_code == 200, r.text
+    ids = [item["version_id"] for item in r.json()["items"]]
+    assert unassigned_vid in ids
+    assert assigned_vid not in ids
 
 
 @pytest.mark.asyncio

--- a/web/app/(admin)/admin/content-review/[version_id]/page.tsx
+++ b/web/app/(admin)/admin/content-review/[version_id]/page.tsx
@@ -84,6 +84,7 @@ export default function AdminContentReviewDetailPage() {
   const unacknowledgedCount = warnings?.unacknowledged_count ?? item?.alex_warnings_count ?? 0;
   const approveBlocked = (item?.alex_warnings_count ?? 0) > 0 && unacknowledgedCount > 0;
 
+  const canSelfAssign = admin && hasPermission(admin.role, "tester");
   const canAssign = admin && hasPermission(admin.role, "product_admin");
 
   const { data: adminUsers } = useQuery({
@@ -189,20 +190,43 @@ export default function AdminContentReviewDetailPage() {
 
           {/* Assignment panel */}
           <div className="rounded-xl border border-gray-200 bg-white px-4 py-3">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 flex-wrap">
               <UserCheck className="h-4 w-4 flex-shrink-0 text-gray-400" />
               <span className="text-sm font-medium text-gray-700">Assigned reviewer</span>
               {item.assigned_to_email ? (
-                <span className="ml-1 text-sm text-gray-900">
-                  {item.assigned_to_email}
-                </span>
+                <span className="ml-1 text-sm text-gray-900">{item.assigned_to_email}</span>
               ) : (
                 <span className="ml-1 text-sm text-gray-400">Unassigned</span>
               )}
-              {canAssign && adminUsers && (
-                <div className="ml-auto flex items-center gap-2">
+
+              <div className="ml-auto flex items-center gap-2">
+                {/* Self-assign / unassign buttons (tester+) */}
+                {canSelfAssign && !canAssign && (
+                  <>
+                    {item.assigned_to_admin_id !== admin?.admin_id ? (
+                      <button
+                        onClick={() => assignMutation.mutate(admin!.admin_id)}
+                        disabled={assignMutation.isPending}
+                        className="rounded-md border border-indigo-200 bg-indigo-50 px-2.5 py-1 text-xs font-medium text-indigo-700 hover:bg-indigo-100 disabled:opacity-50"
+                      >
+                        Assign to me
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => assignMutation.mutate(null)}
+                        disabled={assignMutation.isPending}
+                        className="rounded-md border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50 disabled:opacity-50"
+                      >
+                        Unassign
+                      </button>
+                    )}
+                  </>
+                )}
+
+                {/* Full dropdown (product_admin+) */}
+                {canAssign && adminUsers && (
                   <select
-                    defaultValue={item.assigned_to_admin_id ?? ""}
+                    value={item.assigned_to_admin_id ?? ""}
                     onChange={(e) => assignMutation.mutate(e.target.value || null)}
                     disabled={assignMutation.isPending}
                     className="rounded-md border border-gray-200 px-2.5 py-1 text-xs text-gray-700 focus:border-indigo-400 focus:outline-none disabled:opacity-50"
@@ -214,11 +238,12 @@ export default function AdminContentReviewDetailPage() {
                       </option>
                     ))}
                   </select>
-                  {assignMutation.isError && (
-                    <span className="text-xs text-red-500">Failed</span>
-                  )}
-                </div>
-              )}
+                )}
+
+                {assignMutation.isError && (
+                  <span className="text-xs text-red-500">Failed</span>
+                )}
+              </div>
             </div>
             {item.assigned_at && (
               <p className="mt-1 pl-6 text-xs text-gray-400">

--- a/web/app/(admin)/admin/content-review/page.tsx
+++ b/web/app/(admin)/admin/content-review/page.tsx
@@ -3,12 +3,13 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { BatchApproveResult, batchApproveGrade, getReviewQueue } from "@/lib/api/admin";
-import { useAdmin } from "@/lib/hooks/useAdmin";
+import { BatchApproveResult, assignReview, batchApproveGrade, getReviewQueue } from "@/lib/api/admin";
+import { useAdmin, hasPermission } from "@/lib/hooks/useAdmin";
 import { cn } from "@/lib/utils";
 import { AlertTriangle, CheckCheck, ClipboardList, UserCheck } from "lucide-react";
 
 type StatusFilter = "pending" | "approved" | "published" | "rejected" | "blocked" | "";
+type AssignFilter = "all" | "mine" | "unassigned";
 
 const STATUS_STYLES: Record<string, string> = {
   pending: "bg-yellow-100 text-yellow-700",
@@ -39,27 +40,28 @@ interface ConfirmState {
 
 export default function AdminContentReviewPage() {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("pending");
-  const [myAssignments, setMyAssignments] = useState(false);
+  const [assignFilter, setAssignFilter] = useState<AssignFilter>("all");
   const [confirm, setConfirm] = useState<ConfirmState | null>(null);
   const [batchResult, setBatchResult] = useState<BatchApproveResult | null>(null);
   const queryClient = useQueryClient();
   const admin = useAdmin();
+  const canSelfAssign = admin && hasPermission(admin.role, "tester");
+
+  const assignedToParam =
+    assignFilter === "mine" && admin ? admin.admin_id :
+    assignFilter === "unassigned" ? "unassigned" :
+    undefined;
 
   const { data, isLoading } = useQuery({
-    queryKey: [
-      "admin",
-      "content-review",
-      statusFilter,
-      myAssignments ? admin?.admin_id : null,
-    ],
-    queryFn: () =>
-      getReviewQueue(
-        statusFilter || undefined,
-        undefined,
-        undefined,
-        myAssignments && admin ? admin.admin_id : undefined,
-      ),
+    queryKey: ["admin", "content-review", statusFilter, assignFilter, admin?.admin_id],
+    queryFn: () => getReviewQueue(statusFilter || undefined, undefined, undefined, assignedToParam),
     staleTime: 30_000,
+  });
+
+  const selfAssignMutation = useMutation({
+    mutationFn: (versionId: string) => assignReview(versionId, admin!.admin_id),
+    onSuccess: () =>
+      void queryClient.invalidateQueries({ queryKey: ["admin", "content-review"] }),
   });
 
   const batchMutation = useMutation({
@@ -113,19 +115,22 @@ export default function AdminContentReviewPage() {
             {s || "All"}
           </button>
         ))}
-        <div className="ml-auto">
-          <button
-            onClick={() => setMyAssignments((v) => !v)}
-            className={cn(
-              "flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-colors",
-              myAssignments
-                ? "bg-indigo-100 text-indigo-700"
-                : "bg-gray-100 text-gray-600 hover:bg-gray-200",
-            )}
-          >
-            <UserCheck className="h-3.5 w-3.5" />
-            My assignments
-          </button>
+        <div className="ml-auto flex items-center gap-1 rounded-full bg-gray-100 p-1">
+          {(["all", "mine", "unassigned"] as AssignFilter[]).map((f) => (
+            <button
+              key={f}
+              onClick={() => setAssignFilter(f)}
+              className={cn(
+                "flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium transition-colors",
+                assignFilter === f
+                  ? "bg-white text-gray-900 shadow-sm"
+                  : "text-gray-500 hover:text-gray-700",
+              )}
+            >
+              {f === "mine" && <UserCheck className="h-3 w-3" />}
+              {f === "all" ? "All" : f === "mine" ? "Mine" : "Unassigned"}
+            </button>
+          ))}
         </div>
       </div>
 
@@ -248,9 +253,23 @@ export default function AdminContentReviewPage() {
                               {new Date(item.generated_at).toLocaleDateString()}
                             </td>
                             <td className="px-4 py-3 text-xs text-gray-500">
-                              {item.assigned_to_email ?? (
-                                <span className="text-gray-300">—</span>
-                              )}
+                              <div className="flex items-center gap-2">
+                                <span>
+                                  {item.assigned_to_email ?? (
+                                    <span className="text-gray-300">—</span>
+                                  )}
+                                </span>
+                                {canSelfAssign &&
+                                  item.assigned_to_admin_id !== admin?.admin_id && (
+                                    <button
+                                      onClick={() => selfAssignMutation.mutate(item.version_id)}
+                                      disabled={selfAssignMutation.isPending}
+                                      className="rounded bg-indigo-50 px-1.5 py-0.5 text-xs font-medium text-indigo-600 hover:bg-indigo-100 disabled:opacity-50"
+                                    >
+                                      Assign to me
+                                    </button>
+                                  )}
+                              </div>
                             </td>
                             <td className="px-4 py-3 text-right">
                               {item.has_content ? (


### PR DESCRIPTION
## Summary

Implements issue #78 — lightweight review assignment so each content version has a named reviewer.

- **Backend**: Assign endpoint permission lowered to `review:annotate` for self-assign; assigning to a *different* admin enforces `review:assign` inline in the handler. `list_review_queue` now accepts `assigned_to=unassigned` sentinel to return only unassigned versions.
- **Frontend queue**: Binary "My assignments" toggle replaced with a 3-way filter (All / Mine / Unassigned). Each queue row gets an "Assign to me" quick-action button visible to `tester`+ when the version isn't already assigned to them.
- **Frontend detail**: `tester`+ sees "Assign to me" / "Unassign" buttons; `product_admin`+ retains the full admin dropdown.

## Acceptance criteria

- [x] Queue shows assigned admin email (or —)
- [x] "Assigned to me" / "Unassigned" / "All" filter works
- [x] Assigning self requires only `review:annotate`
- [x] Assigning to another admin requires `product_admin`+ (`review:assign`)
- [x] Null assignment = unassign (idempotent — existing)
- [x] audit_log entry on every assignment change (existing)
- [x] Tests: self-assign, assign-other blocked, unassigned filter, permission checks

## Test plan
- [x] 40/40 backend tests pass (`pytest tests/test_admin.py`)
- [ ] Manual: tester login → queue → "Assign to me" appears → click → assigned
- [ ] Manual: tester → detail page → "Assign to me" / "Unassign" toggle
- [ ] Manual: "Unassigned" filter shows only unassigned rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)