### PR TITLE
fix(web): defensive guards on fetched-data access — unblocks #230 and #231

### DIFF
--- a/web/app/(admin)/admin/analytics/page.tsx
+++ b/web/app/(admin)/admin/analytics/page.tsx
@@ -47,43 +47,45 @@ export default function AdminAnalyticsPage() {
                 <tr>
                   <td className="px-4 py-3 text-gray-700">Monthly subscribers</td>
                   <td className="px-4 py-3 text-right font-mono text-gray-900">
-                    {sub.active_monthly.toLocaleString()}
+                    {sub.active_monthly?.toLocaleString() ?? "—"}
                   </td>
                 </tr>
                 <tr>
                   <td className="px-4 py-3 text-gray-700">Annual subscribers</td>
                   <td className="px-4 py-3 text-right font-mono text-gray-900">
-                    {sub.active_annual.toLocaleString()}
+                    {sub.active_annual?.toLocaleString() ?? "—"}
                   </td>
                 </tr>
                 <tr>
                   <td className="px-4 py-3 text-gray-700">Total active</td>
                   <td className="px-4 py-3 text-right font-mono font-semibold text-gray-900">
-                    {sub.total_active.toLocaleString()}
+                    {sub.total_active?.toLocaleString() ?? "—"}
                   </td>
                 </tr>
                 <tr>
                   <td className="px-4 py-3 text-gray-700">MRR (CAD)</td>
                   <td className="px-4 py-3 text-right font-mono tabular-nums text-gray-900">
-                    ${parseFloat(sub.mrr_usd).toLocaleString("en-CA", { minimumFractionDigits: 2 })}
+                    {sub.mrr_usd
+                      ? `$${parseFloat(sub.mrr_usd).toLocaleString("en-CA", { minimumFractionDigits: 2 })}`
+                      : "—"}
                   </td>
                 </tr>
                 <tr>
                   <td className="px-4 py-3 text-gray-700">New this month</td>
                   <td className="px-4 py-3 text-right font-mono text-green-700">
-                    +{sub.new_this_month}
+                    +{sub.new_this_month ?? 0}
                   </td>
                 </tr>
                 <tr>
                   <td className="px-4 py-3 text-gray-700">Cancelled this month</td>
                   <td className="px-4 py-3 text-right font-mono text-red-600">
-                    -{sub.cancelled_this_month}
+                    -{sub.cancelled_this_month ?? 0}
                   </td>
                 </tr>
                 <tr>
                   <td className="px-4 py-3 text-gray-700">Churn rate</td>
                   <td className="px-4 py-3 text-right font-mono text-gray-900">
-                    {(sub.churn_rate * 100).toFixed(2)}%
+                    {sub.churn_rate != null ? `${(sub.churn_rate * 100).toFixed(2)}%` : "—"}
                   </td>
                 </tr>
               </tbody>

--- a/web/app/(admin)/admin/audit/page.tsx
+++ b/web/app/(admin)/admin/audit/page.tsx
@@ -58,10 +58,10 @@ export default function AdminAuditPage() {
             <div key={i} className="h-12 animate-pulse rounded-lg bg-gray-100" />
           ))}
         </div>
-      ) : data && data.entries.length > 0 ? (
+      ) : data && data.entries && data.entries.length > 0 ? (
         <>
           <p className="mb-3 text-xs text-gray-400">
-            {data.total.toLocaleString()} entries
+            {data.total?.toLocaleString() ?? 0} entries
           </p>
           <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
             <table className="w-full text-sm">

--- a/web/app/(admin)/admin/content-review/page.tsx
+++ b/web/app/(admin)/admin/content-review/page.tsx
@@ -103,7 +103,7 @@ export default function AdminContentReviewPage() {
 
   // Group items by curriculum_id, preserving insertion order
   const groups: Map<string, NonNullable<typeof data>["items"]> = new Map();
-  if (data) {
+  if (data?.items) {
     for (const item of data.items) {
       const key = item.curriculum_id;
       if (!groups.has(key)) groups.set(key, []);
@@ -168,7 +168,7 @@ export default function AdminContentReviewPage() {
             <div key={i} className="h-14 animate-pulse rounded-xl bg-gray-100" />
           ))}
         </div>
-      ) : data && data.items.length > 0 ? (
+      ) : data && data.items && data.items.length > 0 ? (
         <>
           <p className="mb-3 text-xs text-gray-400">
             {data.total} item{data.total !== 1 ? "s" : ""}

--- a/web/app/(admin)/admin/dashboard/page.tsx
+++ b/web/app/(admin)/admin/dashboard/page.tsx
@@ -83,24 +83,32 @@ export default function AdminDashboardPage() {
             <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
               <KpiCard
                 label="Total Active"
-                value={analytics.total_active.toLocaleString()}
-                sub={`${analytics.active_monthly} monthly · ${analytics.active_annual} annual`}
+                value={analytics.total_active?.toLocaleString() ?? "—"}
+                sub={`${analytics.active_monthly ?? 0} monthly · ${analytics.active_annual ?? 0} annual`}
                 icon={<Users className="h-4 w-4" />}
               />
               <KpiCard
                 label="MRR"
-                value={`$${parseFloat(analytics.mrr_usd).toLocaleString("en-CA", { minimumFractionDigits: 0 })}`}
+                value={
+                  analytics.mrr_usd
+                    ? `$${parseFloat(analytics.mrr_usd).toLocaleString("en-CA", { minimumFractionDigits: 0 })}`
+                    : "—"
+                }
                 icon={<DollarSign className="h-4 w-4" />}
               />
               <KpiCard
                 label="New This Month"
-                value={analytics.new_this_month}
+                value={analytics.new_this_month ?? 0}
                 icon={<TrendingUp className="h-4 w-4" />}
               />
               <KpiCard
                 label="Churn Rate"
-                value={`${(analytics.churn_rate * 100).toFixed(1)}%`}
-                sub={`${analytics.cancelled_this_month} cancelled`}
+                value={
+                  analytics.churn_rate != null
+                    ? `${(analytics.churn_rate * 100).toFixed(1)}%`
+                    : "—"
+                }
+                sub={`${analytics.cancelled_this_month ?? 0} cancelled`}
                 icon={<AlertTriangle className="h-4 w-4" />}
               />
             </div>

--- a/web/app/(school)/school/alerts/page.tsx
+++ b/web/app/(school)/school/alerts/page.tsx
@@ -53,9 +53,9 @@ export default function AlertsPage() {
   }
 
   const visibleAlerts =
-    data?.alerts.filter((a) => !a.acknowledged && !dismissed.has(a.alert_id)) ?? [];
+    data?.alerts?.filter((a) => !a.acknowledged && !dismissed.has(a.alert_id)) ?? [];
   const acknowledgedAlerts =
-    data?.alerts.filter((a) => a.acknowledged || dismissed.has(a.alert_id)) ?? [];
+    data?.alerts?.filter((a) => a.acknowledged || dismissed.has(a.alert_id)) ?? [];
 
   return (
     <div className="max-w-3xl space-y-6 p-6">

--- a/web/app/(school)/school/dashboard/page.tsx
+++ b/web/app/(school)/school/dashboard/page.tsx
@@ -75,7 +75,7 @@ export default function SchoolDashboard() {
     staleTime: 60_000,
   });
 
-  const unreadAlerts = alertsData?.alerts.filter((a) => !a.acknowledged).length ?? 0;
+  const unreadAlerts = alertsData?.alerts?.filter((a) => !a.acknowledged).length ?? 0;
 
   const isAdmin = teacher?.role === "school_admin";
 
@@ -187,8 +187,8 @@ export default function SchoolDashboard() {
             />
             <KpiCard
               title="Active this week"
-              value={`${overview.active_pct.toFixed(0)}%`}
-              subtitle={`${overview.active_students_period} of ${overview.enrolled_students}`}
+              value={overview.active_pct != null ? `${overview.active_pct.toFixed(0)}%` : "—"}
+              subtitle={`${overview.active_students_period ?? 0} of ${overview.enrolled_students ?? 0}`}
               icon={<TrendingUp className="h-5 w-5" />}
               accent="green"
             />
@@ -201,9 +201,18 @@ export default function SchoolDashboard() {
             />
             <KpiCard
               title="Pass rate (1st attempt)"
-              value={`${overview.first_attempt_pass_rate_pct.toFixed(0)}%`}
+              value={
+                overview.first_attempt_pass_rate_pct != null
+                  ? `${overview.first_attempt_pass_rate_pct.toFixed(0)}%`
+                  : "—"
+              }
               icon={<CheckCircle className="h-5 w-5" />}
-              accent={overview.first_attempt_pass_rate_pct >= 60 ? "green" : "red"}
+              accent={
+                overview.first_attempt_pass_rate_pct != null &&
+                overview.first_attempt_pass_rate_pct >= 60
+                  ? "green"
+                  : "red"
+              }
             />
             <KpiCard
               title="Quiz attempts"
@@ -220,7 +229,7 @@ export default function SchoolDashboard() {
           </div>
         ) : null}
 
-        {overview && overview.units_with_struggles.length > 0 && (
+        {overview && overview.units_with_struggles && overview.units_with_struggles.length > 0 && (
           <Card className="border shadow-sm">
             <CardHeader className="pb-2">
               <CardTitle className="flex items-center gap-2 text-base">

--- a/web/app/(school)/school/reports/at-risk/page.tsx
+++ b/web/app/(school)/school/reports/at-risk/page.tsx
@@ -75,8 +75,8 @@ export default function AtRiskPage() {
     mutationFn: (studentId: string) => sendAtRiskReminder(schoolId, studentId),
   });
 
-  const unseen = data?.students.filter((s) => !s.is_seen) ?? [];
-  const seen = data?.students.filter((s) => s.is_seen) ?? [];
+  const unseen = data?.students?.filter((s) => !s.is_seen) ?? [];
+  const seen = data?.students?.filter((s) => s.is_seen) ?? [];
 
   return (
     <div className="max-w-5xl space-y-6 p-6">

--- a/web/app/(school)/school/reports/overview/page.tsx
+++ b/web/app/(school)/school/reports/overview/page.tsx
@@ -53,22 +53,34 @@ export default function OverviewReportPage() {
         <>
           <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
             {[
-              { label: "Enrolled", value: data.enrolled_students },
+              { label: "Enrolled", value: data.enrolled_students ?? 0 },
               {
                 label: "Active",
-                value: `${data.active_pct.toFixed(0)}%`,
-                sub: `${data.active_students_period} students`,
+                value:
+                  data.active_pct != null
+                    ? `${data.active_pct.toFixed(0)}%`
+                    : "—",
+                sub: `${data.active_students_period ?? 0} students`,
               },
-              { label: "Lessons viewed", value: data.lessons_viewed },
-              { label: "Quiz attempts", value: data.quiz_attempts },
+              { label: "Lessons viewed", value: data.lessons_viewed ?? 0 },
+              { label: "Quiz attempts", value: data.quiz_attempts ?? 0 },
               {
                 label: "1st-attempt pass rate",
-                value: `${data.first_attempt_pass_rate_pct.toFixed(0)}%`,
-                highlight: data.first_attempt_pass_rate_pct < 60 ? "red" : "green",
+                value:
+                  data.first_attempt_pass_rate_pct != null
+                    ? `${data.first_attempt_pass_rate_pct.toFixed(0)}%`
+                    : "—",
+                highlight:
+                  data.first_attempt_pass_rate_pct != null && data.first_attempt_pass_rate_pct < 60
+                    ? "red"
+                    : "green",
               },
               {
                 label: "Audio play rate",
-                value: `${data.audio_play_rate_pct.toFixed(0)}%`,
+                value:
+                  data.audio_play_rate_pct != null
+                    ? `${data.audio_play_rate_pct.toFixed(0)}%`
+                    : "—",
               },
             ].map(({ label, value, sub, highlight }) => (
               <Card key={label} className="border shadow-sm">
@@ -99,7 +111,7 @@ export default function OverviewReportPage() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                {data.units_with_struggles.length === 0 ? (
+                {!data.units_with_struggles?.length ? (
                   <p className="text-xs text-gray-400">None — all units healthy.</p>
                 ) : (
                   <div className="flex flex-wrap gap-1.5">
@@ -122,7 +134,7 @@ export default function OverviewReportPage() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                {data.units_no_activity.length === 0 ? (
+                {!data.units_no_activity?.length ? (
                   <p className="text-xs text-gray-400">All units have activity.</p>
                 ) : (
                   <div className="flex flex-wrap gap-1.5">

--- a/web/app/(student)/account/settings/page.tsx
+++ b/web/app/(student)/account/settings/page.tsx
@@ -159,17 +159,17 @@ function SettingsPageInner() {
                     <input
                       type="checkbox"
                       className="sr-only"
-                      checked={settings.notifications[key]}
+                      checked={settings.notifications?.[key] ?? false}
                       onChange={(e) => setNotif(key, e.target.checked)}
                     />
                     <div
                       className={`flex h-5 w-5 items-center justify-center rounded border-2 transition-colors ${
-                        settings.notifications[key]
+                        settings.notifications?.[key]
                           ? "border-blue-600 bg-blue-600"
                           : "border-gray-300 bg-white group-hover:border-gray-400"
                       }`}
                     >
-                      {settings.notifications[key] && (
+                      {settings.notifications?.[key] && (
                         <Check className="h-3 w-3 text-white" strokeWidth={3} />
                       )}
                     </div>

--- a/web/app/(student)/curriculum/page.tsx
+++ b/web/app/(student)/curriculum/page.tsx
@@ -53,7 +53,7 @@ export default function CurriculumMapPage() {
               <Skeleton key={i} className="h-32 rounded-lg" />
             ))}
           </div>
-        ) : !tree?.subjects.length ? (
+        ) : !tree?.subjects?.length ? (
           <div className="rounded-xl border border-gray-200 bg-white py-16 text-center">
             <BookOpen className="mx-auto mb-3 h-10 w-10 text-gray-300" />
             <p className="mb-1 text-sm font-medium text-gray-600">

--- a/web/app/(student)/stats/page.tsx
+++ b/web/app/(student)/stats/page.tsx
@@ -129,7 +129,7 @@ export default function StatsPage() {
             </div>
 
             {/* Subject breakdown chart */}
-            {stats.subject_breakdown.length > 0 && (
+            {stats.subject_breakdown && stats.subject_breakdown.length > 0 && (
               <section>
                 <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold text-gray-800">
                   <BarChart3 className="h-4 w-4" />

--- a/web/app/(student)/subjects/page.tsx
+++ b/web/app/(student)/subjects/page.tsx
@@ -29,7 +29,7 @@ export default function SubjectsPage() {
           <p className="text-sm text-red-500">Could not load curriculum. Please retry.</p>
         )}
 
-        {tree && (
+        {tree && tree.subjects && (
           <div className="grid gap-6 sm:grid-cols-2">
             {tree.subjects.map((subject) => (
               <Card key={subject.subject} className="border shadow-sm">

--- a/web/components/layout/SchoolNav.tsx
+++ b/web/components/layout/SchoolNav.tsx
@@ -53,6 +53,7 @@ const NAV_ITEMS: NavItem[] = [
     label: "Reports",
     href: "/school/reports/overview",
     icon: <BarChart2 className="h-4 w-4" />,
+    adminOnly: true,
   },
   {
     label: "Curriculum",
@@ -127,7 +128,7 @@ export function SchoolNav() {
     staleTime: 60_000,
   });
 
-  const unreadAlerts = alertsData?.alerts.filter((a) => !a.acknowledged).length ?? 0;
+  const unreadAlerts = alertsData?.alerts?.filter((a) => !a.acknowledged).length ?? 0;
   const inReports = pathname.startsWith("/school/reports");
 
   function handleLogout() {


### PR DESCRIPTION
## What changed

Adds defensive `?.` / `?? fallback` guards at 15 fetched-data access sites across 13 page/component files. Every site that previously crashed on an empty `{}` response from React Query now renders a safe empty/loading state instead.

Also fixes one pre-existing role-check bug in `SchoolNav.tsx` (Reports nav item missing `adminOnly: true`) that was masked by the SchoolNav crash — the test pair already specified the expected behaviour; the nav config just didn't match.

## Why

While verifying PRs [#230](https://github.com/wegofwd2020-hub/StudyBuddy_OnDemand/pull/230) (a11y html-has-lang) and [#231](https://github.com/wegofwd2020-hub/StudyBuddy_OnDemand/pull/231) (document-title) with Playwright on host, 13 persona tests failed — but not for a11y reasons. They failed because pages were crashing with `TypeError: Cannot read properties of undefined (reading 'X')` during the initial React Query loading state under mocked-API test mode, which causes Next.js to render its Runtime Error overlay. That overlay:
- Lacks `<html lang>` → `html-has-lang` rule violates
- Lacks `<title>` → `document-title` rule violates

The `KNOWN_A11Y_EXCLUSIONS` array in each persona spec was suppressing these two rules. **It wasn't hiding real a11y debt — it was hiding real UI crashes.** My initial a11y PRs (#230, #231) correctly fixed the root layout fallbacks, but they couldn't unblock the tests because the error overlay replaces the root layout entirely.

Why does the mocked API return `{}`? Playwright's `page.route()` uses last-registered-wins matching. The persona specs register a catch-all `**/api/v1/**` → `{}` at the end, which overrides all the specific mocks registered before it. The catch-all always wins. Production is fine (real APIs return the expected shape), but the tests exposed a brittleness: most page components assumed their data had the fields they needed.

## Alternatives considered

- **Reverse the mock order** (catch-all first, specifics last) so the specific mocks win. Rejected: that'd be a test-only fix and wouldn't protect production. In production, intermittent API hiccups could still yield partial responses that crash pages. Guards at access sites are correct defense-in-depth.
- **Add `if (!data?.field) return <Skeleton />` to each page.** Rejected: too heavy — most sites just need a single-character `?.`. Blanket skeletons would hide the specific field that's missing.
- **Fix only the pages the persona suite tests.** Rejected: those are the same files that will have production loading-state bugs when React Query returns undefined on first render. Fix them all.

## Risk

- **Behavioural change under `{}` responses:** previously pages crashed → error overlay. Now they render with `"—"` placeholders and empty lists. This is strictly better UX, but if any test was *asserting* on the specific crashed state, it would fail. (Scanned: no test asserts on the Runtime Error overlay.)
- **Reports-nav role gate change:** plain teachers no longer see the Reports link. This was the test pair's explicit expectation; treating it as a bug fix, not a UX regression.
- **Production impact: zero** when APIs return complete responses. Only fires when the response is partial or undefined — which would have crashed before.

## Test plan

- [x] Scoped Playwright run: `npx playwright test personas/` with exclusions intact (as on main) → **36 passed, 6 fixme'd, 0 failed** (1.1min)
- [x] Combined run (pre-verified on a scratch branch): UI fixes + #230 + #231 exclusions removed → **36 passed, 6 fixme'd, 0 failed**
- [ ] After merge: rebase #230 and #231 (trivial — shared KNOWN_A11Y_EXCLUSIONS line), re-run Playwright, merge each
- [ ] Spot-check in dev server: `/admin/analytics`, `/school/dashboard`, `/school/reports/overview` with real data → values still render identically

## Sequencing

| Step | Action |
|---|---|
| 1 | **Merge this PR first** |
| 2 | Rebase #230 (html-has-lang); Playwright should pass; merge |
| 3 | Rebase #231 (document-title); Playwright should pass; merge |
| 4 | #232 (wizard-submit) needs a separate test-mock shortfall fix (missing alerts mock causes SchoolNav to crash); can go in after |

🤖 Generated with [Claude Code](https://claude.com/claude-code)