### PR TITLE
fix(a11y): document-title — explicit <title> per portal; split admin layout (#189, 2/3)

### DIFF
--- a/web/app/(admin)/AdminAuthShell.tsx
+++ b/web/app/(admin)/AdminAuthShell.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { AdminNav } from "@/components/layout/AdminNav";
+import { QueryProvider } from "@/lib/providers/QueryProvider";
+import { PortalHeader } from "@/components/layout/PortalHeader";
+import { PortalFooter } from "@/components/layout/PortalFooter";
+
+function parseAdminName(token: string): string | undefined {
+  try {
+    const payload = JSON.parse(
+      atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")),
+    );
+    // Prefer name > email (show the local-part before @ for brevity) > admin_id UUID as last resort.
+    if (payload.name) return payload.name;
+    if (payload.email) return String(payload.email).split("@")[0];
+    return payload.sub ?? payload.admin_id ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function AdminAuthShell({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const [userName, setUserName] = useState<string | undefined>(undefined);
+  const redirectedRef = useRef(false);
+
+  useEffect(() => {
+    if (redirectedRef.current) return;
+    const token = localStorage.getItem("sb_admin_token");
+    if (!token) {
+      redirectedRef.current = true;
+      router.replace("/admin/login");
+    } else {
+      setUserName(parseAdminName(token));
+    }
+  }, [router]);
+
+  return (
+    <QueryProvider>
+      <div className="flex min-h-screen bg-gray-50">
+        <AdminNav />
+        <div className="flex flex-1 flex-col overflow-auto">
+          <PortalHeader portal="admin" userName={userName} />
+          <main id="main-content" className="flex-1">
+            {children}
+          </main>
+          <PortalFooter />
+        </div>
+      </div>
+    </QueryProvider>
+  );
+}

--- a/web/app/(admin)/layout.tsx
+++ b/web/app/(admin)/layout.tsx
@@ -1,54 +1,12 @@
-"use client";
+import type { Metadata } from "next";
+import { AdminAuthShell } from "./AdminAuthShell";
 
-import { useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
-import { AdminNav } from "@/components/layout/AdminNav";
-import { QueryProvider } from "@/lib/providers/QueryProvider";
-import { PortalHeader } from "@/components/layout/PortalHeader";
-import { PortalFooter } from "@/components/layout/PortalFooter";
-
-function parseAdminName(token: string): string | undefined {
-  try {
-    const payload = JSON.parse(
-      atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")),
-    );
-    // Prefer name > email (show the local-part before @ for brevity) > admin_id UUID as last resort.
-    if (payload.name) return payload.name;
-    if (payload.email) return String(payload.email).split("@")[0];
-    return payload.sub ?? payload.admin_id ?? undefined;
-  } catch {
-    return undefined;
-  }
-}
+// Server layout (no `"use client"`) so the Metadata API can set <title>.
+// All interactive/auth-guard logic lives in the AdminAuthShell client component.
+export const metadata: Metadata = {
+  title: "Admin | StudyBuddy",
+};
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
-  const router = useRouter();
-  const [userName, setUserName] = useState<string | undefined>(undefined);
-  const redirectedRef = useRef(false);
-
-  useEffect(() => {
-    if (redirectedRef.current) return;
-    const token = localStorage.getItem("sb_admin_token");
-    if (!token) {
-      redirectedRef.current = true;
-      router.replace("/admin/login");
-    } else {
-      setUserName(parseAdminName(token));
-    }
-  }, [router]);
-
-  return (
-    <QueryProvider>
-      <div className="flex min-h-screen bg-gray-50">
-        <AdminNav />
-        <div className="flex flex-1 flex-col overflow-auto">
-          <PortalHeader portal="admin" userName={userName} />
-          <main id="main-content" className="flex-1">
-            {children}
-          </main>
-          <PortalFooter />
-        </div>
-      </div>
-    </QueryProvider>
-  );
+  return <AdminAuthShell>{children}</AdminAuthShell>;
 }

--- a/web/app/(school)/layout.tsx
+++ b/web/app/(school)/layout.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { auth0 } from "@/lib/auth0";
 import { getDevSession, getDemoTeacherSession, getLocalTeacherSession } from "@/lib/dev-session";
@@ -8,6 +9,10 @@ import { QueryProvider } from "@/lib/providers/QueryProvider";
 import { PortalHeader } from "@/components/layout/PortalHeader";
 import { PortalFooter } from "@/components/layout/PortalFooter";
 import { HelpWidget } from "@/components/help/HelpWidget";
+
+export const metadata: Metadata = {
+  title: "School | StudyBuddy",
+};
 
 export default async function SchoolLayout({ children }: { children: React.ReactNode }) {
   // Phase A local-auth session — cookie set at login, validated client-side.

--- a/web/app/(student)/layout.tsx
+++ b/web/app/(student)/layout.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { auth0 } from "@/lib/auth0";
 import { getDevSession } from "@/lib/dev-session";
@@ -7,6 +8,10 @@ import { TrialBanner } from "@/components/student/TrialBanner";
 import { DemoBanner } from "@/components/demo/DemoBanner";
 import { PortalHeader } from "@/components/layout/PortalHeader";
 import { PortalFooter } from "@/components/layout/PortalFooter";
+
+export const metadata: Metadata = {
+  title: "Student | StudyBuddy",
+};
 
 export default async function StudentLayout({ children }: { children: React.ReactNode }) {
   const session = (await auth0.getSession()) ?? (await getDevSession());

--- a/web/app/(teacher)/layout.tsx
+++ b/web/app/(teacher)/layout.tsx
@@ -1,9 +1,14 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { auth0 } from "@/lib/auth0";
 import { getDevSession } from "@/lib/dev-session";
 import { QueryProvider } from "@/lib/providers/QueryProvider";
 import { PortalHeader } from "@/components/layout/PortalHeader";
 import { PortalFooter } from "@/components/layout/PortalFooter";
+
+export const metadata: Metadata = {
+  title: "Teacher | StudyBuddy",
+};
 
 /**
  * Layout for independent teacher pages (no school affiliation required).

--- a/web/tests/e2e/README.md
+++ b/web/tests/e2e/README.md
@@ -145,7 +145,7 @@ Playwright fails loudly — the terminal output shows:
 | `Error: browserType.launch: Executable doesn't exist` | Browser binary missing | `npx playwright install chromium` |
 | `Error: spawn ... ENOENT` + `__memset_chk: symbol not found` | Running Playwright inside the Alpine container | Run on host instead — see §6 |
 | `Timeout: 5000ms` waiting for a network request | Mock route doesn't match the real URL pattern | Run with `--trace=on` and inspect the network panel; tighten the route glob |
-| Color-contrast / document-title axe failures | Known debt tracked in issue #189 | Do NOT add more rules to `KNOWN_A11Y_EXCLUSIONS` — fix the app |
+| Color-contrast axe failures | Known debt tracked in issue #189 | Do NOT add more rules to `KNOWN_A11Y_EXCLUSIONS` — fix the app |
 
 ### 3.2 Debugging with trace
 
@@ -273,19 +273,21 @@ specs without filing a GitHub issue first (currently tracked in #189).
 
 ## 5. The `KNOWN_A11Y_EXCLUSIONS` technical debt
 
-The three persona specs disable two axe rules:
+The three persona specs disable one axe rule:
 
 ```typescript
 const KNOWN_A11Y_EXCLUSIONS = [
   "color-contrast",
-  "document-title",
 ] as const;
 ```
 
 Each is tracked in GitHub issue **#189** with root-cause hypothesis +
 fix approach. (`html-has-lang` was resolved by adding a server-side
-`"en"` fallback in `app/layout.tsx` — see the merged PR on #189.)
-Do NOT add more rules without:
+`"en"` fallback in `app/layout.tsx`. `document-title` was resolved by
+giving every portal layout an explicit `export const metadata`; the
+admin layout was split into a server shell + client auth component so
+`metadata` could be exported from the route-group layout.) Do NOT add
+more rules without:
 
 1. Filing a tracking issue.
 2. Linking it in the comment block above the constant.

--- a/web/tests/e2e/personas/admin-accessibility.spec.ts
+++ b/web/tests/e2e/personas/admin-accessibility.spec.ts
@@ -20,7 +20,7 @@ import { checkA11y } from "../helpers/axe";
 // Axe rules disabled for this persona. Tracked in GitHub issue #189
 // (umbrella Epic 9 accessibility audit). Do NOT extend without filing
 // a corresponding issue first.
-const KNOWN_A11Y_EXCLUSIONS = ["color-contrast", "document-title"] as const;
+const KNOWN_A11Y_EXCLUSIONS = ["color-contrast"] as const;
 import { makeAdminToken } from "../helpers/tokens";
 
 // ---------------------------------------------------------------------------

--- a/web/tests/e2e/personas/student-accessibility.spec.ts
+++ b/web/tests/e2e/personas/student-accessibility.spec.ts
@@ -20,8 +20,7 @@ import { makeStudentToken, devSessionCookie } from "../helpers/tokens";
 // a corresponding issue first.
 //
 //   color-contrast — several pages have tokens below WCAG AA 4.5:1
-//   document-title — teacher/admin routes miss <title>. Real regression.
-const KNOWN_A11Y_EXCLUSIONS = ["color-contrast", "document-title"] as const;
+const KNOWN_A11Y_EXCLUSIONS = ["color-contrast"] as const;
 
 // ---------------------------------------------------------------------------
 // Auth helpers

--- a/web/tests/e2e/personas/teacher-accessibility.spec.ts
+++ b/web/tests/e2e/personas/teacher-accessibility.spec.ts
@@ -17,7 +17,7 @@ import { checkA11y } from "../helpers/axe";
 // Axe rules disabled for this persona. Tracked in GitHub issue #189
 // (umbrella Epic 9 accessibility audit). Do NOT extend without filing
 // a corresponding issue first.
-const KNOWN_A11Y_EXCLUSIONS = ["color-contrast", "document-title"] as const;
+const KNOWN_A11Y_EXCLUSIONS = ["color-contrast"] as const;
 import { makeTeacherToken, devSessionCookie } from "../helpers/tokens";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

Three coordinated fixes so every authenticated portal page has a `<title>`:

1. **`(admin)/layout.tsx` split.** The previous single-file client layout is now (a) a **server** layout that exports `metadata: { title: "Admin | StudyBuddy" }` and (b) a new `AdminAuthShell.tsx` client component holding the existing auth-guard + router logic. Behaviour unchanged; metadata now flows.
2. **Explicit `metadata` on `(student)`, `(teacher)`, `(school)` layouts** — all three are already server components, so a direct `export const metadata = { title: ... }` works and gives defence-in-depth against Next.js 16 cascade edge cases.
3. **`"document-title"` removed from `KNOWN_A11Y_EXCLUSIONS`** in all three persona specs + README + inline comments updated.

This is **2 of 3** PRs closing the #189 umbrella. Remaining: `color-contrast` (design-token palette, largest scope).

## Why

Axe's `document-title` rule failed on teacher/admin persona pages. Root layout's `metadata.title.default` should have cascaded, but the admin route group's layout was `"use client"` — and client components cannot export `metadata` in Next.js. That broke the cascade for the entire `(admin)` branch. Explicit layout-level metadata makes titles deterministic across all four portals and no longer dependent on cascade through a client layer.

Refs #189

## Alternatives considered

- **Keep `(admin)/layout.tsx` as client, add metadata to individual admin pages.** Rejected: pages are also `"use client"` (useQuery + useState heavily), so they can't export metadata either. Would require splitting ~25 page files.
- **Rely on root layout's `default` title only.** Rejected: already was relying on that and it demonstrably wasn't reaching admin pages — cascade was broken.
- **Use `document.title = "..."` in a `useEffect`.** Rejected: client-side title changes arrive after SSR + hydration; axe running against the initial DOM (pre-hydration) would still flag the violation. Also fights Next.js's Metadata API instead of working with it.
- **Remove `"use client"` from `(admin)/layout.tsx` and move `useRouter`/`useEffect` inline using React Server Actions.** Rejected: those features are for mutations, not auth guard patterns. The split-file pattern is the idiomatic Next.js 16 solution.

## Risk

- **Admin layout refactor — logic preserved verbatim.** The client shell has identical behaviour: same `parseAdminName()`, same `useEffect` with `redirectedRef`, same redirect target (`/admin/login`), same layout markup. Line-for-line copy into `AdminAuthShell.tsx` with the exported function renamed from `AdminLayout` to `AdminAuthShell`.
- **Metadata cascade semantics changed.** Previously all four portals inherited `"StudyBuddy — AI-powered study material for Grades 5–12"` from the root `default`. Now they show portal-specific titles (`Student | StudyBuddy`, `Teacher | StudyBuddy`, etc.). Visible to users in the browser tab / bookmarks. Low regression risk — clearer, not worse — but worth noting in case there's a product preference for the long-form default.
- **Didn't run the full Playwright suite in this session** — Alpine/glibc constraint (pitfall #26). Reviewer should run `cd web && npx playwright test personas/` on host to confirm specs pass with `document-title` re-enabled.
- **Pre-existing CI red** on main (Backend Ruff, Frontend ESLint, pre-existing tsc error in `(school)/school/subscription/page.tsx`) is unrelated. Scoped lint on the 8 files I changed → exit 0.

## Test plan

- [x] Scoped lint (`npx eslint <8 changed files>`) → exit 0
- [x] Scoped typecheck (`tsc --noEmit` filtered to changed files) → clean
- [ ] `cd web && npx playwright test personas/` on host → all 3 persona specs pass with `document-title` in the axe-enabled set
- [ ] Visual smoke: `npm run dev`, visit `/admin/dashboard`, `/school/dashboard`, `/teacher/subscription`, `/dashboard` — inspect browser tab to confirm each shows its portal-specific title
- [ ] Verify admin auth guard still works: clear `sb_admin_token` → refreshing any `/admin/*` page should redirect to `/admin/login`

## Sequencing

Will conflict with PR #230 (html-has-lang) on the single-line `KNOWN_A11Y_EXCLUSIONS` array in all 3 persona specs. Trivial rebase — whichever merges second removes the remaining rule that its sibling already removed. Not blocking.

Refs #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)