### PR TITLE
feat(billing): independent teacher subscription plans — Solo/Growth/Pro (#57)

### DIFF
--- a/backend/alembic/versions/0034_independent_teacher_subscriptions.py
+++ b/backend/alembic/versions/0034_independent_teacher_subscriptions.py
@@ -1,0 +1,110 @@
+"""0034 — independent_teacher_subscriptions
+
+Adds Stripe billing support for independent (non-school-affiliated) teachers.
+
+An independent teacher signs up without a school invitation, pays a flat monthly
+fee (Solo $29 · Growth $59 · Pro $99), and teaches up to 25 / 75 / 200 students.
+The teacher keeps 100% of any student-side revenue they collect (Option A, #57).
+
+Schema changes
+──────────────
+1. teacher_subscriptions
+   Mirrors the school_subscriptions table but scoped to a single teacher.
+   Fields: teacher_id (PK → teachers), plan, status, max_students,
+           stripe_customer_id, stripe_subscription_id,
+           current_period_end, grace_period_end, created_at, updated_at.
+
+2. teachers.teacher_plan
+   Denormalised fast-read column: 'solo' | 'growth' | 'pro' | NULL.
+   NULL = school-affiliated (no independent plan).
+   Kept in sync by the subscription webhook.
+
+Revision ID: 0034
+Revises: 0033
+Create Date: 2026-04-10
+"""
+
+from alembic import op
+
+revision = "0034"
+down_revision = "0033"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Extend the demo-only NULL school_id guard to also allow independent teachers.
+    # Old constraint: school_id IS NOT NULL OR auth_provider = 'demo'
+    # New constraint: school_id IS NOT NULL OR auth_provider IN ('demo', 'auth0')
+    #   where auth_provider='auth0' with school_id IS NULL = independent teacher.
+    # The independent teacher path is distinguished from school-auth0-teachers by
+    # school_id IS NULL; demo teachers continue to use auth_provider='demo'.
+    op.execute(
+        "ALTER TABLE teachers DROP CONSTRAINT IF EXISTS chk_teachers_school_id_or_demo"
+    )
+    op.execute(
+        """
+        ALTER TABLE teachers
+            ADD CONSTRAINT chk_teachers_school_id_or_demo
+                CHECK (school_id IS NOT NULL OR auth_provider IN ('demo', 'auth0'))
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS teacher_subscriptions (
+            teacher_id          UUID        PRIMARY KEY
+                                            REFERENCES teachers(teacher_id)
+                                            ON DELETE CASCADE,
+            plan                VARCHAR(20) NOT NULL
+                                            CHECK (plan IN ('solo', 'growth', 'pro')),
+            status              VARCHAR(20) NOT NULL DEFAULT 'active'
+                                            CHECK (status IN ('active', 'past_due',
+                                                              'cancelled', 'trialing')),
+            max_students        INTEGER     NOT NULL DEFAULT 25,
+            stripe_customer_id  VARCHAR(255),
+            stripe_subscription_id VARCHAR(255),
+            current_period_end  TIMESTAMPTZ,
+            grace_period_end    TIMESTAMPTZ,
+            created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_teacher_subscriptions_stripe_sub
+            ON teacher_subscriptions (stripe_subscription_id)
+            WHERE stripe_subscription_id IS NOT NULL
+        """
+    )
+    # Denormalised plan column on teachers for fast JWT population.
+    op.execute(
+        """
+        ALTER TABLE teachers
+            ADD COLUMN IF NOT EXISTS teacher_plan VARCHAR(20)
+                CHECK (teacher_plan IN ('solo', 'growth', 'pro'))
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE teachers DROP COLUMN IF EXISTS teacher_plan")
+    op.execute("DROP TABLE IF EXISTS teacher_subscriptions")
+    # Remove independent-teacher rows before reinstating the demo-only constraint.
+    # SET LOCAL ensures the RLS bypass applies within this migration's transaction
+    # even when running as a non-superuser (e.g. the studybuddy_rls_tester role in CI).
+    op.execute("SELECT set_config('app.current_school_id', 'bypass', true)")
+    op.execute(
+        "DELETE FROM teachers WHERE auth_provider = 'auth0' AND school_id IS NULL"
+    )
+    op.execute(
+        "ALTER TABLE teachers DROP CONSTRAINT IF EXISTS chk_teachers_school_id_or_demo"
+    )
+    op.execute(
+        """
+        ALTER TABLE teachers
+            ADD CONSTRAINT chk_teachers_school_id_or_demo
+                CHECK (school_id IS NOT NULL OR auth_provider = 'demo')
+        """
+    )

--- a/backend/config.py
+++ b/backend/config.py
@@ -264,6 +264,12 @@ class Settings(BaseSettings):
     TEACHER_PLAN_GROWTH_MONTHLY_USD: str = "59.00"  # Growth: up to 75 students (future)
     TEACHER_PLAN_PRO_MONTHLY_USD: str = "99.00"     # Pro: up to 200 students (future)
 
+    # ── Independent Teacher plan — Stripe recurring price IDs (#57) ──────────
+    # Leave unset in dev — subscription endpoints return 503 when unconfigured.
+    STRIPE_TEACHER_PRICE_SOLO_ID: str | None = None     # $29/mo recurring
+    STRIPE_TEACHER_PRICE_GROWTH_ID: str | None = None   # $59/mo recurring
+    STRIPE_TEACHER_PRICE_PRO_ID: str | None = None      # $99/mo recurring
+
     # ── Mobile API versioning ─────────────────────────────────────────────────
     # Oldest mobile app version the backend will accept (semver string).
     # Requests carrying X-App-Version below this receive HTTP 426 Upgrade Required.

--- a/backend/src/core/app_factory.py
+++ b/backend/src/core/app_factory.py
@@ -239,6 +239,7 @@ def _register_routers(app: FastAPI) -> None:
     from src.school.subscription_router import router as school_subscription_router
     from src.student.router import router as student_router
     from src.subscription.router import router as subscription_router
+    from src.teacher.subscription_router import router as teacher_subscription_router
 
     # Health + metrics at root (no /api/v1 prefix).
     app.include_router(obs_router)
@@ -259,6 +260,7 @@ def _register_routers(app: FastAPI) -> None:
     app.include_router(school_router, prefix="/api/v1")
     app.include_router(school_content_router, prefix="/api/v1")
     app.include_router(school_subscription_router, prefix="/api/v1")
+    app.include_router(teacher_subscription_router, prefix="/api/v1")
     app.include_router(school_limits_router, prefix="/api/v1")
     app.include_router(school_pipeline_router, prefix="/api/v1")
     app.include_router(school_retention_router, prefix="/api/v1")

--- a/backend/src/pricing.py
+++ b/backend/src/pricing.py
@@ -282,16 +282,28 @@ AI_COST = AICostModel()
 @dataclass(frozen=True)
 class TeacherPlan:
     """
-    Flat-fee independent teacher plan (Option A: teacher keeps all student revenue).
+    Flat-fee independent teacher subscription tier (#57).
 
-    Option B (revenue share via Stripe Connect) → GitHub #104
-    Option C (seat-tiered flat fee) → GitHub #105
+    Teachers pay a flat monthly fee and keep 100% of any student-side revenue
+    they collect (Option A).  Option B (Stripe Connect revenue share) and
+    Option C (seat-tiered flat) are tracked in GitHub #104 and #105 respectively.
+
+    Attributes
+    ----------
+    id              Stripe metadata key and DB plan column value.
+    name            Display name shown in the teacher portal.
+    price_monthly   USD / month (decimal string, e.g. "29.00").
+    max_students    Hard seat cap on independently-enrolled students.
+    features        Bullet points shown in the plan comparison card.
+    highlight       True = "Popular" badge in the UI.
     """
 
     id: str
     name: str
     price_monthly: str          # decimal string
     max_students: int
+    features: tuple[str, ...] = field(default_factory=tuple)
+    highlight: bool = False
 
 
 TEACHER_PLANS: dict[str, TeacherPlan] = {
@@ -300,17 +312,47 @@ TEACHER_PLANS: dict[str, TeacherPlan] = {
         name="Solo",
         price_monthly="29.00",
         max_students=25,
+        features=(
+            "Up to 25 students",
+            "Default curriculum (Grades 5–12)",
+            "English content",
+            "Progress dashboard",
+        ),
+        highlight=False,
     ),
     "growth": TeacherPlan(
         id="growth",
         name="Growth",
         price_monthly="59.00",
         max_students=75,
+        features=(
+            "Up to 75 students",
+            "EN + FR + ES content",
+            "Teacher reporting dashboard",
+            "Weekly digest emails",
+        ),
+        highlight=True,
     ),
     "pro": TeacherPlan(
         id="pro",
         name="Pro",
         price_monthly="99.00",
         max_students=200,
+        features=(
+            "Up to 200 students",
+            "All languages",
+            "Full reporting suite",
+            "Priority support",
+        ),
+        highlight=False,
     ),
 }
+
+VALID_TEACHER_PLAN_IDS: frozenset[str] = frozenset(TEACHER_PLANS.keys())
+
+
+def get_teacher_plan(plan_id: str) -> TeacherPlan:
+    """Return TeacherPlan for plan_id. Raises KeyError for unknown IDs."""
+    if plan_id not in TEACHER_PLANS:
+        raise KeyError(f"Unknown teacher plan: {plan_id!r}. Valid: {sorted(VALID_TEACHER_PLAN_IDS)}")
+    return TEACHER_PLANS[plan_id]

--- a/backend/src/subscription/router.py
+++ b/backend/src/subscription/router.py
@@ -1,18 +1,20 @@
 """
 backend/src/subscription/router.py
 
-Stripe webhook endpoint (school subscriptions only).
+Stripe webhook endpoint — school and teacher subscriptions.
 
 Routes (all prefixed /api/v1 in main.py):
   POST /subscription/webhook  → 200  (Stripe webhook — no JWT required)
 
 Individual student subscription endpoints (status / checkout / cancel) were
-removed in migration 0027 per ADR-001 Decision 2.  All billing is now
-school-level only — see src/school/subscription_router.py.
+removed in migration 0027 per ADR-001 Decision 2.
+
+School billing:   src/school/subscription_router.py
+Teacher billing:  src/teacher/subscription_router.py  (#57)
 
 Security:
   POST /subscription/webhook validates the Stripe-Signature header.
-  All other routes in the subscription domain are on school_subscription_router.
+  All other routes in the subscription domain are on the domain-specific routers.
 
 Idempotency:
   Webhook handler checks stripe_events table before processing.
@@ -108,8 +110,100 @@ async def stripe_webhook(request: Request) -> dict:
 
 
 async def _dispatch_event(conn, redis, event_type: str, obj: dict) -> None:
-    """Route a Stripe event to the school subscription handler."""
+    """Route a Stripe event to the appropriate subscription handler.
+
+    Teacher subscription events are identified by product_type='teacher_subscription'
+    in checkout.session.metadata or by matching stripe_subscription_id against
+    teacher_subscriptions for lifecycle events.
+    """
+    # ── Teacher subscription events (#57) ─────────────────────────────────────
+    if event_type == "checkout.session.completed":
+        metadata = obj.get("metadata") or {}
+        if metadata.get("product_type") == "teacher_subscription":
+            await _dispatch_teacher_checkout(conn, obj, metadata)
+            return
+
+    elif event_type in (
+        "customer.subscription.updated",
+        "customer.subscription.deleted",
+        "invoice.payment_failed",
+    ):
+        stripe_sub_id = obj.get("id") or obj.get("subscription", "")
+        if stripe_sub_id:
+            from src.teacher.subscription_service import find_teacher_by_stripe_subscription
+            teacher_id = await find_teacher_by_stripe_subscription(conn, stripe_sub_id)
+            if teacher_id:
+                await _dispatch_teacher_lifecycle(conn, event_type, obj, stripe_sub_id)
+                return
+
+    # ── School subscription events (existing) ─────────────────────────────────
     await _dispatch_school_event(conn, redis, event_type, obj)
+
+
+async def _dispatch_teacher_checkout(conn, obj: dict, metadata: dict) -> None:
+    """Handle checkout.session.completed for teacher_subscription product_type."""
+    import datetime as _dt
+    from src.teacher.subscription_service import handle_teacher_subscription_activated
+
+    teacher_id = metadata.get("teacher_id", "")
+    plan = metadata.get("plan", "")
+    if not teacher_id or not plan:
+        log.warning(
+            "teacher_checkout.session.completed missing metadata "
+            "teacher_id=%s plan=%s",
+            teacher_id, plan,
+        )
+        return
+
+    stripe_customer_id = obj.get("customer", "")
+    stripe_subscription_id = obj.get("subscription", "")
+    current_period_end = None
+
+    try:
+        stripe_mod = _get_stripe_module()
+        from config import settings as _settings
+        stripe_mod.api_key = _settings.STRIPE_SECRET_KEY
+        sub = await run_stripe(stripe_mod.Subscription.retrieve, stripe_subscription_id)
+        current_period_end = _dt.datetime.fromtimestamp(
+            sub["current_period_end"], tz=_dt.UTC
+        )
+    except Exception as exc:
+        log.warning("could_not_fetch_teacher_subscription_period error=%s", exc)
+
+    await handle_teacher_subscription_activated(
+        conn,
+        teacher_id=teacher_id,
+        plan=plan,
+        stripe_customer_id=stripe_customer_id,
+        stripe_subscription_id=stripe_subscription_id,
+        current_period_end=current_period_end,
+    )
+
+
+async def _dispatch_teacher_lifecycle(
+    conn, event_type: str, obj: dict, stripe_sub_id: str
+) -> None:
+    """Handle lifecycle events (updated / deleted / payment_failed) for teacher subscriptions."""
+    import datetime as _dt
+    from src.teacher.subscription_service import (
+        handle_teacher_payment_failed,
+        handle_teacher_subscription_deleted,
+        handle_teacher_subscription_updated,
+    )
+
+    if event_type == "customer.subscription.updated":
+        status = _map_stripe_status(obj.get("status", "active"))
+        period_end_ts = obj.get("current_period_end")
+        current_period_end = (
+            _dt.datetime.fromtimestamp(period_end_ts, tz=_dt.UTC) if period_end_ts else None
+        )
+        await handle_teacher_subscription_updated(conn, stripe_sub_id, status, current_period_end)
+
+    elif event_type == "customer.subscription.deleted":
+        await handle_teacher_subscription_deleted(conn, stripe_sub_id)
+
+    elif event_type == "invoice.payment_failed":
+        await handle_teacher_payment_failed(conn, stripe_sub_id)
 
 
 def _map_stripe_status(stripe_status: str) -> str:

--- a/backend/src/teacher/subscription_router.py
+++ b/backend/src/teacher/subscription_router.py
@@ -1,0 +1,244 @@
+"""
+backend/src/teacher/subscription_router.py
+
+Independent teacher subscription endpoints (#57).
+
+Routes (all prefixed /api/v1 in main.py):
+  POST   /teachers/{teacher_id}/subscription/checkout  — start Stripe checkout
+  GET    /teachers/{teacher_id}/subscription            — status + seat usage
+  DELETE /teachers/{teacher_id}/subscription            — cancel at period end
+
+Auth: teacher JWT required.  teacher_id in path must match JWT.
+      Only teachers with school_id IS NULL may subscribe (school-affiliated
+      teachers are covered by their school's plan).
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, field_validator
+
+from src.auth.dependencies import get_current_teacher
+from src.core.db import get_db
+from src.pricing import VALID_TEACHER_PLAN_IDS
+from src.teacher.subscription_service import (
+    cancel_teacher_stripe_subscription,
+    cancel_teacher_subscription_db,
+    create_teacher_checkout_session,
+    get_teacher_subscription_status,
+)
+from src.utils.logger import get_logger
+
+log = get_logger("teacher.subscription")
+router = APIRouter(tags=["teacher-subscription"])
+
+
+# ── Schemas ───────────────────────────────────────────────────────────────────
+
+
+class TeacherCheckoutRequest(BaseModel):
+    plan: str
+    success_url: str
+    cancel_url: str
+
+    @field_validator("plan")
+    @classmethod
+    def valid_plan(cls, v: str) -> str:
+        if v not in VALID_TEACHER_PLAN_IDS:
+            raise ValueError(f"plan must be one of {sorted(VALID_TEACHER_PLAN_IDS)}")
+        return v
+
+
+class TeacherCheckoutResponse(BaseModel):
+    checkout_url: str
+
+
+class TeacherSubscriptionStatusResponse(BaseModel):
+    plan: str
+    status: str | None = None
+    max_students: int = 0
+    seats_used_students: int = 0
+    current_period_end: str | None = None
+
+
+class TeacherSubscriptionCancelResponse(BaseModel):
+    status: str
+    current_period_end: str | None = None
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _cid(request: Request) -> str:
+    return getattr(request.state, "correlation_id", "")
+
+
+def _assert_teacher_match(teacher: dict, teacher_id: str, request: Request) -> None:
+    if teacher.get("teacher_id") != teacher_id:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "forbidden",
+                "detail": "Cannot access subscription for a different teacher.",
+                "correlation_id": _cid(request),
+            },
+        )
+
+
+def _assert_independent(teacher: dict, request: Request) -> None:
+    """Reject school-affiliated teachers — their plan is covered by the school."""
+    if teacher.get("school_id"):
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "school_affiliated",
+                "detail": (
+                    "This teacher is affiliated with a school. "
+                    "Subscription is managed by the school admin."
+                ),
+                "correlation_id": _cid(request),
+            },
+        )
+
+
+# ── POST /teachers/{teacher_id}/subscription/checkout ────────────────────────
+
+
+@router.post(
+    "/teachers/{teacher_id}/subscription/checkout",
+    response_model=TeacherCheckoutResponse,
+    status_code=200,
+)
+async def teacher_subscription_checkout(
+    teacher_id: str,
+    body: TeacherCheckoutRequest,
+    request: Request,
+    teacher: Annotated[dict, Depends(get_current_teacher)],
+) -> TeacherCheckoutResponse:
+    """
+    Create a Stripe Checkout Session (mode=subscription) for an independent teacher.
+
+    Returns the Stripe-hosted checkout URL.  On successful payment the webhook
+    activates the subscription and sets teacher.teacher_plan.
+
+    Only teachers with no school affiliation (school_id IS NULL) may use this.
+    """
+    _assert_teacher_match(teacher, teacher_id, request)
+    _assert_independent(teacher, request)
+
+    try:
+        url = await create_teacher_checkout_session(
+            teacher_id=teacher_id,
+            plan=body.plan,
+            success_url=body.success_url,
+            cancel_url=body.cancel_url,
+        )
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": "payment_unavailable",
+                "detail": str(exc),
+                "correlation_id": _cid(request),
+            },
+        )
+    except Exception as exc:
+        log.error("teacher_checkout_error teacher_id=%s error=%s", teacher_id, exc)
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error": "stripe_error",
+                "detail": "Could not create checkout session.",
+                "correlation_id": _cid(request),
+            },
+        )
+
+    return TeacherCheckoutResponse(checkout_url=url)
+
+
+# ── GET /teachers/{teacher_id}/subscription ───────────────────────────────────
+
+
+@router.get(
+    "/teachers/{teacher_id}/subscription",
+    response_model=TeacherSubscriptionStatusResponse,
+    status_code=200,
+)
+async def teacher_subscription_status(
+    teacher_id: str,
+    request: Request,
+    teacher: Annotated[dict, Depends(get_current_teacher)],
+) -> TeacherSubscriptionStatusResponse:
+    """Return current subscription plan, status, seat cap, and seats used."""
+    _assert_teacher_match(teacher, teacher_id, request)
+
+    async with get_db(request) as conn:
+        status = await get_teacher_subscription_status(conn, teacher_id)
+
+    return TeacherSubscriptionStatusResponse(**status)
+
+
+# ── DELETE /teachers/{teacher_id}/subscription ────────────────────────────────
+
+
+@router.delete(
+    "/teachers/{teacher_id}/subscription",
+    response_model=TeacherSubscriptionCancelResponse,
+    status_code=200,
+)
+async def cancel_teacher_subscription(
+    teacher_id: str,
+    request: Request,
+    teacher: Annotated[dict, Depends(get_current_teacher)],
+) -> TeacherSubscriptionCancelResponse:
+    """
+    Cancel the teacher's subscription at the end of the current billing period.
+
+    The teacher retains access until current_period_end.
+    """
+    _assert_teacher_match(teacher, teacher_id, request)
+    _assert_independent(teacher, request)
+
+    async with get_db(request) as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT stripe_subscription_id, current_period_end
+            FROM teacher_subscriptions
+            WHERE teacher_id = $1::uuid AND status NOT IN ('cancelled')
+            """,
+            teacher_id,
+        )
+
+    if not row:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": "not_found",
+                "detail": "No active subscription found.",
+                "correlation_id": _cid(request),
+            },
+        )
+
+    try:
+        await cancel_teacher_stripe_subscription(row["stripe_subscription_id"])
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": "payment_unavailable",
+                "detail": str(exc),
+                "correlation_id": _cid(request),
+            },
+        )
+
+    async with get_db(request) as conn:
+        await cancel_teacher_subscription_db(conn, teacher_id)
+
+    valid_until = row["current_period_end"].isoformat() if row["current_period_end"] else None
+    log.info("teacher_subscription_cancelled teacher_id=%s", teacher_id)
+    return TeacherSubscriptionCancelResponse(
+        status="cancelled_at_period_end",
+        current_period_end=valid_until,
+    )

--- a/backend/src/teacher/subscription_service.py
+++ b/backend/src/teacher/subscription_service.py
@@ -1,0 +1,408 @@
+"""
+backend/src/teacher/subscription_service.py
+
+Business logic for independent teacher Stripe subscriptions (#57).
+
+An independent teacher is one with school_id IS NULL in the teachers table.
+They pay a flat monthly recurring fee (Solo $29 · Growth $59 · Pro $99) and
+access the platform without a school affiliation.
+
+Public API
+──────────
+  create_teacher_checkout_session(teacher_id, plan, success_url, cancel_url) → str
+  get_teacher_subscription_status(conn, teacher_id) → dict
+  cancel_teacher_stripe_subscription(stripe_sub_id) → None
+  cancel_teacher_subscription_db(conn, teacher_id) → None
+
+  check_student_seat_limit(conn, teacher_id) → dict
+    Returns {allowed, seats_used, max_students, plan}.
+
+  handle_teacher_subscription_activated(conn, teacher_id, plan,
+      stripe_customer_id, stripe_subscription_id, current_period_end) → None
+  handle_teacher_subscription_updated(conn, stripe_subscription_id,
+      status, current_period_end) → None
+  handle_teacher_subscription_deleted(conn, stripe_subscription_id) → None
+  handle_teacher_payment_failed(conn, stripe_subscription_id) → None
+
+  find_teacher_by_stripe_subscription(conn, stripe_subscription_id) → str | None
+    Returns teacher_id or None.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from functools import partial
+
+import asyncpg
+
+from src.pricing import TEACHER_PLANS, get_teacher_plan
+from src.utils.logger import get_logger
+
+log = get_logger("teacher.subscription")
+
+
+# ── Stripe helpers (mirrors school/subscription_service.py pattern) ────────────
+
+
+def _get_stripe():
+    try:
+        import stripe  # type: ignore
+        return stripe
+    except ImportError:
+        raise RuntimeError("stripe package not installed — run: pip install stripe")
+
+
+def _stripe_key() -> str:
+    from config import settings
+    key = getattr(settings, "STRIPE_SECRET_KEY", None)
+    if not key:
+        raise RuntimeError("STRIPE_SECRET_KEY is not configured")
+    return key
+
+
+async def _run_stripe(fn, *args, **kwargs):
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, partial(fn, *args, **kwargs))
+
+
+def _teacher_price_id(plan_id: str) -> str:
+    """Return Stripe price ID for the given teacher plan. Raises RuntimeError if unset."""
+    from config import settings
+    mapping = {
+        "solo":   getattr(settings, "STRIPE_TEACHER_PRICE_SOLO_ID", None),
+        "growth": getattr(settings, "STRIPE_TEACHER_PRICE_GROWTH_ID", None),
+        "pro":    getattr(settings, "STRIPE_TEACHER_PRICE_PRO_ID", None),
+    }
+    price_id = mapping.get(plan_id)
+    if not price_id:
+        raise RuntimeError(
+            f"STRIPE_TEACHER_PRICE_{plan_id.upper()}_ID is not configured"
+        )
+    return price_id
+
+
+# ── Stripe Checkout session ────────────────────────────────────────────────────
+
+
+async def create_teacher_checkout_session(
+    teacher_id: str,
+    plan: str,
+    success_url: str,
+    cancel_url: str,
+) -> str:
+    """
+    Create a Stripe Checkout Session (mode=subscription) for an independent teacher.
+
+    On checkout.session.completed the webhook calls handle_teacher_subscription_activated().
+    Returns the Stripe-hosted checkout URL.
+    """
+    get_teacher_plan(plan)   # validates plan_id; raises KeyError on unknown
+
+    stripe = _get_stripe()
+    stripe.api_key = _stripe_key()
+    price_id = _teacher_price_id(plan)
+
+    session = await _run_stripe(
+        stripe.checkout.Session.create,
+        mode="subscription",
+        line_items=[{"price": price_id, "quantity": 1}],
+        success_url=success_url,
+        cancel_url=cancel_url,
+        metadata={
+            "teacher_id": teacher_id,
+            "plan": plan,
+            "product_type": "teacher_subscription",
+        },
+    )
+    log.info("teacher_checkout_session_created teacher_id=%s plan=%s", teacher_id, plan)
+    return session.url
+
+
+# ── Subscription status ────────────────────────────────────────────────────────
+
+
+async def get_teacher_subscription_status(
+    conn: asyncpg.Connection,
+    teacher_id: str,
+) -> dict:
+    """
+    Return subscription status for an independent teacher.
+
+    Returns plan='none', status=None when no subscription row exists.
+    Includes seat usage so the frontend can show the student cap.
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT plan, status, max_students,
+               stripe_subscription_id, current_period_end, grace_period_end
+        FROM teacher_subscriptions
+        WHERE teacher_id = $1::uuid
+        """,
+        teacher_id,
+    )
+    seats = await check_student_seat_limit(conn, teacher_id)
+
+    if row is None:
+        return {
+            "plan": "none",
+            "status": None,
+            "max_students": 0,
+            "seats_used_students": seats["seats_used"],
+            "current_period_end": None,
+        }
+
+    if row["status"] == "past_due" and row["grace_period_end"]:
+        valid_until = row["grace_period_end"].isoformat()
+    elif row["current_period_end"]:
+        valid_until = row["current_period_end"].isoformat()
+    else:
+        valid_until = None
+
+    return {
+        "plan": row["plan"],
+        "status": row["status"],
+        "max_students": row["max_students"],
+        "seats_used_students": seats["seats_used"],
+        "current_period_end": valid_until,
+    }
+
+
+# ── Seat limit check ──────────────────────────────────────────────────────────
+
+
+async def check_student_seat_limit(
+    conn: asyncpg.Connection,
+    teacher_id: str,
+) -> dict:
+    """
+    Return {allowed, seats_used, max_students, plan} for an independent teacher.
+
+    'allowed' is True only when seats_used < max_students and the subscription
+    is active or trialing.  Returns allowed=False when no subscription exists.
+    """
+    sub_row = await conn.fetchrow(
+        """
+        SELECT plan, status, max_students
+        FROM teacher_subscriptions
+        WHERE teacher_id = $1::uuid
+        """,
+        teacher_id,
+    )
+
+    # Count students currently enrolled by this independent teacher.
+    # Independent-teacher students have no school_id and are linked via
+    # student_teacher_assignments.
+    seats_used = await conn.fetchval(
+        """
+        SELECT COUNT(*)
+        FROM student_teacher_assignments sta
+        JOIN students s ON s.student_id = sta.student_id
+        WHERE sta.teacher_id = $1::uuid
+          AND s.school_id IS NULL
+          AND s.account_status = 'active'
+        """,
+        teacher_id,
+    ) or 0
+
+    if sub_row is None:
+        return {
+            "allowed": False,
+            "seats_used": int(seats_used),
+            "max_students": 0,
+            "plan": "none",
+        }
+
+    active = sub_row["status"] in ("active", "trialing")
+    max_s = sub_row["max_students"]
+
+    return {
+        "allowed": active and int(seats_used) < max_s,
+        "seats_used": int(seats_used),
+        "max_students": max_s,
+        "plan": sub_row["plan"],
+    }
+
+
+# ── Cancellation ──────────────────────────────────────────────────────────────
+
+
+async def cancel_teacher_stripe_subscription(stripe_subscription_id: str) -> None:
+    """Set cancel_at_period_end=True on the Stripe subscription."""
+    stripe = _get_stripe()
+    stripe.api_key = _stripe_key()
+    await _run_stripe(
+        stripe.Subscription.modify,
+        stripe_subscription_id,
+        cancel_at_period_end=True,
+    )
+    log.info("teacher_stripe_sub_cancel_at_period_end sub_id=%s", stripe_subscription_id)
+
+
+async def cancel_teacher_subscription_db(
+    conn: asyncpg.Connection,
+    teacher_id: str,
+) -> None:
+    """Mark the DB subscription row as cancelled and clear teacher_plan."""
+    await conn.execute(
+        """
+        UPDATE teacher_subscriptions
+        SET status = 'cancelled', updated_at = NOW()
+        WHERE teacher_id = $1::uuid
+        """,
+        teacher_id,
+    )
+    await conn.execute(
+        "UPDATE teachers SET teacher_plan = NULL WHERE teacher_id = $1::uuid",
+        teacher_id,
+    )
+    log.info("teacher_subscription_cancelled_db teacher_id=%s", teacher_id)
+
+
+# ── Webhook event handlers ────────────────────────────────────────────────────
+
+
+async def handle_teacher_subscription_activated(
+    conn: asyncpg.Connection,
+    teacher_id: str,
+    plan: str,
+    stripe_customer_id: str,
+    stripe_subscription_id: str,
+    current_period_end,
+) -> None:
+    """
+    Called on checkout.session.completed for product_type='teacher_subscription'.
+
+    Upserts teacher_subscriptions and stamps teacher.teacher_plan.
+    Idempotent — safe to call on replay.
+    """
+    teacher_plan = get_teacher_plan(plan)
+    max_students = teacher_plan.max_students
+
+    await conn.execute(
+        """
+        INSERT INTO teacher_subscriptions
+            (teacher_id, plan, status, max_students,
+             stripe_customer_id, stripe_subscription_id,
+             current_period_end)
+        VALUES ($1::uuid, $2, 'active', $3, $4, $5, $6)
+        ON CONFLICT (teacher_id) DO UPDATE SET
+            plan                  = EXCLUDED.plan,
+            status                = 'active',
+            max_students          = EXCLUDED.max_students,
+            stripe_customer_id    = EXCLUDED.stripe_customer_id,
+            stripe_subscription_id = EXCLUDED.stripe_subscription_id,
+            current_period_end    = EXCLUDED.current_period_end,
+            updated_at            = NOW()
+        """,
+        teacher_id,
+        plan,
+        max_students,
+        stripe_customer_id,
+        stripe_subscription_id,
+        current_period_end,
+    )
+    await conn.execute(
+        "UPDATE teachers SET teacher_plan = $1 WHERE teacher_id = $2::uuid",
+        plan, teacher_id,
+    )
+    log.info(
+        "teacher_subscription_activated teacher_id=%s plan=%s sub_id=%s",
+        teacher_id, plan, stripe_subscription_id,
+    )
+
+
+async def handle_teacher_subscription_updated(
+    conn: asyncpg.Connection,
+    stripe_subscription_id: str,
+    status: str,
+    current_period_end,
+) -> None:
+    """
+    Called on customer.subscription.updated.
+
+    Updates status and current_period_end.  If status transitions to 'active'
+    from 'past_due' the grace_period_end is cleared.
+    """
+    clear_grace = "grace_period_end = NULL," if status == "active" else ""
+    await conn.execute(
+        f"""
+        UPDATE teacher_subscriptions
+        SET status = $1,
+            {clear_grace}
+            current_period_end = $2,
+            updated_at = NOW()
+        WHERE stripe_subscription_id = $3
+        """,
+        status, current_period_end, stripe_subscription_id,
+    )
+    log.info(
+        "teacher_subscription_updated sub_id=%s status=%s",
+        stripe_subscription_id, status,
+    )
+
+
+async def handle_teacher_subscription_deleted(
+    conn: asyncpg.Connection,
+    stripe_subscription_id: str,
+) -> None:
+    """
+    Called on customer.subscription.deleted.
+
+    Sets status='cancelled' and clears teacher.teacher_plan.
+    """
+    teacher_id = await conn.fetchval(
+        "SELECT teacher_id::text FROM teacher_subscriptions WHERE stripe_subscription_id = $1",
+        stripe_subscription_id,
+    )
+    if teacher_id:
+        await conn.execute(
+            """
+            UPDATE teacher_subscriptions
+            SET status = 'cancelled', updated_at = NOW()
+            WHERE stripe_subscription_id = $1
+            """,
+            stripe_subscription_id,
+        )
+        await conn.execute(
+            "UPDATE teachers SET teacher_plan = NULL WHERE teacher_id = $1::uuid",
+            teacher_id,
+        )
+        log.info(
+            "teacher_subscription_deleted sub_id=%s teacher_id=%s",
+            stripe_subscription_id, teacher_id,
+        )
+
+
+async def handle_teacher_payment_failed(
+    conn: asyncpg.Connection,
+    stripe_subscription_id: str,
+) -> None:
+    """
+    Called on invoice.payment_failed for a teacher subscription.
+
+    Sets status='past_due' and stamps grace_period_end = NOW() + 7 days.
+    After grace_period_end expires the teacher loses access.
+    """
+    await conn.execute(
+        """
+        UPDATE teacher_subscriptions
+        SET status = 'past_due',
+            grace_period_end = NOW() + INTERVAL '7 days',
+            updated_at = NOW()
+        WHERE stripe_subscription_id = $1
+        """,
+        stripe_subscription_id,
+    )
+    log.info("teacher_payment_failed sub_id=%s", stripe_subscription_id)
+
+
+async def find_teacher_by_stripe_subscription(
+    conn: asyncpg.Connection,
+    stripe_subscription_id: str,
+) -> str | None:
+    """Return teacher_id (str) for a Stripe subscription ID, or None if not found."""
+    row = await conn.fetchval(
+        "SELECT teacher_id::text FROM teacher_subscriptions WHERE stripe_subscription_id = $1",
+        stripe_subscription_id,
+    )
+    return row

--- a/backend/tests/helpers/token_factory.py
+++ b/backend/tests/helpers/token_factory.py
@@ -58,26 +58,38 @@ def make_student_token(
     return jwt.encode(payload, TEST_JWT_SECRET, algorithm=JWT_ALGORITHM)
 
 
+_UNSET = object()  # sentinel for "use default"
+
+
 def make_teacher_token(
     teacher_id: str | None = None,
-    school_id: str | None = None,
+    school_id: object = _UNSET,   # pass None explicitly for independent teachers
     role: str = "teacher",
     account_status: str = "active",
     expire_minutes: int = 15,
 ) -> str:
-    """Return a signed teacher JWT for testing."""
+    """Return a signed teacher JWT for testing.
+
+    Pass school_id=None explicitly to produce an independent-teacher token
+    (school_id omitted from payload, matching the auth0 exchange path for
+    teachers without a school affiliation).
+
+    Omitting school_id (or passing the _UNSET sentinel) uses _DEFAULT_SCHOOL_ID.
+    """
     tid = teacher_id or _DEFAULT_TEACHER_ID
-    sid = school_id or _DEFAULT_SCHOOL_ID
+    sid = _DEFAULT_SCHOOL_ID if school_id is _UNSET else school_id
     now = datetime.now(tz=UTC)
     payload = {
         "teacher_id": tid,
-        "school_id": sid,
         "role": role,
         "account_status": account_status,
         "iat": now,
         "exp": now + timedelta(minutes=expire_minutes),
         "jti": str(uuid.uuid4()),
     }
+    # Only include school_id in the JWT when set — mirrors the real exchange endpoint.
+    if sid is not None:
+        payload["school_id"] = sid
     return jwt.encode(payload, TEST_JWT_SECRET, algorithm=JWT_ALGORITHM)
 
 

--- a/backend/tests/test_teacher_subscription.py
+++ b/backend/tests/test_teacher_subscription.py
@@ -1,0 +1,560 @@
+"""
+tests/test_teacher_subscription.py
+
+Tests for independent teacher subscription endpoints (#57):
+  POST   /teachers/{teacher_id}/subscription/checkout
+  GET    /teachers/{teacher_id}/subscription
+  DELETE /teachers/{teacher_id}/subscription
+
+Plus service-layer unit tests:
+  - get_teacher_subscription_status()
+  - check_student_seat_limit()
+  - handle_teacher_subscription_activated()
+  - handle_teacher_subscription_updated()
+  - handle_teacher_subscription_deleted()
+  - handle_teacher_payment_failed()
+
+And webhook routing for teacher subscription events.
+
+All Stripe SDK calls are mocked — no live API keys required.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from tests.helpers.token_factory import make_teacher_token
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_INDEPENDENT_TEACHER_ID = "a1000000-0000-4000-8000-000000000001"
+_SCHOOL_TEACHER_ID       = "a2000000-0000-4000-8000-000000000002"
+_SCHOOL_ID               = "b1000000-0000-4000-8000-000000000001"
+
+
+def _indep_token(teacher_id: str = _INDEPENDENT_TEACHER_ID) -> str:
+    """JWT for an independent teacher (no school_id)."""
+    return make_teacher_token(teacher_id=teacher_id, school_id=None)
+
+
+def _school_token(teacher_id: str = _SCHOOL_TEACHER_ID) -> str:
+    """JWT for a school-affiliated teacher."""
+    return make_teacher_token(teacher_id=teacher_id, school_id=_SCHOOL_ID)
+
+
+async def _create_independent_teacher(client: AsyncClient, teacher_id: str) -> None:
+    """Insert a teacher row with school_id=NULL directly via pool.
+
+    Sets app.current_school_id='bypass' to satisfy the FORCE ROW LEVEL SECURITY
+    policy on teachers (migration 0028).  Independent teachers have no school_id
+    so 'bypass' is the correct sentinel for fixture inserts.
+    """
+    pool = client._transport.app.state.pool
+    async with pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        await conn.execute(
+            """
+            INSERT INTO teachers (teacher_id, school_id, external_auth_id,
+                                  auth_provider, name, email, role, account_status)
+            VALUES ($1::uuid, NULL, $2, 'auth0', 'Indie Teacher', $3, 'teacher', 'active')
+            ON CONFLICT (teacher_id) DO NOTHING
+            """,
+            uuid.UUID(teacher_id),
+            f"auth0|indep_{teacher_id[:8]}",
+            f"indie_{teacher_id[:8]}@example.com",
+        )
+
+
+async def _insert_teacher_subscription(
+    client: AsyncClient,
+    teacher_id: str,
+    plan: str = "solo",
+    status: str = "active",
+    stripe_sub_id: str | None = None,
+    max_students: int | None = None,
+) -> str:
+    """Insert a teacher_subscriptions row directly via pool."""
+    sub_id = stripe_sub_id or f"sub_teacher_{uuid.uuid4().hex[:12]}"
+    from src.pricing import get_teacher_plan
+    ms = max_students if max_students is not None else get_teacher_plan(plan).max_students
+    pool = client._transport.app.state.pool
+    async with pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        await conn.execute(
+            """
+            INSERT INTO teacher_subscriptions
+                (teacher_id, plan, status, max_students,
+                 stripe_customer_id, stripe_subscription_id, current_period_end)
+            VALUES ($1::uuid, $2, $3, $4, 'cus_test_teacher', $5,
+                    NOW() + INTERVAL '30 days')
+            ON CONFLICT (teacher_id) DO UPDATE SET
+                plan = EXCLUDED.plan,
+                status = EXCLUDED.status,
+                max_students = EXCLUDED.max_students,
+                stripe_subscription_id = EXCLUDED.stripe_subscription_id,
+                updated_at = NOW()
+            """,
+            uuid.UUID(teacher_id),
+            plan, status, ms, sub_id,
+        )
+        # Stamp teacher_plan column
+        await conn.execute(
+            "UPDATE teachers SET teacher_plan = $1 WHERE teacher_id = $2::uuid",
+            plan if status == "active" else None,
+            uuid.UUID(teacher_id),
+        )
+    return sub_id
+
+
+# ── GET /teachers/{teacher_id}/subscription — no subscription ────────────────
+
+
+@pytest.mark.asyncio
+async def test_teacher_subscription_status_no_subscription(client: AsyncClient):
+    """Returns plan='none', status=None when no subscription exists."""
+    tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+    token = _indep_token(tid)
+
+    r = await client.get(
+        f"/api/v1/teachers/{tid}/subscription",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["plan"] == "none"
+    assert data["status"] is None
+    assert data["max_students"] == 0
+    assert data["seats_used_students"] == 0
+
+
+@pytest.mark.asyncio
+async def test_teacher_subscription_status_active(client: AsyncClient):
+    """Returns correct plan, status, and seat cap when subscription is active."""
+    tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+    await _insert_teacher_subscription(client, tid, plan="growth")
+    token = _indep_token(tid)
+
+    r = await client.get(
+        f"/api/v1/teachers/{tid}/subscription",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["plan"] == "growth"
+    assert data["status"] == "active"
+    assert data["max_students"] == 75
+
+
+@pytest.mark.asyncio
+async def test_teacher_subscription_status_forbidden_other_teacher(client: AsyncClient):
+    """Cannot read another teacher's subscription."""
+    tid = str(uuid.uuid4())
+    other_tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+    token = _indep_token(other_tid)   # JWT for a different teacher
+
+    r = await client.get(
+        f"/api/v1/teachers/{tid}/subscription",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 403
+
+
+# ── POST /teachers/{teacher_id}/subscription/checkout ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_teacher_checkout_school_affiliated_blocked(client: AsyncClient):
+    """School-affiliated teachers cannot initiate an independent subscription."""
+    # Register a real school so we have a valid school_id FK target.
+    r = await client.post("/api/v1/schools/register", json={
+        "school_name": "Affiliated School",
+        "contact_email": f"admin-{uuid.uuid4().hex[:8]}@example.com",
+        "country": "US",
+    })
+    assert r.status_code == 201, r.text
+    real_school_id = r.json()["school_id"]
+    real_teacher_id = r.json()["teacher_id"]
+
+    token = make_teacher_token(teacher_id=real_teacher_id, school_id=real_school_id)
+
+    r = await client.post(
+        f"/api/v1/teachers/{real_teacher_id}/subscription/checkout",
+        json={
+            "plan": "solo",
+            "success_url": "https://app.example.com/success",
+            "cancel_url": "https://app.example.com/cancel",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 403
+    assert r.json()["error"] == "school_affiliated"
+
+
+@pytest.mark.asyncio
+async def test_teacher_checkout_invalid_plan_rejected(client: AsyncClient):
+    """Invalid plan name returns 422."""
+    tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+    token = _indep_token(tid)
+
+    r = await client.post(
+        f"/api/v1/teachers/{tid}/subscription/checkout",
+        json={
+            "plan": "enterprise",   # not a valid teacher plan
+            "success_url": "https://app.example.com/success",
+            "cancel_url": "https://app.example.com/cancel",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_teacher_checkout_price_not_configured_returns_503(client: AsyncClient):
+    """Returns 503 when Stripe price ID is not set in config."""
+    tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+    token = _indep_token(tid)
+
+    with patch("src.teacher.subscription_service._stripe_key", return_value="sk_test"):
+        with patch("src.teacher.subscription_service._teacher_price_id",
+                   side_effect=RuntimeError("STRIPE_TEACHER_PRICE_SOLO_ID is not configured")):
+            r = await client.post(
+                f"/api/v1/teachers/{tid}/subscription/checkout",
+                json={
+                    "plan": "solo",
+                    "success_url": "https://app.example.com/success",
+                    "cancel_url": "https://app.example.com/cancel",
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    assert r.status_code == 503
+    assert r.json()["error"] == "payment_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_teacher_checkout_returns_stripe_url(client: AsyncClient):
+    """Returns checkout_url from Stripe on success."""
+    tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+    token = _indep_token(tid)
+
+    mock_session = MagicMock()
+    mock_session.url = "https://checkout.stripe.com/pay/cs_test_abc123"
+
+    with patch("src.teacher.subscription_service._stripe_key", return_value="sk_test"):
+        with patch("src.teacher.subscription_service._teacher_price_id", return_value="price_test_solo"):
+            with patch("src.teacher.subscription_service._run_stripe",
+                       return_value=mock_session):
+                with patch("src.teacher.subscription_service._get_stripe"):
+                    r = await client.post(
+                        f"/api/v1/teachers/{tid}/subscription/checkout",
+                        json={
+                            "plan": "solo",
+                            "success_url": "https://app.example.com/success",
+                            "cancel_url": "https://app.example.com/cancel",
+                        },
+                        headers={"Authorization": f"Bearer {token}"},
+                    )
+    assert r.status_code == 200, r.text
+    assert r.json()["checkout_url"] == "https://checkout.stripe.com/pay/cs_test_abc123"
+
+
+# ── DELETE /teachers/{teacher_id}/subscription ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_teacher_cancel_no_subscription_returns_404(client: AsyncClient):
+    """Returns 404 when there is no active subscription to cancel."""
+    tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+    token = _indep_token(tid)
+
+    r = await client.delete(
+        f"/api/v1/teachers/{tid}/subscription",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_teacher_cancel_sets_cancelled_at_period_end(client: AsyncClient):
+    """Cancellation sets status=cancelled and returns current_period_end."""
+    tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+    sub_id = await _insert_teacher_subscription(client, tid, plan="solo")
+    token = _indep_token(tid)
+
+    with patch("src.teacher.subscription_service._stripe_key", return_value="sk_test"):
+        with patch("src.teacher.subscription_service._run_stripe", return_value=MagicMock()):
+            with patch("src.teacher.subscription_service._get_stripe"):
+                r = await client.delete(
+                    f"/api/v1/teachers/{tid}/subscription",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["status"] == "cancelled_at_period_end"
+    assert data["current_period_end"] is not None
+
+
+# ── Service-layer unit tests ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_handle_teacher_subscription_activated(client: AsyncClient):
+    """Activation creates teacher_subscriptions row and stamps teacher_plan."""
+    from src.teacher.subscription_service import (
+        get_teacher_subscription_status,
+        handle_teacher_subscription_activated,
+    )
+
+    tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+
+    pool = client._transport.app.state.pool
+    async with pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        await handle_teacher_subscription_activated(
+            conn,
+            teacher_id=tid,
+            plan="growth",
+            stripe_customer_id="cus_test_abc",
+            stripe_subscription_id="sub_test_abc",
+            current_period_end=datetime.now(UTC) + timedelta(days=30),
+        )
+        status = await get_teacher_subscription_status(conn, tid)
+        # Read teacher_plan on the same connection (bypass is set) so RLS doesn't
+        # filter out the independent-teacher row (school_id IS NULL).
+        plan_col = await conn.fetchval(
+            "SELECT teacher_plan FROM teachers WHERE teacher_id = $1::uuid",
+            uuid.UUID(tid),
+        )
+
+    assert status["plan"] == "growth"
+    assert status["status"] == "active"
+    assert status["max_students"] == 75
+    assert plan_col == "growth"
+
+
+@pytest.mark.asyncio
+async def test_handle_teacher_subscription_activated_is_idempotent(client: AsyncClient):
+    """Calling activated twice (replay) does not create duplicate rows."""
+    from src.teacher.subscription_service import handle_teacher_subscription_activated
+
+    tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+
+    pool = client._transport.app.state.pool
+    async with pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        for _ in range(2):
+            await handle_teacher_subscription_activated(
+                conn,
+                teacher_id=tid,
+                plan="solo",
+                stripe_customer_id="cus_idempotent",
+                stripe_subscription_id="sub_idempotent",
+                current_period_end=datetime.now(UTC) + timedelta(days=30),
+            )
+        count = await conn.fetchval(
+            "SELECT COUNT(*) FROM teacher_subscriptions WHERE teacher_id = $1::uuid",
+            uuid.UUID(tid),
+        )
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_teacher_subscription_updated_changes_status(client: AsyncClient):
+    """Updated event changes status and period_end."""
+    from src.teacher.subscription_service import (
+        get_teacher_subscription_status,
+        handle_teacher_subscription_updated,
+    )
+
+    tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+    sub_id = await _insert_teacher_subscription(client, tid, plan="pro", stripe_sub_id="sub_upd_test")
+
+    new_period_end = datetime.now(UTC) + timedelta(days=60)
+    pool = client._transport.app.state.pool
+    async with pool.acquire() as conn:
+        await handle_teacher_subscription_updated(conn, sub_id, "past_due", new_period_end)
+        status = await get_teacher_subscription_status(conn, tid)
+
+    assert status["status"] == "past_due"
+
+
+@pytest.mark.asyncio
+async def test_handle_teacher_subscription_deleted_clears_plan(client: AsyncClient):
+    """Deleted event sets status=cancelled and clears teacher_plan column."""
+    from src.teacher.subscription_service import (
+        get_teacher_subscription_status,
+        handle_teacher_subscription_deleted,
+    )
+
+    tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+    sub_id = await _insert_teacher_subscription(client, tid, plan="solo", stripe_sub_id="sub_del_test")
+
+    pool = client._transport.app.state.pool
+    async with pool.acquire() as conn:
+        await handle_teacher_subscription_deleted(conn, sub_id)
+        status = await get_teacher_subscription_status(conn, tid)
+        plan_col = await conn.fetchval(
+            "SELECT teacher_plan FROM teachers WHERE teacher_id = $1::uuid",
+            uuid.UUID(tid),
+        )
+
+    assert status["status"] == "cancelled"
+    assert plan_col is None
+
+
+@pytest.mark.asyncio
+async def test_handle_teacher_payment_failed_sets_past_due(client: AsyncClient):
+    """payment_failed sets status=past_due and stamps grace_period_end."""
+    from src.teacher.subscription_service import handle_teacher_payment_failed
+
+    tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+    sub_id = await _insert_teacher_subscription(
+        client, tid, plan="growth", stripe_sub_id="sub_fail_test"
+    )
+
+    pool = client._transport.app.state.pool
+    async with pool.acquire() as conn:
+        await handle_teacher_payment_failed(conn, sub_id)
+        row = await conn.fetchrow(
+            "SELECT status, grace_period_end FROM teacher_subscriptions WHERE teacher_id = $1::uuid",
+            uuid.UUID(tid),
+        )
+
+    assert row["status"] == "past_due"
+    assert row["grace_period_end"] is not None
+
+
+# ── Webhook routing ───────────────────────────────────────────────────────────
+
+
+def _make_webhook_teacher_session(metadata: dict, sub_id: str = "sub_wh_test") -> dict:
+    return {
+        "id": f"cs_test_{uuid.uuid4().hex[:16]}",
+        "object": "checkout.session",
+        "customer": "cus_webhook_teacher",
+        "subscription": sub_id,
+        "metadata": metadata,
+    }
+
+
+@pytest.mark.asyncio
+async def test_webhook_teacher_checkout_activates_subscription(client: AsyncClient):
+    """Webhook with product_type=teacher_subscription creates subscription row."""
+    from src.teacher.subscription_service import get_teacher_subscription_status
+
+    tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+
+    stripe_event_id = f"evt_teacher_{uuid.uuid4().hex[:12]}"
+    session = _make_webhook_teacher_session({
+        "teacher_id": tid,
+        "plan": "solo",
+        "product_type": "teacher_subscription",
+    })
+
+    mock_stripe = MagicMock()
+    mock_stripe.Webhook.construct_event.return_value = {
+        "id": stripe_event_id,
+        "type": "checkout.session.completed",
+        "data": {"object": session},
+    }
+    # Mock Subscription.retrieve to return a period_end timestamp
+    future_ts = int((datetime.now(UTC) + timedelta(days=30)).timestamp())
+    mock_stripe.Subscription.retrieve.return_value = {"current_period_end": future_ts}
+
+    with patch("src.subscription.router._get_stripe_module", return_value=mock_stripe):
+        with patch("config.settings") as mock_settings:
+            mock_settings.STRIPE_WEBHOOK_SECRET = "whsec_test"
+            mock_settings.STRIPE_SECRET_KEY = "sk_test"
+            with patch("src.subscription.service.already_processed", return_value=False):
+                with patch("src.subscription.service.log_stripe_event", return_value=None):
+                    r = await client.post(
+                        "/api/v1/subscription/webhook",
+                        content=b"payload",
+                        headers={"stripe-signature": "t=1,v1=sig"},
+                    )
+
+    assert r.status_code == 200, r.text
+    pool = client._transport.app.state.pool
+    async with pool.acquire() as conn:
+        status = await get_teacher_subscription_status(conn, tid)
+    assert status["plan"] == "solo"
+    assert status["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_webhook_teacher_subscription_deleted(client: AsyncClient):
+    """Webhook customer.subscription.deleted cancels teacher subscription."""
+    from src.teacher.subscription_service import get_teacher_subscription_status
+
+    tid = str(uuid.uuid4())
+    await _create_independent_teacher(client, tid)
+    sub_id = await _insert_teacher_subscription(
+        client, tid, plan="growth", stripe_sub_id="sub_del_wh"
+    )
+
+    stripe_event_id = f"evt_del_{uuid.uuid4().hex[:12]}"
+    obj = {"id": sub_id, "status": "canceled", "current_period_end": None}
+
+    mock_stripe = MagicMock()
+    mock_stripe.Webhook.construct_event.return_value = {
+        "id": stripe_event_id,
+        "type": "customer.subscription.deleted",
+        "data": {"object": obj},
+    }
+
+    with patch("src.subscription.router._get_stripe_module", return_value=mock_stripe):
+        with patch("config.settings") as mock_settings:
+            mock_settings.STRIPE_WEBHOOK_SECRET = "whsec_test"
+            with patch("src.subscription.service.already_processed", return_value=False):
+                with patch("src.subscription.service.log_stripe_event", return_value=None):
+                    r = await client.post(
+                        "/api/v1/subscription/webhook",
+                        content=b"payload",
+                        headers={"stripe-signature": "t=1,v1=sig"},
+                    )
+
+    assert r.status_code == 200, r.text
+    pool = client._transport.app.state.pool
+    async with pool.acquire() as conn:
+        status = await get_teacher_subscription_status(conn, tid)
+    assert status["status"] == "cancelled"
+
+
+# ── Pricing constants ─────────────────────────────────────────────────────────
+
+
+def test_teacher_plan_prices():
+    """Verify pricing constants match the agreed rates."""
+    from src.pricing import TEACHER_PLANS
+    assert TEACHER_PLANS["solo"].price_monthly == "29.00"
+    assert TEACHER_PLANS["solo"].max_students == 25
+    assert TEACHER_PLANS["growth"].price_monthly == "59.00"
+    assert TEACHER_PLANS["growth"].max_students == 75
+    assert TEACHER_PLANS["pro"].price_monthly == "99.00"
+    assert TEACHER_PLANS["pro"].max_students == 200
+
+
+def test_get_teacher_plan_invalid_raises():
+    """get_teacher_plan raises KeyError for unknown plan IDs."""
+    from src.pricing import get_teacher_plan
+    with pytest.raises(KeyError):
+        get_teacher_plan("enterprise")


### PR DESCRIPTION
## Summary

- Adds a self-serve Stripe subscription flow for independent teachers (no school affiliation)
- Three tiers: Solo ($29/mo, 25 students) · Growth ($59/mo, 75 students) · Pro ($99/mo, 200 students)
- School-affiliated teachers are blocked from this path — their access is covered by the school's plan
- Closes #57

## Changes

**Migration 0034** (`backend/alembic/versions/0034_independent_teacher_subscriptions.py`):
- `teacher_subscriptions` table (mirrors `school_subscriptions` pattern)
- `teachers.teacher_plan` denormalised column for fast JWT population
- Extends `chk_teachers_school_id_or_demo` CHECK to allow `auth_provider='auth0'` with `school_id IS NULL`

**Backend**:
- `src/teacher/subscription_service.py` — checkout session, status, cancel, and webhook event handlers (activated / updated / deleted / payment_failed)
- `src/teacher/subscription_router.py` — `POST/GET/DELETE /api/v1/teachers/{teacher_id}/subscription`
- `src/subscription/router.py` — webhook fan-out routes teacher events by `product_type='teacher_subscription'` metadata or by `find_teacher_by_stripe_subscription()` DB lookup
- `config.py` — `STRIPE_TEACHER_PRICE_{SOLO,GROWTH,PRO}_ID` settings
- `src/pricing.py` — `TeacherPlan` feature bullets, `VALID_TEACHER_PLAN_IDS`, `get_teacher_plan()`
- `tests/helpers/token_factory.py` — `_UNSET` sentinel so `make_teacher_token(school_id=None)` works correctly

**Tests**: 18 tests, all passing.

## Test plan

- [ ] All 18 tests in `tests/test_teacher_subscription.py` pass
- [ ] Full suite: `docker compose exec api python -m pytest --tb=no -q`
- [ ] Set `STRIPE_TEACHER_PRICE_{SOLO,GROWTH,PRO}_ID` in `.env` before running manual Stripe checkout tests
- [ ] Verify `alembic upgrade head` applies migration 0034 cleanly
- [ ] Verify school-affiliated teacher receives 403 `school_affiliated` on checkout endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)