### PR TITLE
fix(e2e): correct student_flow.spec.ts stubs and assertions

### DIFF
--- a/web/tests/e2e/data/landing-page.ts
+++ b/web/tests/e2e/data/landing-page.ts
@@ -21,9 +21,10 @@ export const BANNER = {
 // ---------------------------------------------------------------------------
 
 export const HERO = {
-  heading: "STEM tutoring available the moment students need it",
+  // Matches en.json "hero_heading". Update here if the i18n value changes.
+  heading: "Study Buddy",
   subheading:
-    "Instant lessons, quizzes, and audio for Grades 5–12. No waiting. No API keys. Just learning.",
+    "Instant lessons, quizzes, and audio where available. Just learning.",
   ctaPrimary: { text: "Start free trial", href: "/signup" },
   ctaSecondary: { text: "See how it works", href: "/#features" },
 } as const;

--- a/web/tests/e2e/data/quiz-page.ts
+++ b/web/tests/e2e/data/quiz-page.ts
@@ -6,16 +6,88 @@
  * Unit tests mock useQuiz() and progress API calls directly.
  *
  * Backend API routes for E2E page.route() interception:
- *   GET  /api/v1/content/{unit_id}/quiz     → MOCK_QUIZ
- *   POST /api/v1/progress/session/start     → MOCK_SESSION_START
- *   POST /api/v1/progress/answer            → MOCK_ANSWER_CORRECT | MOCK_ANSWER_WRONG
- *   POST /api/v1/progress/session/end       → MOCK_SESSION_END_PASSED | MOCK_SESSION_END_FAILED
+ *   GET  /api/v1/content/{unit_id}/quiz           → MOCK_BACKEND_QUIZ_RESPONSE (BackendQuizResponse shape)
+ *   POST /api/v1/progress/session                 → { session_id }
+ *   POST /api/v1/progress/session/{id}/answer     → MOCK_ANSWER_CORRECT | MOCK_ANSWER_WRONG
+ *   POST /api/v1/progress/session/{id}/end        → { session_id, score, total_questions, passed, ... }
+ *
+ * Note: getQuiz() in lib/api/content.ts maps BackendQuizResponse → QuizContent.
+ * MOCK_BACKEND_QUIZ_RESPONSE is the raw backend shape that must be returned by the stub.
+ * MOCK_QUIZ is the frontend QuizContent shape (used for assertion values only).
  */
 
 import type { QuizContent, AnswerResponse, SessionEndResponse } from "@/lib/types/api";
 
 // ---------------------------------------------------------------------------
-// Mock quiz — 3 questions, correct_index varies (STU-19..STU-23)
+// Mock quiz backend response — BackendQuizResponse shape (stub for GET /quiz)
+// getQuiz() in content.ts maps this to QuizContent. set_number=1 → title
+// becomes "Quiz — Set 1".
+// ---------------------------------------------------------------------------
+
+export const MOCK_BACKEND_QUIZ_RESPONSE = {
+  unit_id: "G8-SCI-001",
+  set_number: 1,
+  language: "en",
+  total_questions: 3,
+  estimated_duration_minutes: 5,
+  passing_score: 0.7,
+  generated_at: "2026-01-01T00:00:00Z",
+  model: "claude-sonnet-4-6",
+  content_version: 1,
+  questions: [
+    {
+      question_id: "G8-SCI-001-Q1",
+      question_text: "What is the basic unit of all living organisms?",
+      question_type: "multiple_choice",
+      options: [
+        { option_id: "A", text: "Atom" },
+        { option_id: "B", text: "Cell" },
+        { option_id: "C", text: "Tissue" },
+        { option_id: "D", text: "Organ" },
+      ],
+      correct_option: "B",
+      explanation:
+        "The cell is the basic structural and functional unit of all living organisms.",
+      difficulty: "easy",
+    },
+    {
+      question_id: "G8-SCI-001-Q2",
+      question_text: "Which organelle contains the cell's DNA?",
+      question_type: "multiple_choice",
+      options: [
+        { option_id: "A", text: "Mitochondria" },
+        { option_id: "B", text: "Ribosome" },
+        { option_id: "C", text: "Nucleus" },
+        { option_id: "D", text: "Vacuole" },
+      ],
+      correct_option: "C",
+      explanation: "The nucleus houses the cell's genetic material (DNA).",
+      difficulty: "easy",
+    },
+    {
+      question_id: "G8-SCI-001-Q3",
+      question_text: "What do mitochondria produce?",
+      question_type: "multiple_choice",
+      options: [
+        { option_id: "A", text: "Protein" },
+        { option_id: "B", text: "DNA" },
+        { option_id: "C", text: "ATP (energy)" },
+        { option_id: "D", text: "Cell membrane" },
+      ],
+      correct_option: "C",
+      explanation:
+        "Mitochondria are the powerhouse of the cell, producing ATP through cellular respiration.",
+      difficulty: "medium",
+    },
+  ],
+} as const;
+
+/** Display title rendered by getQuiz() from the backend response above. */
+export const MOCK_QUIZ_DISPLAY_TITLE = "Quiz — Set 1";
+
+// ---------------------------------------------------------------------------
+// Mock quiz frontend shape — QuizContent (used for assertion values only, not
+// as a stub response — stubs must use MOCK_BACKEND_QUIZ_RESPONSE)
 // ---------------------------------------------------------------------------
 
 export const MOCK_QUIZ: QuizContent = {

--- a/web/tests/e2e/student_flow.spec.ts
+++ b/web/tests/e2e/student_flow.spec.ts
@@ -98,8 +98,12 @@ async function stubQuizApis(page: Page) {
     route.fulfill({ status: 200, json: MOCK_QUIZ }),
   );
   // POST /progress/session — actual URL used by startSession() in progress.ts
-  await page.route("**/api/v1/progress/session", (route) =>
-    route.fulfill({ status: 200, json: { session_id: MOCK_SESSION_ID } }),
+  // Use function predicate: glob "**/api/v1/progress/session" (no trailing **)
+  // is ambiguous in Playwright's LIFO resolver when the more-specific
+  // "/*/answer" and "/*/end" patterns are registered after it.
+  await page.route(
+    (url) => url.pathname === "/api/v1/progress/session",
+    (route) => route.fulfill({ status: 200, json: { session_id: MOCK_SESSION_ID } }),
   );
   // POST /progress/session/{id}/answer
   await page.route("**/api/v1/progress/session/*/answer", (route) =>

--- a/web/tests/e2e/student_flow.spec.ts
+++ b/web/tests/e2e/student_flow.spec.ts
@@ -34,7 +34,8 @@ import {
   MOCK_SESSION_END_PASSED,
   QUIZ_STRINGS,
 } from "./data/quiz-page";
-import { MOCK_PROGRESS_HISTORY } from "./data/progress-page";
+// MOCK_PROGRESS_HISTORY not imported — stubProgressApis uses inline backend-format response
+// (getProgressHistory maps /progress/student backend shape; frontend ProgressHistory type differs)
 import { HERO, NAV_LINKS } from "./data/landing-page";
 
 // ---------------------------------------------------------------------------
@@ -96,20 +97,55 @@ async function stubQuizApis(page: Page) {
   await page.route("**/api/v1/content/G8-SCI-001/quiz**", (route) =>
     route.fulfill({ status: 200, json: MOCK_QUIZ }),
   );
-  await page.route("**/api/v1/progress/session/start**", (route) =>
+  // POST /progress/session — actual URL used by startSession() in progress.ts
+  await page.route("**/api/v1/progress/session", (route) =>
     route.fulfill({ status: 200, json: { session_id: MOCK_SESSION_ID } }),
   );
-  await page.route("**/api/v1/progress/answer**", (route) =>
-    route.fulfill({ status: 200, json: MOCK_ANSWER_CORRECT }),
+  // POST /progress/session/{id}/answer
+  await page.route("**/api/v1/progress/session/*/answer", (route) =>
+    route.fulfill({ status: 200, json: { correct: true, explanation: "" } }),
   );
-  await page.route("**/api/v1/progress/session/end**", (route) =>
-    route.fulfill({ status: 200, json: MOCK_SESSION_END_PASSED }),
+  // POST /progress/session/{id}/end — backend returns total_questions, not total
+  await page.route("**/api/v1/progress/session/*/end", (route) =>
+    route.fulfill({
+      status: 200,
+      json: {
+        session_id: MOCK_SESSION_ID,
+        score: 3,
+        total_questions: 3,
+        passed: true,
+        attempt_number: 1,
+        ended_at: new Date().toISOString(),
+      },
+    }),
   );
 }
 
 async function stubProgressApis(page: Page) {
-  await page.route("**/api/v1/progress/history**", (route) =>
-    route.fulfill({ status: 200, json: MOCK_PROGRESS_HISTORY }),
+  // useProgressHistory → getProgressHistory → GET /progress/student?limit=...
+  // Response must match the backend shape that getProgressHistory maps from.
+  await page.route("**/api/v1/progress/student**", (route) =>
+    route.fulfill({
+      status: 200,
+      json: {
+        student_id: "test-student-001",
+        sessions: [
+          {
+            session_id: "sess-001",
+            unit_id: "G8-SCI-001",
+            curriculum_id: "default-2026-g8",
+            subject: "Science",
+            started_at: "2026-03-25T10:00:00Z",
+            ended_at: "2026-03-25T10:15:00Z",
+            score: 3,
+            total_questions: 3,
+            completed: true,
+            passed: true,
+            attempt_number: 1,
+          },
+        ],
+      },
+    }),
   );
 }
 
@@ -246,6 +282,6 @@ test("student learning loop: lesson → quiz → result → progress", async ({
   await page.goto("/progress");
   await page.waitForLoadState("networkidle");
 
-  // Cell Biology session from MOCK_PROGRESS_HISTORY.sessions[0]
-  await expect(page.getByText("Cell Biology")).toBeVisible();
+  // getProgressHistory maps unit_title from unit_id (backend doesn't return title)
+  await expect(page.getByText("G8-SCI-001")).toBeVisible();
 });

--- a/web/tests/e2e/student_flow.spec.ts
+++ b/web/tests/e2e/student_flow.spec.ts
@@ -29,9 +29,9 @@ import {
 } from "./data/lesson-page";
 import {
   MOCK_QUIZ,
+  MOCK_BACKEND_QUIZ_RESPONSE,
+  MOCK_QUIZ_DISPLAY_TITLE,
   MOCK_SESSION_ID,
-  MOCK_ANSWER_CORRECT,
-  MOCK_SESSION_END_PASSED,
   QUIZ_STRINGS,
 } from "./data/quiz-page";
 // MOCK_PROGRESS_HISTORY not imported — stubProgressApis uses inline backend-format response
@@ -94,8 +94,9 @@ async function stubLessonApis(page: Page) {
 }
 
 async function stubQuizApis(page: Page) {
+  // Stub must return BackendQuizResponse shape — getQuiz() in content.ts maps it.
   await page.route("**/api/v1/content/G8-SCI-001/quiz**", (route) =>
-    route.fulfill({ status: 200, json: MOCK_QUIZ }),
+    route.fulfill({ status: 200, json: MOCK_BACKEND_QUIZ_RESPONSE }),
   );
   // POST /progress/session — actual URL used by startSession() in progress.ts
   // Use function predicate: glob "**/api/v1/progress/session" (no trailing **)
@@ -241,8 +242,8 @@ test("student learning loop: lesson → quiz → result → progress", async ({
   await page.waitForURL("**/quiz/G8-SCI-001**");
   await page.waitForLoadState("networkidle");
 
-  // Quiz title
-  await expect(page.getByText(MOCK_QUIZ.title)).toBeVisible();
+  // Quiz title — getQuiz() constructs "Quiz — Set {n}" from the backend set_number
+  await expect(page.getByText(MOCK_QUIZ_DISPLAY_TITLE)).toBeVisible();
 
   // ── Step 3: answer all 3 questions correctly ──────────────────────────────
   for (let i = 0; i < MOCK_QUIZ.questions.length; i++) {
@@ -278,7 +279,7 @@ test("student learning loop: lesson → quiz → result → progress", async ({
   }
 
   // ── Step 4: result screen shows a passing score ───────────────────────────
-  // MOCK_SESSION_END_PASSED: score=3, total=3, passed=true
+  // Session end stub: score=3, total_questions=3, passed=true
   await expect(page.getByText("3")).toBeVisible();
 
   // ── Step 5: progress history reflects the completed unit ─────────────────


### PR DESCRIPTION
## Root cause

Three bugs in the test file written for #126 (Playwright E2E) caused 2 of 3 tests to fail in CI:

### Bug 1 — `HERO.heading` mismatch
`landing-page.ts` had `heading: "STEM tutoring available the moment students need it"` but `en.json → hero_heading` is `"Study Buddy"`. Test 1 timed out looking for a heading that doesn't exist.

### Bug 2 — Wrong progress URL stubs in `stubQuizApis`
The actual calls made by `progress.ts` are:
| Stubbed (wrong) | Actual |
|---|---|
| `**/api/v1/progress/session/start**` | `POST /api/v1/progress/session` |
| `**/api/v1/progress/answer**` | `POST /api/v1/progress/session/{id}/answer` |
| `**/api/v1/progress/session/end**` | `POST /api/v1/progress/session/{id}/end` |

Because the session-start stub never matched, `sessionId` stayed `null`, and the quiz page was permanently in skeleton state. Test 3 timed out at `expect(page.getByText("Cell Biology Quiz")).toBeVisible()`.

### Bug 3 — Wrong progress history stub in `stubProgressApis`
`useProgressHistory` calls `GET /progress/student?limit=N`, not `/progress/history`. The response shape also needs to match the backend format (`total_questions`, `completed`) not the frontend `ProgressHistory` type. The page renders `unit_id` as the session title (backend doesn't return names), so the `"Cell Biology"` assertion is corrected to `"G8-SCI-001"`.

## Changes
- `tests/e2e/data/landing-page.ts` — fix `HERO.heading` and `subheading` to match `en.json`
- `tests/e2e/student_flow.spec.ts` — fix 3 stub URL patterns + inline backend-format response for progress + fix progress assertion

## Test plan
- [ ] CI passes (all 3 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)