### PR TITLE
feat(arch): mobile API versioning — fix 4 gaps in X-App-Version enforcement (#125)

### DIFF
--- a/backend/src/content/router.py
+++ b/backend/src/content/router.py
@@ -413,11 +413,14 @@ async def submit_marked_feedback(
 @router.get("/app/version", response_model=AppVersionResponse)
 async def get_app_version(
     request: Request,
-    student: Annotated[dict, Depends(get_current_student)],
 ):
     """
     Return the current minimum and latest app versions.
-    Loaded from the app_versions table (platform='all' or platform='ios'/'android').
+
+    No authentication required — called by the mobile app on startup before
+    the user has logged in.  Version info is not sensitive.
+
+    Loaded from the app_versions table (platform='all').
     """
     pool = request.app.state.pool
 

--- a/backend/src/core/app_factory.py
+++ b/backend/src/core/app_factory.py
@@ -202,7 +202,7 @@ def _register_middleware(app: FastAPI) -> None:
         allow_origins=settings.allowed_origins_list,
         allow_credentials=True,
         allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-        allow_headers=["Content-Type", "Authorization", "X-Correlation-Id", "X-Requested-With"],
+        allow_headers=["Content-Type", "Authorization", "X-Correlation-Id", "X-Requested-With", "X-App-Version"],
         expose_headers=["X-Correlation-Id"],
     )
 

--- a/mobile/main.py
+++ b/mobile/main.py
@@ -34,8 +34,9 @@ import config as cfg
 
 log = logging.getLogger("mobile.main")
 
-# ── App version (embedded at build time) ──────────────────────────────────────
-APP_VERSION = "0.1.0"
+# ── App version — single source of truth is config.py ─────────────────────────
+# Never hardcode the version here; config.APP_VERSION is updated at release time.
+APP_VERSION = cfg.APP_VERSION
 
 
 def _version_tuple(v: str) -> tuple[int, ...]:
@@ -99,14 +100,16 @@ def _show_upgrade_banner(latest_version: str) -> None:
 
 # ── Async version check (runs in daemon thread) ───────────────────────────────
 
-def _check_version_thread(token: Optional[str]) -> None:
+def _check_version_thread() -> None:
     """
     Run in a daemon thread.  Calls GET /app/version and triggers the
     appropriate UI response on the main thread.
+
+    The endpoint is unauthenticated — no token is needed or sent.
     """
     async def _fetch():
         from mobile.src.api.content_client import get_app_version
-        return await get_app_version(token or "")
+        return await get_app_version()
 
     try:
         loop = asyncio.new_event_loop()
@@ -162,10 +165,7 @@ class StudyBuddyApp(App):
 
     def on_start(self) -> None:
         """Called after build().  Launch version check without blocking the UI."""
-        # Read stored JWT (if any) for authenticated version check.
-        token = self._read_stored_token()
-
-        t = Thread(target=_check_version_thread, args=(token,), daemon=True)
+        t = Thread(target=_check_version_thread, daemon=True)
         t.start()
 
         # Navigate to login screen (or home screen if already authenticated).

--- a/mobile/src/api/content_client.py
+++ b/mobile/src/api/content_client.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     BACKEND_URL = os.environ.get("BACKEND_URL", "http://localhost:8000")
 
-from mobile.src.api import app_headers  # noqa: E402
+from mobile.src.api import app_headers, version_headers  # noqa: E402
 
 
 async def get_lesson(unit_id: str, token: str) -> dict:
@@ -73,16 +73,17 @@ async def get_audio_url(unit_id: str, token: str) -> dict:
         return response.json()
 
 
-async def get_app_version(token: str) -> dict:
+async def get_app_version() -> dict:
     """
     Fetch the current min/latest app version from the backend.
 
     Returns {min_version: str, latest_version: str}.
-    Called on app startup to check if an upgrade is required.
+    Called on app startup before login — no auth token required.
+    The endpoint is unauthenticated; only X-App-Version is sent.
     """
     url = f"{BACKEND_URL}/api/v1/app/version"
     async with httpx.AsyncClient(timeout=10) as client:
-        response = await client.get(url, headers=app_headers(token))
+        response = await client.get(url, headers=version_headers())
         response.raise_for_status()
         return response.json()
 

--- a/mobile/tests/test_version_check.py
+++ b/mobile/tests/test_version_check.py
@@ -1,0 +1,198 @@
+"""
+mobile/tests/test_version_check.py
+
+Unit tests for app version check logic in mobile/main.py.
+
+Covers:
+  - _version_tuple() parsing
+  - _check_version_thread(): upgrade required when below minimum
+  - _check_version_thread(): upgrade banner when below latest but >= minimum
+  - _check_version_thread(): no UI calls when already at latest
+  - _check_version_thread(): network failure is non-fatal (app continues)
+  - X-App-Version header is sent on every API call (app_headers / version_headers)
+  - APP_VERSION is read from config, not hardcoded
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the mobile package root is importable without Kivy installed.
+# We stub out kivy before any mobile import so tests run in CI without
+# a display server.
+# ---------------------------------------------------------------------------
+
+# Kivy top-level stub
+kivy_stub = MagicMock()
+kivy_stub.app = MagicMock()
+kivy_stub.app.App = object  # base class — StudyBuddyApp won't be instantiated
+kivy_stub.clock = MagicMock()
+kivy_stub.clock.mainthread = lambda fn: fn  # no-op in tests
+kivy_stub.uix = MagicMock()
+kivy_stub.uix.boxlayout = MagicMock()
+kivy_stub.uix.button = MagicMock()
+kivy_stub.uix.label = MagicMock()
+kivy_stub.uix.popup = MagicMock()
+kivy_stub.uix.screenmanager = MagicMock()
+
+sys.modules.setdefault("kivy", kivy_stub)
+sys.modules.setdefault("kivy.app", kivy_stub.app)
+sys.modules.setdefault("kivy.clock", kivy_stub.clock)
+sys.modules.setdefault("kivy.uix", kivy_stub.uix)
+sys.modules.setdefault("kivy.uix.boxlayout", kivy_stub.uix.boxlayout)
+sys.modules.setdefault("kivy.uix.button", kivy_stub.uix.button)
+sys.modules.setdefault("kivy.uix.label", kivy_stub.uix.label)
+sys.modules.setdefault("kivy.uix.popup", kivy_stub.uix.popup)
+sys.modules.setdefault("kivy.uix.screenmanager", kivy_stub.uix.screenmanager)
+
+# Now safe to import mobile.main and mobile.src.api
+from mobile.main import _version_tuple, _check_version_thread  # noqa: E402
+import mobile.main as main_module  # noqa: E402
+from mobile.src.api import app_headers, version_headers  # noqa: E402
+import mobile.config as mobile_config  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _version_tuple() — parsing
+# ---------------------------------------------------------------------------
+
+
+class TestVersionTuple:
+    def test_standard_semver(self):
+        assert _version_tuple("2.0.0") == (2, 0, 0)
+
+    def test_two_parts(self):
+        assert _version_tuple("1.5") == (1, 5)
+
+    def test_leading_zeros_ignored(self):
+        assert _version_tuple("2.0.10") == (2, 0, 10)
+
+    def test_comparison_less_than(self):
+        assert _version_tuple("1.9.9") < _version_tuple("2.0.0")
+
+    def test_comparison_equal(self):
+        assert _version_tuple("2.0.0") == _version_tuple("2.0.0")
+
+    def test_comparison_greater(self):
+        assert _version_tuple("2.1.0") > _version_tuple("2.0.9")
+
+    def test_malformed_returns_zero_tuple(self):
+        assert _version_tuple("not-a-version") == (0,)
+
+    def test_empty_returns_zero_tuple(self):
+        assert _version_tuple("") == (0,)
+
+
+# ---------------------------------------------------------------------------
+# APP_VERSION sourced from config
+# ---------------------------------------------------------------------------
+
+
+def test_app_version_matches_config():
+    """APP_VERSION in main.py must equal config.APP_VERSION, never hardcoded."""
+    assert main_module.APP_VERSION == mobile_config.APP_VERSION
+
+
+# ---------------------------------------------------------------------------
+# _check_version_thread() — behaviour under different server responses
+# ---------------------------------------------------------------------------
+
+
+def _run_version_check(server_response: dict) -> None:
+    """Helper: run _check_version_thread() synchronously with a mocked API."""
+    mock_get_app_version = AsyncMock(return_value=server_response)
+    with patch("mobile.src.api.content_client.get_app_version", mock_get_app_version):
+        _check_version_thread()
+
+
+class TestCheckVersionThread:
+    def test_upgrade_required_when_below_minimum(self):
+        """When APP_VERSION < min_version, the upgrade-required modal fires."""
+        with patch.object(main_module, "APP_VERSION", "1.0.0"):
+            with patch.object(
+                main_module, "_show_upgrade_required_main"
+            ) as mock_required, patch.object(
+                main_module, "_show_upgrade_banner_main"
+            ) as mock_banner:
+                _run_version_check({"min_version": "2.0.0", "latest_version": "2.1.0"})
+
+        mock_required.assert_called_once_with("2.0.0")
+        mock_banner.assert_not_called()
+
+    def test_upgrade_banner_when_below_latest(self):
+        """When min <= APP_VERSION < latest_version, the non-blocking banner fires."""
+        with patch.object(main_module, "APP_VERSION", "2.0.0"):
+            with patch.object(
+                main_module, "_show_upgrade_required_main"
+            ) as mock_required, patch.object(
+                main_module, "_show_upgrade_banner_main"
+            ) as mock_banner:
+                _run_version_check({"min_version": "2.0.0", "latest_version": "2.1.0"})
+
+        mock_banner.assert_called_once_with("2.1.0")
+        mock_required.assert_not_called()
+
+    def test_no_ui_when_on_latest(self):
+        """When APP_VERSION == latest_version, no modal or banner is shown."""
+        with patch.object(main_module, "APP_VERSION", "2.1.0"):
+            with patch.object(
+                main_module, "_show_upgrade_required_main"
+            ) as mock_required, patch.object(
+                main_module, "_show_upgrade_banner_main"
+            ) as mock_banner:
+                _run_version_check({"min_version": "2.0.0", "latest_version": "2.1.0"})
+
+        mock_required.assert_not_called()
+        mock_banner.assert_not_called()
+
+    def test_network_failure_is_non_fatal(self):
+        """A connection error must not raise — app must continue to login screen."""
+        mock_fail = AsyncMock(side_effect=Exception("connection refused"))
+        with patch("mobile.src.api.content_client.get_app_version", mock_fail):
+            # Must not raise
+            _check_version_thread()
+
+    def test_missing_keys_use_safe_defaults(self):
+        """A response with missing keys must not crash — safe fallback values used."""
+        with patch.object(main_module, "APP_VERSION", "2.0.0"):
+            with patch.object(main_module, "_show_upgrade_required_main") as mock_required, \
+                 patch.object(main_module, "_show_upgrade_banner_main") as mock_banner:
+                _run_version_check({})  # empty dict — no min_version, no latest_version
+
+        # min_version defaults to "0.0.0" — 2.0.0 >= 0.0.0, so no upgrade required
+        mock_required.assert_not_called()
+        # latest_version defaults to APP_VERSION itself — no banner
+        mock_banner.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# X-App-Version header helpers
+# ---------------------------------------------------------------------------
+
+
+class TestApiHeaders:
+    def test_app_headers_includes_x_app_version(self):
+        headers = app_headers("some-token")
+        assert "X-App-Version" in headers
+
+    def test_app_headers_x_app_version_matches_config(self):
+        headers = app_headers("some-token")
+        assert headers["X-App-Version"] == mobile_config.APP_VERSION
+
+    def test_version_headers_includes_x_app_version(self):
+        headers = version_headers()
+        assert "X-App-Version" in headers
+
+    def test_version_headers_has_no_authorization(self):
+        headers = version_headers()
+        assert "Authorization" not in headers
+
+    def test_app_headers_includes_authorization(self):
+        headers = app_headers("tok-abc")
+        assert headers["Authorization"] == "Bearer tok-abc"


### PR DESCRIPTION
## Summary

The `AppVersionMiddleware`, `X-App-Version` headers in API clients, `GET /app/version` endpoint, and `app_versions` table were already in place from a previous sprint. This PR fixes four end-to-end gaps that meant the feature never actually worked:

- **`mobile/main.py` — hardcoded version**: `APP_VERSION = "0.1.0"` was always used for the upgrade comparison regardless of what `config.py` said. Changed to `cfg.APP_VERSION` (single source of truth).
- **`GET /api/v1/app/version` required auth**: Called on startup before the user logs in — `Depends(get_current_student)` caused a 401 on every first launch. Endpoint is now unauthenticated (version info is not sensitive).
- **`get_app_version()` sent an auth header**: Used `app_headers(token)` for what is now an unauthenticated call. Switched to `version_headers()`, removed the `token` argument.
- **CORS missing `X-App-Version`**: Browser-origin clients would fail the CORS preflight. Added to `allow_headers`.

## Tests

19 new unit tests in `mobile/tests/test_version_check.py` covering:
- `_version_tuple()` parsing and comparison
- `_check_version_thread()`: upgrade-required modal, non-blocking banner, no-op when current, network failure resilience, missing-key safe defaults
- `app_headers()` / `version_headers()` header content
- `APP_VERSION` sourced from config, not hardcoded

```
19 passed in 0.20s
```

## Test plan
- [ ] CI passes
- [ ] On startup with an old `APP_VERSION` in config, the upgrade-required modal fires
- [ ] `GET /api/v1/app/version` returns 200 without an Authorization header

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)