### PR TITLE
feat(school-billing): Option A — curriculum build allowance absorbed into plan

### DIFF
--- a/backend/alembic/versions/0032_build_allowance.py
+++ b/backend/alembic/versions/0032_build_allowance.py
@@ -1,0 +1,59 @@
+"""0032 — build_allowance: track curriculum build quota per school subscription year
+
+Adds three columns to school_storage_quotas so the platform can enforce
+Option A: absorbed into plan with a hard annual allowance.
+
+  builds_included  — how many grade builds the plan covers per year.
+                     Stamped from plan defaults at subscription activation time.
+                     -1 = unlimited (Enterprise).
+  builds_used      — cumulative grade builds consumed in the current period.
+                     Incremented each time a school-scoped pipeline job completes.
+  builds_period_end — when the current allowance resets (1 year from activation).
+
+A Celery Beat task (future: feat/q3-b-pay-per-build) will reset builds_used
+and roll builds_period_end forward annually.
+
+Revision ID: 0032
+Revises: 0031
+Create Date: 2026-04-10
+"""
+
+from alembic import op
+
+revision = "0032"
+down_revision = "0031"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE school_storage_quotas
+            ADD COLUMN IF NOT EXISTS builds_included  INTEGER NOT NULL DEFAULT 1,
+            ADD COLUMN IF NOT EXISTS builds_used      INTEGER NOT NULL DEFAULT 0,
+            ADD COLUMN IF NOT EXISTS builds_period_end TIMESTAMPTZ
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE school_storage_quotas
+            ADD CONSTRAINT school_storage_quotas_builds_included_check
+                CHECK (builds_included >= -1),
+            ADD CONSTRAINT school_storage_quotas_builds_used_check
+                CHECK (builds_used >= 0)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE school_storage_quotas
+            DROP CONSTRAINT IF EXISTS school_storage_quotas_builds_used_check,
+            DROP CONSTRAINT IF EXISTS school_storage_quotas_builds_included_check,
+            DROP COLUMN IF EXISTS builds_period_end,
+            DROP COLUMN IF EXISTS builds_used,
+            DROP COLUMN IF EXISTS builds_included
+        """
+    )

--- a/backend/config.py
+++ b/backend/config.py
@@ -220,6 +220,25 @@ class Settings(BaseSettings):
     # ── Extra curriculum build price ──────────────────────────────────────────
     STRIPE_SCHOOL_PRICE_EXTRA_BUILD_ID: str | None = None  # $15/grade build — Q3-B #106
 
+    # ── School curriculum build allowance per plan (Option A — absorbed into plan)
+    # Number of grade-level pipeline builds included per subscription year.
+    # -1 = unlimited (Enterprise).
+    # Future: Option B (pay-per-build) and Option C (credit bundles) tracked in
+    # GitHub issues feat/q3-b-pay-per-build and feat/q3-c-credit-bundles.
+    SCHOOL_BUILDS_STARTER: int = 1
+    SCHOOL_BUILDS_PROFESSIONAL: int = 3
+    SCHOOL_BUILDS_ENTERPRISE: int = -1  # unlimited
+
+    # ── Independent Teacher plan pricing (Option A — flat fee, teacher keeps student revenue)
+    # Future: Option B (revenue share) tracked in feat/q2-b-revenue-share.
+    #         Option C (seat-tiered flat) tracked in feat/q2-c-seat-tiered.
+    TEACHER_PLAN_SOLO_MONTHLY_USD: str = "29.00"   # Solo: up to 25 students
+    TEACHER_PLAN_GROWTH_MONTHLY_USD: str = "59.00"  # Growth: up to 75 students (future)
+    TEACHER_PLAN_PRO_MONTHLY_USD: str = "99.00"     # Pro: up to 200 students (future)
+
+    # ── Extra curriculum build price (Stripe one-time, beyond plan allowance) ──
+    STRIPE_SCHOOL_PRICE_EXTRA_BUILD_ID: str | None = None  # $15/grade build
+
     # ── Feature flags ─────────────────────────────────────────────────────────
     REVIEW_AUTO_APPROVE: bool = False
 

--- a/backend/src/school/subscription_service.py
+++ b/backend/src/school/subscription_service.py
@@ -43,6 +43,133 @@ def _plan_seats(plan: str) -> dict[str, int]:
     return plan_seats(plan)
 
 
+def _plan_builds(plan: str) -> int:
+    """
+    Return builds_included for a plan (Option A: absorbed into plan).
+
+    -1 = unlimited (Enterprise).
+    """
+    from config import settings
+
+    mapping = {
+        "starter": settings.SCHOOL_BUILDS_STARTER,
+        "professional": settings.SCHOOL_BUILDS_PROFESSIONAL,
+        "enterprise": settings.SCHOOL_BUILDS_ENTERPRISE,
+    }
+    return mapping.get(plan, settings.SCHOOL_BUILDS_STARTER)
+
+
+# ── Build allowance (Option A — absorbed into plan) ───────────────────────────
+
+
+async def _stamp_build_allowance(
+    conn: asyncpg.Connection,
+    school_id: str,
+    plan: str,
+    period_end: datetime | None = None,
+) -> None:
+    """
+    Upsert school_storage_quotas with builds_included from the plan and reset
+    builds_used to 0.  Called on subscription activation and on annual renewal.
+
+    builds_period_end defaults to 1 year from now when not supplied.
+    """
+    builds = _plan_builds(plan)
+    if period_end is None:
+        period_end = datetime.now(UTC) + timedelta(days=365)
+
+    await conn.execute(
+        """
+        INSERT INTO school_storage_quotas (school_id, builds_included, builds_used, builds_period_end)
+        VALUES ($1, $2, 0, $3)
+        ON CONFLICT (school_id) DO UPDATE SET
+            builds_included  = EXCLUDED.builds_included,
+            builds_used      = 0,
+            builds_period_end = EXCLUDED.builds_period_end,
+            updated_at       = NOW()
+        """,
+        uuid.UUID(school_id),
+        builds,
+        period_end,
+    )
+    log.info(
+        "build_allowance_stamped school_id=%s plan=%s builds_included=%d",
+        school_id,
+        plan,
+        builds,
+    )
+
+
+async def check_build_allowance(
+    conn: asyncpg.Connection,
+    school_id: str,
+) -> dict:
+    """
+    Return the current build allowance state for a school.
+
+    Returns:
+      allowed         — True if the school can trigger another pipeline build.
+      builds_included — total builds per year (-1 = unlimited).
+      builds_used     — builds consumed this period.
+      builds_remaining — builds_included - builds_used, or -1 if unlimited.
+      builds_period_end — ISO timestamp when the allowance resets.
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT builds_included, builds_used, builds_period_end
+        FROM school_storage_quotas
+        WHERE school_id = $1
+        """,
+        uuid.UUID(school_id),
+    )
+    if row is None:
+        # No quota row yet — school has no subscription, treat as 0 allowance.
+        return {
+            "allowed": False,
+            "builds_included": 0,
+            "builds_used": 0,
+            "builds_remaining": 0,
+            "builds_period_end": None,
+        }
+
+    included = row["builds_included"]
+    used = row["builds_used"]
+    unlimited = included == -1
+    remaining = -1 if unlimited else max(included - used, 0)
+    allowed = unlimited or remaining > 0
+
+    return {
+        "allowed": allowed,
+        "builds_included": included,
+        "builds_used": used,
+        "builds_remaining": remaining,
+        "builds_period_end": row["builds_period_end"].isoformat() if row["builds_period_end"] else None,
+    }
+
+
+async def consume_build(
+    conn: asyncpg.Connection,
+    school_id: str,
+) -> None:
+    """
+    Increment builds_used for a school after a successful pipeline build.
+
+    Does not check the allowance — call check_build_allowance first and enforce
+    before triggering the pipeline job (see school-scoped pipeline trigger, #61).
+    Safe to call for Enterprise schools (builds_included = -1); the counter is
+    incremented for audit purposes but never blocks access.
+    """
+    await conn.execute(
+        """
+        UPDATE school_storage_quotas
+        SET builds_used = builds_used + 1, updated_at = NOW()
+        WHERE school_id = $1
+        """,
+        uuid.UUID(school_id),
+    )
+    log.info("build_consumed school_id=%s", school_id)
+
+
 # ── Seat usage ────────────────────────────────────────────────────────────────
 
 
@@ -86,6 +213,7 @@ async def get_school_subscription_status(
     )
 
     usage = await get_seat_usage(conn, school_id)
+    builds = await check_build_allowance(conn, school_id)
 
     if row is None:
         return {
@@ -95,6 +223,7 @@ async def get_school_subscription_status(
             "max_teachers": 0,
             "current_period_end": None,
             **usage,
+            **{f"builds_{k}": v for k, v in builds.items() if k != "allowed"},
         }
 
     if row["status"] == "past_due" and row["grace_period_end"]:
@@ -111,6 +240,7 @@ async def get_school_subscription_status(
         "max_teachers": row["max_teachers"],
         "current_period_end": valid_until,
         **usage,
+        **{f"builds_{k}": v for k, v in builds.items() if k != "allowed"},
     }
 
 
@@ -250,6 +380,9 @@ async def activate_school_subscription(
 
     # Bulk-upsert student_entitlements for all enrolled students
     await _bulk_update_enrolled_student_entitlements(conn, school_id, plan, current_period_end)
+
+    # Stamp build allowance for the new subscription period (Option A).
+    await _stamp_build_allowance(conn, school_id, plan, current_period_end)
 
     await expire_school_entitlement_cache(redis, school_id)
     log.info("school_subscription_activated school_id=%s plan=%s", school_id, plan)

--- a/backend/tests/test_school_subscription.py
+++ b/backend/tests/test_school_subscription.py
@@ -409,3 +409,173 @@ async def test_teacher_invite_blocked_at_seat_limit(client: AsyncClient):
     )
     assert r.status_code == 402, r.text
     assert r.json()["error"] == "seat_limit_reached"
+
+
+# ── Build allowance (Option A) ────────────────────────────────────────────────
+
+
+async def _insert_quota_row(
+    client: AsyncClient,
+    school_id: str,
+    builds_included: int = 3,
+    builds_used: int = 0,
+    builds_period_end_days: int = 365,
+) -> None:
+    """Insert a school_storage_quotas row with build allowance columns set."""
+    pool = client._transport.app.state.pool
+    await pool.execute(
+        """
+        INSERT INTO school_storage_quotas
+            (school_id, builds_included, builds_used, builds_period_end)
+        VALUES ($1, $2, $3, NOW() + ($4 || ' days')::INTERVAL)
+        ON CONFLICT (school_id) DO UPDATE SET
+            builds_included   = EXCLUDED.builds_included,
+            builds_used       = EXCLUDED.builds_used,
+            builds_period_end = EXCLUDED.builds_period_end,
+            updated_at        = NOW()
+        """,
+        uuid.UUID(school_id),
+        builds_included,
+        builds_used,
+        str(builds_period_end_days),
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_build_allowance_no_quota_row(client: AsyncClient):
+    """Returns allowed=False with 0 allowance when no quota row exists."""
+    from src.school.subscription_service import check_build_allowance
+
+    reg = await _register_school(client)
+    school_id = reg["school_id"]
+    pool = client._transport.app.state.pool
+
+    async with pool.acquire() as conn:
+        result = await check_build_allowance(conn, school_id)
+
+    assert result["allowed"] is False
+    assert result["builds_included"] == 0
+    assert result["builds_used"] == 0
+    assert result["builds_remaining"] == 0
+    assert result["builds_period_end"] is None
+
+
+@pytest.mark.asyncio
+async def test_check_build_allowance_has_remaining(client: AsyncClient):
+    """Returns allowed=True with correct remaining count when builds available."""
+    from src.school.subscription_service import check_build_allowance
+
+    reg = await _register_school(client)
+    school_id = reg["school_id"]
+    await _insert_quota_row(client, school_id, builds_included=3, builds_used=1)
+
+    pool = client._transport.app.state.pool
+    async with pool.acquire() as conn:
+        result = await check_build_allowance(conn, school_id)
+
+    assert result["allowed"] is True
+    assert result["builds_included"] == 3
+    assert result["builds_used"] == 1
+    assert result["builds_remaining"] == 2
+    assert result["builds_period_end"] is not None
+
+
+@pytest.mark.asyncio
+async def test_check_build_allowance_exhausted(client: AsyncClient):
+    """Returns allowed=False when builds_used >= builds_included."""
+    from src.school.subscription_service import check_build_allowance
+
+    reg = await _register_school(client)
+    school_id = reg["school_id"]
+    await _insert_quota_row(client, school_id, builds_included=1, builds_used=1)
+
+    pool = client._transport.app.state.pool
+    async with pool.acquire() as conn:
+        result = await check_build_allowance(conn, school_id)
+
+    assert result["allowed"] is False
+    assert result["builds_remaining"] == 0
+
+
+@pytest.mark.asyncio
+async def test_check_build_allowance_enterprise_unlimited(client: AsyncClient):
+    """Enterprise plan (-1) reports allowed=True and builds_remaining=-1."""
+    from src.school.subscription_service import check_build_allowance
+
+    reg = await _register_school(client)
+    school_id = reg["school_id"]
+    await _insert_quota_row(client, school_id, builds_included=-1, builds_used=99)
+
+    pool = client._transport.app.state.pool
+    async with pool.acquire() as conn:
+        result = await check_build_allowance(conn, school_id)
+
+    assert result["allowed"] is True
+    assert result["builds_included"] == -1
+    assert result["builds_remaining"] == -1
+
+
+@pytest.mark.asyncio
+async def test_consume_build_increments_counter(client: AsyncClient):
+    """consume_build increments builds_used by 1."""
+    from src.school.subscription_service import check_build_allowance, consume_build
+
+    reg = await _register_school(client)
+    school_id = reg["school_id"]
+    await _insert_quota_row(client, school_id, builds_included=3, builds_used=0)
+
+    pool = client._transport.app.state.pool
+    async with pool.acquire() as conn:
+        await consume_build(conn, school_id)
+        result = await check_build_allowance(conn, school_id)
+
+    assert result["builds_used"] == 1
+    assert result["builds_remaining"] == 2
+
+
+@pytest.mark.asyncio
+async def test_stamp_build_allowance_resets_on_reactivation(client: AsyncClient):
+    """_stamp_build_allowance resets builds_used=0 and sets builds_included from plan."""
+    from src.school.subscription_service import _stamp_build_allowance, check_build_allowance
+
+    reg = await _register_school(client)
+    school_id = reg["school_id"]
+    # Start with used=2 (simulating mid-year)
+    await _insert_quota_row(client, school_id, builds_included=3, builds_used=2)
+
+    pool = client._transport.app.state.pool
+    new_period_end = datetime.now(UTC) + timedelta(days=365)
+    async with pool.acquire() as conn:
+        # Simulate reactivation on professional plan
+        await _stamp_build_allowance(conn, school_id, "professional", new_period_end)
+        result = await check_build_allowance(conn, school_id)
+
+    assert result["builds_used"] == 0           # reset
+    assert result["builds_included"] == 3       # professional = 3
+    assert result["builds_remaining"] == 3
+    assert result["allowed"] is True
+
+
+@pytest.mark.asyncio
+async def test_subscription_status_response_includes_builds_fields(client: AsyncClient):
+    """GET /subscription response includes builds_included, builds_used, builds_remaining."""
+    reg = await _register_school(client)
+    school_id = reg["school_id"]
+    token = make_teacher_token(teacher_id=reg["teacher_id"], school_id=school_id, role="school_admin")
+
+    await _insert_school_subscription(client, school_id, plan="professional")
+    await _insert_quota_row(client, school_id, builds_included=3, builds_used=1)
+
+    r = await client.get(
+        f"/api/v1/schools/{school_id}/subscription",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+
+    assert "builds_included" in data
+    assert "builds_used" in data
+    assert "builds_remaining" in data
+    assert data["builds_included"] == 3
+    assert data["builds_used"] == 1
+    assert data["builds_remaining"] == 2

--- a/web/app/(school)/school/subscription/page.tsx
+++ b/web/app/(school)/school/subscription/page.tsx
@@ -11,7 +11,7 @@ import {
 import { SCHOOL_PLANS_LIST, formatPlanPrice } from "@/lib/pricing";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Loader2, CheckCircle, XCircle, CreditCard, Users, GraduationCap, AlertTriangle } from "lucide-react";
+import { Loader2, CheckCircle, XCircle, CreditCard, Users, GraduationCap, AlertTriangle, Hammer } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // ── Seat usage bar ────────────────────────────────────────────────────────────
@@ -266,6 +266,19 @@ export default function SubscriptionPage() {
                       max={sub.max_teachers}
                       icon={<GraduationCap className="h-3.5 w-3.5 text-gray-400" />}
                     />
+                    {sub.builds_included === -1 ? (
+                      <div className="flex items-center gap-1.5 text-xs text-gray-500">
+                        <Hammer className="h-3.5 w-3.5 text-gray-400" />
+                        Unlimited curriculum builds (Enterprise)
+                      </div>
+                    ) : (
+                      <SeatBar
+                        label="Curriculum builds / year"
+                        used={sub.builds_used}
+                        max={sub.builds_included}
+                        icon={<Hammer className="h-3.5 w-3.5 text-gray-400" />}
+                      />
+                    )}
                   </div>
 
                   {periodEndDate && (

--- a/web/lib/api/school-admin.ts
+++ b/web/lib/api/school-admin.ts
@@ -189,6 +189,11 @@ export interface SchoolSubscription {
   seats_used_students: number;
   seats_used_teachers: number;
   current_period_end: string | null;
+  // Curriculum build allowance (Option A — absorbed into plan)
+  builds_included: number;    // -1 = unlimited (Enterprise)
+  builds_used: number;
+  builds_remaining: number;   // -1 = unlimited
+  builds_period_end: string | null;
 }
 
 export async function getSchoolSubscription(schoolId: string): Promise<SchoolSubscription> {


### PR DESCRIPTION
## Summary

- **Migration 0032**: adds `builds_included`, `builds_used`, `builds_period_end` to `school_storage_quotas` (1/yr Starter · 3/yr Professional · unlimited Enterprise)
- **Backend service**: `check_build_allowance()` and `consume_build()` give the school-scoped pipeline trigger (#61) a clean interface to enforce quotas; `_stamp_build_allowance()` resets the counter on every subscription activation/renewal
- **Subscription page**: current-plan card now shows a "Curriculum builds / year" progress bar; Enterprise shows an "Unlimited" badge instead
- **API type**: `SchoolSubscription` extended with `builds_included`, `builds_used`, `builds_remaining`, `builds_period_end`
- **Tests**: 7 new integration tests covering no-row, has-remaining, exhausted, unlimited, consume, stamp-reset, and API response shape
- **Future options tracked**: Q2-B #104, Q2-C #105, Q3-B #106, Q3-C #107

## Architecture note

Build allowance enforcement belongs in the school-scoped pipeline trigger (#61, not yet built). The admin pipeline trigger (`POST /admin/pipeline/trigger`) is not subject to school build quotas — it is admin-only. The service layer (`check_build_allowance`, `consume_build`) is ready to be called from #61.

## Test plan

- [ ] Run `docker compose exec api pytest tests/test_school_subscription.py -v` — all 19 tests pass (12 existing + 7 new)
- [ ] Register a school, activate a Starter subscription via webhook mock → confirm `builds_included=1` in `GET /schools/{id}/subscription`
- [ ] Subscribe to Professional → confirm `builds_included=3`
- [ ] School subscription page shows builds progress bar for non-Enterprise plans
- [ ] Enterprise plan shows "Unlimited curriculum builds" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)