### PR TITLE
fix(a11y): html-has-lang — guarantee <html lang="en"> fallback (#189, 1/3)

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -51,7 +51,7 @@ export default async function RootLayout({
 
   return (
     <html
-      lang={locale}
+      lang={locale || "en"}
       className={`${inter.variable} ${merriweather.variable} ${jetbrainsMono.variable} h-full antialiased`}
       suppressHydrationWarning
       {...(dyslexic ? { "data-dyslexic": "true" } : {})}

--- a/web/tests/e2e/README.md
+++ b/web/tests/e2e/README.md
@@ -145,7 +145,7 @@ Playwright fails loudly — the terminal output shows:
 | `Error: browserType.launch: Executable doesn't exist` | Browser binary missing | `npx playwright install chromium` |
 | `Error: spawn ... ENOENT` + `__memset_chk: symbol not found` | Running Playwright inside the Alpine container | Run on host instead — see §6 |
 | `Timeout: 5000ms` waiting for a network request | Mock route doesn't match the real URL pattern | Run with `--trace=on` and inspect the network panel; tighten the route glob |
-| Color-contrast / html-has-lang / document-title axe failures | Known debt tracked in issue #189 | Do NOT add more rules to `KNOWN_A11Y_EXCLUSIONS` — fix the app |
+| Color-contrast / document-title axe failures | Known debt tracked in issue #189 | Do NOT add more rules to `KNOWN_A11Y_EXCLUSIONS` — fix the app |
 
 ### 3.2 Debugging with trace
 
@@ -273,18 +273,19 @@ specs without filing a GitHub issue first (currently tracked in #189).
 
 ## 5. The `KNOWN_A11Y_EXCLUSIONS` technical debt
 
-The three persona specs disable three axe rules:
+The three persona specs disable two axe rules:
 
 ```typescript
 const KNOWN_A11Y_EXCLUSIONS = [
   "color-contrast",
-  "html-has-lang",
   "document-title",
 ] as const;
 ```
 
 Each is tracked in GitHub issue **#189** with root-cause hypothesis +
-fix approach. Do NOT add more rules without:
+fix approach. (`html-has-lang` was resolved by adding a server-side
+`"en"` fallback in `app/layout.tsx` — see the merged PR on #189.)
+Do NOT add more rules without:
 
 1. Filing a tracking issue.
 2. Linking it in the comment block above the constant.

--- a/web/tests/e2e/personas/admin-accessibility.spec.ts
+++ b/web/tests/e2e/personas/admin-accessibility.spec.ts
@@ -20,7 +20,7 @@ import { checkA11y } from "../helpers/axe";
 // Axe rules disabled for this persona. Tracked in GitHub issue #189
 // (umbrella Epic 9 accessibility audit). Do NOT extend without filing
 // a corresponding issue first.
-const KNOWN_A11Y_EXCLUSIONS = ["color-contrast", "html-has-lang", "document-title"] as const;
+const KNOWN_A11Y_EXCLUSIONS = ["color-contrast", "document-title"] as const;
 import { makeAdminToken } from "../helpers/tokens";
 
 // ---------------------------------------------------------------------------

--- a/web/tests/e2e/personas/student-accessibility.spec.ts
+++ b/web/tests/e2e/personas/student-accessibility.spec.ts
@@ -20,12 +20,8 @@ import { makeStudentToken, devSessionCookie } from "../helpers/tokens";
 // a corresponding issue first.
 //
 //   color-contrast — several pages have tokens below WCAG AA 4.5:1
-//   html-has-lang  — some routes render before next-intl has resolved
-//                    the locale cookie, leaving <html> without a lang.
-//                    Symptom only under mocked-API test mode; the real
-//                    dev server resolves the attribute correctly.
 //   document-title — teacher/admin routes miss <title>. Real regression.
-const KNOWN_A11Y_EXCLUSIONS = ["color-contrast", "html-has-lang", "document-title"] as const;
+const KNOWN_A11Y_EXCLUSIONS = ["color-contrast", "document-title"] as const;
 
 // ---------------------------------------------------------------------------
 // Auth helpers

--- a/web/tests/e2e/personas/teacher-accessibility.spec.ts
+++ b/web/tests/e2e/personas/teacher-accessibility.spec.ts
@@ -17,7 +17,7 @@ import { checkA11y } from "../helpers/axe";
 // Axe rules disabled for this persona. Tracked in GitHub issue #189
 // (umbrella Epic 9 accessibility audit). Do NOT extend without filing
 // a corresponding issue first.
-const KNOWN_A11Y_EXCLUSIONS = ["color-contrast", "html-has-lang", "document-title"] as const;
+const KNOWN_A11Y_EXCLUSIONS = ["color-contrast", "document-title"] as const;
 import { makeTeacherToken, devSessionCookie } from "../helpers/tokens";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

Single-token fallback in `web/app/layout.tsx`: `<html lang={locale || "en"}>`. Paired with removing `"html-has-lang"` from the `KNOWN_A11Y_EXCLUSIONS` array in all three persona accessibility specs (student/teacher/admin) and updating the documenting comment/README to reflect the remaining 2 exclusions.

This is **1 of 3** PRs closing the #189 umbrella. Remaining work: `color-contrast` (design-token palette, largest scope), `document-title` (missing `<title>` on teacher/admin routes).

## Why

The `html-has-lang` axe rule failed deterministically under Playwright's mocked-API test mode because next-intl's SSR cookie resolution could lose the race with the route-mock layer, leaving `<html>` without a lang attribute. Real dev server was fine (cookie resolution settles on first request). The failing rule forced us to suppress it across all 3 persona specs — which was tech debt tracked since the specs landed.

The fallback matches `defaultLocale = "en"` already declared in `lib/i18n/request.ts`, so the observable semantics are unchanged — we're only closing the race window.

Refs #189

## Alternatives considered

- **Set the `locale` cookie in test setup** (`page.context().addCookies(...)`). Rejected: test-only patch that doesn't address the underlying SSR-race window. Anyone writing a new persona spec would re-hit the same issue.
- **Move the lang computation to a client-side `<Html>` wrapper**. Rejected: React 19 + Next.js 16 strongly prefers server-resolved `<html>` attributes to avoid hydration mismatches. Added complexity for no gain.
- **Hardcode `lang=\"en\"`**. Rejected: would break French and Spanish locales when they're activated (currently en-only, but the locale plumbing is in place per `request.ts`).
- **Suppress the rule permanently**. Rejected: that's the debt we're paying down, not avoiding.

## Risk

- **Runtime:** zero — production already resolves `getLocale()` to `\"en\"` via `defaultLocale`, so the fallback is never hit. The change is defensive.
- **Locale regression in French/Spanish**: only fires if `locale` is truthy, which it always will be once a `locale` cookie is set. The fallback only kicks in when `getLocale()` returned falsy — which only happens on the SSR-race edge.
- **Didn't run the full Playwright suite in this session** — Alpine vs glibc constraint (pitfall #26). Reviewer should run `cd web && npx playwright test personas/` locally to confirm the 3 persona specs pass with `html-has-lang` re-enabled.
- **Pre-existing CI red** on main (Backend Ruff, Frontend ESLint) is unrelated — this PR adds zero new lint errors (verified via scoped `npx eslint` on the 4 changed files; exit 0).

## Test plan

- [ ] `cd web && npx eslint app/layout.tsx tests/e2e/personas/*.spec.ts` → clean (verified locally: exit 0)
- [ ] `cd web && npx playwright test personas/` → all 3 persona specs pass with `html-has-lang` in the axe-enabled set
- [ ] Visual smoke: `npm run dev`, inspect `<html>` in the first-request DOM — confirm `lang=\"en\"` is present even before any cookie work
- [ ] After merge: close 1 of 3 checkboxes on #189 (convert to umbrella if not already)

Refs #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)