### PR TITLE
chore(workflow): /done and /ship-ready quality gates (#215)

### DIFF
--- a/.claude/commands/done.md
+++ b/.claude/commands/done.md
@@ -1,0 +1,81 @@
+---
+description: Fast post-implementation gate — tests + lint + types on changed scope. Target <2min.
+---
+
+You just declared a feature implemented. Before moving on, run the fast gate against what actually changed. **Target runtime: under 2 minutes.** Not a substitute for `/ship-ready` — that's the pre-PR gate.
+
+## Step 1 — Identify scope
+
+```bash
+git diff --name-only main...HEAD
+git status --short
+```
+
+Bucket the changes:
+
+| Bucket | Pattern | Triggers |
+|---|---|---|
+| Backend | `backend/**/*.py`, `pipeline/**/*.py` | backend gates |
+| Web | `web/**/*.{ts,tsx}` | web gates |
+| Migrations | `backend/alembic/versions/*.py` | migration gates |
+
+If no code files changed, stop — there's nothing to gate.
+
+## Step 2 — Run the applicable gates in parallel
+
+Only run a bucket's gates if that bucket has changes. Use multiple Bash tool calls in a single message for concurrency.
+
+### Backend (if Python changed)
+
+```bash
+docker compose exec -T api pytest tests/ -x --tb=short
+ruff check backend/ pipeline/
+bandit -q -r backend/src/ -ll
+```
+
+### Web (if TS/TSX changed)
+
+```bash
+cd web && npm run lint
+cd web && npm run typecheck
+cd web && npm test -- --run
+```
+
+### Migrations (if any `backend/alembic/versions/*.py` touched)
+
+```bash
+docker compose exec -T api alembic upgrade head
+docker compose exec -T api alembic downgrade -1
+docker compose exec -T api alembic upgrade head
+```
+
+The three-step upgrade/downgrade/upgrade cycle is pitfall #27 — never skip.
+
+## Step 3 — Report
+
+Single table, one row per gate actually run:
+
+| Gate | Status | Time | Notes |
+|---|---|---|---|
+| pytest | ✅ / ❌ | ... | ... |
+| ruff | ... | ... | ... |
+
+Don't list gates you skipped (only confuses the reader). Do mention the skipped buckets in prose: "Web gates skipped — no TS/TSX changed."
+
+## Step 4 — Declare
+
+- **All green:** `✅ /done — <N> gates passed. Run /ship-ready before opening the PR.`
+- **Any red:** `❌ Not done — <N> gate(s) failed.` Enumerate each. Offer to fix the first trivial one; otherwise hand back.
+
+**Do not auto-fix broken tests or lint issues.** Fixing is a conscious follow-up decision — silent fixes hide regressions.
+
+## Deliberately out of scope
+
+Excluded from `/done` to keep runtime fast:
+- `npm run build` (1-2min by itself) → in `/ship-ready`
+- OpenAPI regen + TS types drift → in `/regen-openapi` or `/ship-ready`
+- Doc-drift scans → in `/ship-ready`
+- Pitfall checklist read-through → in `/ship-ready`
+- Integration tests against real Stripe/Auth0/Anthropic → never automatable here
+
+If any of the above feel load-bearing for a specific PR, run `/ship-ready` instead.

--- a/.claude/commands/ship-ready.md
+++ b/.claude/commands/ship-ready.md
@@ -1,0 +1,118 @@
+---
+description: Thorough pre-PR gate — full tests + build + contract drift + doc drift + pitfalls. Target <10min.
+---
+
+Comprehensive gate before the PR goes up. Runs everything `/done` runs plus the slow checks that catch cross-cutting issues. **Target runtime: under 10 minutes.** Run once, right before `gh pr create`.
+
+## Step 1 — Confirm branch state
+
+```bash
+git status
+git log main..HEAD --oneline
+```
+
+- **Uncommitted changes?** Abort. Commit them first (they won't be in the PR otherwise).
+- **HEAD == main?** Abort — nothing to ship.
+- **Branch name generic** (`feat`, `wip`, etc.)? Warn — reviewers scan by branch name.
+
+## Step 2 — Full gate suite (parallel where possible)
+
+Launch these groups concurrently via multiple Bash tool calls in a single message. Each group serializes internally.
+
+### Group A — Backend full test suite + security
+```bash
+docker compose exec -T api pytest tests/ --tb=short
+ruff check backend/ pipeline/
+bandit -q -r backend/src/ -ll
+```
+No `-x` here — we want the complete failure list, not the first one.
+
+### Group B — Web full build
+```bash
+cd web && npm run lint && npm run typecheck && npm test -- --run && npm run build
+```
+Production build catches type issues that `tsc --noEmit` misses (e.g., Next.js route-level static-analysis errors).
+
+### Group C — API contract drift
+```bash
+docker compose exec -T api python scripts/export_openapi.py > web/openapi.json
+cd web && npm run gen:types
+git diff --stat web/openapi.json web/lib/api/types.gen.ts
+```
+If the diff is non-empty and **was not produced in this branch's commits**, that's unintentional drift — a pydantic model changed without `/regen-openapi`. Flag it.
+
+### Group D — Migration graph integrity
+```bash
+docker compose exec -T api alembic upgrade head
+docker compose exec -T api alembic downgrade -1
+docker compose exec -T api alembic upgrade head
+docker compose exec -T api alembic check
+```
+
+### Group E — Doc drift (Rule #16)
+Find functions/classes/exports renamed or deleted in this branch:
+```bash
+git diff main...HEAD -- '*.py' '*.ts' '*.tsx' \
+  | grep -E '^-[[:space:]]*(def |class |export (function|const|class) |async def )' \
+  | sed -E 's/^-[[:space:]]*(def|class|async def|export function|export const|export class) ([A-Za-z_][A-Za-z0-9_]*).*/\2/' \
+  | sort -u
+```
+For each name in the output, grep `CLAUDE.md`, `docs/`, `README.md` for references. Any hits = stale doc → flag.
+
+### Group F — Hardcoded secrets spot-check
+```bash
+grep -rnE '(api[_-]?key|secret|password|token)[[:space:]]*=[[:space:]]*["'\''][A-Za-z0-9/+_-]{16,}' \
+  backend/src/ pipeline/ web/app/ web/lib/ \
+  --include='*.py' --include='*.ts' --include='*.tsx' \
+  | grep -vE '(test_|_test\.|conftest\.|\.env\.example)'
+```
+Any hit is a 🔴 block finding.
+
+## Step 3 — Pitfall checklist read-through
+
+No automation here — scan this PR's diff manually against the high-probability pitfalls:
+
+- [ ] Mobile/web does NOT call Anthropic or Stripe directly (pitfall #1, #10)
+- [ ] Async event loop not blocked — bcrypt/CPU work in `run_in_executor` (pitfall #2)
+- [ ] Audio via pre-signed URL, not streamed through FastAPI if touched (pitfall #3)
+- [ ] Progress/analytics writes are fire-and-forget via Celery (pitfall #4)
+- [ ] Stripe webhook still verifies signature + dedupes by `stripe_event_id` (pitfall #8, #9)
+- [ ] Idempotency key support on new POST endpoints (Rule #5)
+- [ ] `attempt_number` computed server-side (pitfall #12)
+- [ ] Auth track not mixed — student JWT can't hit teacher/admin endpoints (pitfall #13)
+- [ ] RLS bypass only where required (login lookup — pitfall #23); tests use `studybuddy_rls_tester`
+- [ ] New migration: full downgrade→upgrade cycle proven (pitfall #27)
+- [ ] `unit_name NOT NULL` respected if migration touches `curriculum_units` (pitfall #20)
+- [ ] CLAUDE.md migrations table updated if new migration file shipped
+
+Report any that tripped as findings.
+
+## Step 4 — Report
+
+Consolidated table:
+
+| Group | Gate | Status | Time | Notes |
+|---|---|---|---|---|
+| A | pytest | ✅ / ❌ | ... | ... |
+| A | ruff | ... | ... | ... |
+| A | bandit | ... | ... | ... |
+| B | npm build | ... | ... | ... |
+| C | OpenAPI drift | ✅ none / ❌ unintentional / ✨ intentional | ... | ... |
+| D | alembic cycle | ... | ... | ... |
+| E | doc drift | ... | ... | list of stale refs |
+| F | secrets scan | ... | ... | ... |
+| — | pitfall checklist | ... | ... | list of trips |
+
+## Step 5 — Declare
+
+- **All green + pitfall scan clean:** `🚀 Ship-ready — <N> gates passed. Open PR with /pr-description.`
+- **Any red:** `🚧 Not ship-ready.` Enumerate each failure. Do not auto-fix.
+
+## Deliberately out of scope
+
+- Integration tests hitting real Stripe / Auth0 / Anthropic — not automatable, run manually before ship for webhook/auth-critical PRs
+- Load / performance tests — separate Epic 6 workflow
+- Cross-browser Playwright full matrix — slow (~30min); run manually for UX-significant PRs
+- Accessibility axe scan beyond the persona spec a11y debt (#189) — separate workflow
+
+If any of these feel load-bearing for this specific PR, run them by hand and note the result in the PR description under "Test plan."


### PR DESCRIPTION
## What changed

Two new slash commands under `.claude/commands/` implementing the bundled quality gates from §2.3 of the workflow-improvements doc:

| Command | Purpose | Budget | When to run |
|---|---|---|---|
| `/done` | Fast post-implementation check — tests + lint + types on changed scope only | **<2min** | After each feature/fix, before moving on |
| `/ship-ready` | Thorough pre-PR check — full test suite + build + drift + docs + secrets + pitfalls | **<10min** | Once, right before `gh pr create` |

## Why two commands, not one

A single gate either gets run constantly at slow-cost (drains time) or rarely at fast-cost (misses issues). Splitting by runtime budget gives both properties:
- `/done` is cheap enough to run after each logical unit of work
- `/ship-ready` bundles the expensive-but-critical checks (contract drift, doc drift, production build) where the stakes justify the cost

## What each gate catches

### `/done` (fast)
- Backend: `pytest -x` + `ruff check` + `bandit -ll` on changed Python
- Web: `npm run lint` + `typecheck` + `test` on changed TS/TSX
- Migrations: full `upgrade → downgrade → upgrade` cycle (pitfall #27)

### `/ship-ready` (thorough, adds on top of /done)
- Backend: full `pytest` (no `-x`, complete failure list)
- Web: production `npm run build` (catches Next.js route-level errors `tsc --noEmit` misses)
- API contract drift: OpenAPI export + `gen:types` → flag if diff doesn't match this branch's intent
- Migration graph: `alembic check` on top of the cycle
- Doc drift (Rule #16): renamed symbols grep'd against `CLAUDE.md` / `docs/`
- Hardcoded-secret spot-check
- 12-item pitfall checklist read-through (the high-probability ones from the top pitfalls list)

## Alternatives considered

- **Single `/ready` command with a `--fast` flag.** Rejected: flag-based modes get skipped ("I'll do fast this time") and you lose the discipline. Distinct names force a conscious choice.
- **Auto-fix failures.** Rejected: silent fixes hide regressions. Both commands explicitly refuse to auto-fix; they surface issues and let the user decide.
- **Run as a PostToolUse hook / Stop hook.** Rejected: these are gates the user invokes deliberately, not event-triggered. A Stop hook running `/done` would misfire on `/clear` and `/compact`.

## Risk

- **Low runtime risk** — pure documentation files under `.claude/commands/`, no code path touched.
- **Docker dependency** — both commands invoke `docker compose exec` for backend steps. If the stack isn't running, the command fails clearly (not silently). Commands could be enhanced with `./dev_start.sh` fallback in a follow-up.
- **Drift with actual test infrastructure** — if `pytest` targets / `alembic` commands / `npm` scripts change, these command bodies drift. No doc-drift CI catches this; trust convention.
- **Depends on /regen-openapi + /pr-description from earlier PRs.** Forward references in the command bodies to `/regen-openapi` (PR #226) and `/pr-description` (issue #216, not yet shipped). Those references become live as their respective PRs merge.

## Test plan

- [ ] `/done` on a trivial one-file Python change → gates scope to backend only, completes under 2min
- [ ] `/done` on a mixed-scope change (Python + TS) → runs both buckets in parallel
- [ ] `/ship-ready` on a branch with no real code change → reports all-green quickly
- [ ] `/ship-ready` on a branch with a deliberate contract drift → flags Group C as unintentional
- [ ] `/ship-ready` on a branch with a renamed function referenced in CLAUDE.md → flags Group E

## Sequencing

Independent of PRs #225, #226, #227 — all different files under `.claude/commands/`. No merge conflict regardless of order.

Refs #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)