### PR TITLE
fix(ci): unblock Playwright E2E — legacy-peer-deps for TypeScript 6 + next-intl (#126)

### DIFF
--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Problem

The Playwright E2E workflow (`e2e.yml`) was failing at `npm ci` before any tests ran:

```
npm error ERESOLVE unable to resolve dependency tree
npm error peer dep typescript@"^5.0.0" from next-intl@4.8.3
npm error   found typescript@"6.0.2" in devDependencies
```

`next-intl@4.8.3` declares `peerOptional typescript@"^5.0.0"` (i.e. `>=5.0.0 <6.0.0`).
npm 9+ treats peerOptional violations as ERESOLVE errors in strict mode, blocking install.

## Fix

Add `web/.npmrc` with `legacy-peer-deps=true`.

This restores npm v6 peer-dep resolution behaviour for the `web/` directory — peerOptional
mismatches are silently skipped rather than hard-failed.  No packages are changed; TypeScript 6
remains installed.

## What this unblocks

The E2E infrastructure was already fully in place from the previous sprint:
- `web/tests/e2e/student_flow.spec.ts` — 3 critical-path tests (public landing, curriculum map → lesson, full learning loop)
- `.github/workflows/e2e.yml` — runs `npx playwright test --project=chromium tests/e2e/student_flow.spec.ts` on every PR
- All mock data files (`tests/e2e/data/`) and helpers (`tests/e2e/helpers/`) present

With this fix, CI can now install deps and execute the tests.

## Test plan
- [ ] CI passes (green `npm ci` + Playwright tests run)
- [ ] No packages are downgraded or added

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)