### PR TITLE
fix(e2e): use specific score locator to avoid strict-mode violation

### DIFF
--- a/web/tests/e2e/student_flow.spec.ts
+++ b/web/tests/e2e/student_flow.spec.ts
@@ -279,8 +279,9 @@ test("student learning loop: lesson → quiz → result → progress", async ({
   }
 
   // ── Step 4: result screen shows a passing score ───────────────────────────
-  // Session end stub: score=3, total_questions=3, passed=true
-  await expect(page.getByText("3")).toBeVisible();
+  // score_label = "Score: {score}/{total} ({pct}%)" → "Score: 3/3 (100%)"
+  // Use regex to avoid strict-mode violation from other elements containing "3".
+  await expect(page.getByText(/Score: 3\/3/)).toBeVisible();
 
   // ── Step 5: progress history reflects the completed unit ─────────────────
   await stubProgressApis(page);


### PR DESCRIPTION
## Summary

- `getByText('3')` on the result screen matched 2+ elements (timestamp + score paragraph), causing a strict-mode violation
- Changed to `getByText(/Score: 3\/3/)` which uniquely targets `score_label` = `"Score: {score}/{total} ({pct}%)"` rendered as `"Score: 3/3 (100%)"`

## Root cause

The Dependabot PRs rebased after #132 merged but still failed E2E because of this assertion. The quiz flow itself was working (score screen reached) but the final check was ambiguous.