### PR TITLE
chore(progress): step summary + consumption guide

### DIFF
--- a/.github/workflows/progress.yml
+++ b/.github/workflows/progress.yml
@@ -20,17 +20,71 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Generate PROGRESS.md
+      - name: Generate PROGRESS.md + CSVs
         run: python3 scripts/generate_progress.py
+
+      - name: Write step summary (Option C per docs/PROGRESS_consumption.md)
+        run: |
+          python3 << 'PYEOF' >> "$GITHUB_STEP_SUMMARY"
+          import csv
+
+          epics   = list(csv.DictReader(open("docs/PROGRESS_epics.csv")))
+          tickets = list(csv.DictReader(open("docs/PROGRESS_tickets.csv")))
+
+          hot_tickets = sorted(
+              (t for t in tickets if int(t["commit_count"]) >= 2),
+              key=lambda t: -int(t["commit_count"]),
+          )
+          total_commits = sum(int(e["commit_count"]) for e in epics)
+
+          print("## 🗂️ Progress Chart — StudyBuddy OnDemand")
+          print()
+          print(f"- **{len(epics)} epics** tracked, **{total_commits} commits** attributed")
+          print(f"- **{len(hot_tickets)} tickets** with 2+ commits (iteration / redesign candidates)")
+          print()
+
+          if hot_tickets:
+              print("### 🔥 Top redesign hot-spots")
+              print()
+              print("| Ticket | Epic | Commits | Span (days) |")
+              print("|---|---|---|---|")
+              for t in hot_tickets[:10]:
+                  epic_label = f"Epic {t['epic_num']} — {t['epic_title'][:40]}".replace("|", "\\|")
+                  print(f"| `{t['ticket']}` | {epic_label} | {t['commit_count']} | {t['span_days']} |")
+              print()
+
+          top_epics = sorted(
+              (e for e in epics if int(e["commit_count"]) > 0),
+              key=lambda e: -int(e["commit_count"]),
+          )[:5]
+          if top_epics:
+              print("### 📊 Most active epics (top 5)")
+              print()
+              print("| Epic | Status | Commits | Tickets | Hot-spots |")
+              print("|---|---|---|---|---|")
+              for e in top_epics:
+                  title = e["title"][:50].replace("|", "\\|")
+                  status = e["status"][:40].replace("|", "\\|")
+                  print(f"| {title} | {status} | {e['commit_count']} | {e['ticket_count']} | {e['hotspots'] or '—'} |")
+              print()
+
+          print("### 📄 Generated artifacts")
+          print()
+          print("- [`docs/PROGRESS.md`](../blob/main/docs/PROGRESS.md) — full report")
+          print("- [`docs/PROGRESS_epics.csv`](../blob/main/docs/PROGRESS_epics.csv) — spreadsheet rows by epic")
+          print("- [`docs/PROGRESS_tickets.csv`](../blob/main/docs/PROGRESS_tickets.csv) — spreadsheet rows by ticket")
+          print()
+          print("_See `docs/PROGRESS_consumption.md` for all dashboard options._")
+          PYEOF
 
       - name: Commit and push if changed
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet docs/PROGRESS.md; then
-            echo "No changes to PROGRESS.md"
+          git add docs/PROGRESS.md docs/PROGRESS_epics.csv docs/PROGRESS_tickets.csv
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
             exit 0
           fi
-          git add docs/PROGRESS.md
-          git commit -m "chore(progress): nightly update of docs/PROGRESS.md"
+          git commit -m "chore(progress): nightly update of docs/PROGRESS.md + CSVs"
           git push

--- a/docs/PROGRESS_consumption.md
+++ b/docs/PROGRESS_consumption.md
@@ -1,0 +1,118 @@
+# Consuming the Progress Chart Data
+
+`docs/PROGRESS.md` and its sibling CSVs (`PROGRESS_epics.csv`,
+`PROGRESS_tickets.csv`) are regenerated nightly by
+[`.github/workflows/progress.yml`](../.github/workflows/progress.yml).
+
+This page enumerates the options for getting that data in front of a
+human. Each option has its own tradeoffs — pick based on audience and how
+live the view needs to be.
+
+---
+
+## Currently active: Option C — workflow step summary
+
+The nightly workflow writes a top-of-highlights summary to its own run
+page via `$GITHUB_STEP_SUMMARY`. To see it:
+
+1. Open [Actions → Progress Chart](../../actions/workflows/progress.yml)
+2. Click the latest run
+3. The summary block lives above the job logs
+
+This gives "at-a-glance numbers" when you're in the repo checking on CI,
+with zero extra hosting. It's per-run — there is no persistent URL for
+"the latest summary." For a persistent dashboard, see Option A below.
+
+---
+
+## Option catalogue
+
+### Option A — GitHub Pages dashboard
+
+Build a small static site (HTML + JS + Chart.js / Plotly) that fetches
+the CSVs from `raw.githubusercontent.com` and renders live charts. Host
+free at `https://wegofwd2020-hub.github.io/StudyBuddy_OnDemand`.
+
+**Pros.** Real dashboard; auto-updates as CSVs change; shareable URL;
+supports hover/filter/drilldown.
+
+**Cons.** You're maintaining a small frontend. 2-3 hours initial build.
+
+**Setup sketch.**
+1. Enable Pages on the repo (Settings → Pages → Source: `docs/` on `main`).
+2. Add `docs/dashboard/index.html` that `fetch()`es the CSVs.
+3. Parse with PapaParse, render with Chart.js.
+4. No workflow changes — Pages rebuilds on every push to `main`.
+
+### Option B — commit PNG charts nightly
+
+Extend `generate_progress.py` to call `matplotlib` and write chart PNGs
+alongside the markdown. The nightly workflow commits them. Embed in
+`PROGRESS.md` via standard image tags.
+
+**Pros.** No hosting. Renders directly in the GitHub UI. Still
+auto-updated nightly.
+
+**Cons.** Static images — no interactivity. Adds `matplotlib` as a
+workflow dep. Commits .png files bloats the repo (~tens of KB per night).
+
+**Setup sketch.**
+1. `pip install matplotlib` in the workflow.
+2. Extend `scripts/generate_progress.py` with a `render_charts()` step.
+3. Commit `docs/PROGRESS_*.png` alongside the markdown.
+
+### Option C — workflow step summary ✅ *active*
+
+Append markdown tables to `$GITHUB_STEP_SUMMARY` in the `progress.yml`
+workflow. Shows on the workflow run page.
+
+**Pros.** Zero infra. ~30 min to set up. No new files committed.
+
+**Cons.** Per-run only — no persistent landing page. Only visible to
+people with repo access who know to navigate to Actions.
+
+**Setup.** Already done — see [`progress.yml`](../.github/workflows/progress.yml).
+
+### Option D — GitHub Projects v2
+
+Create a Project board with a table view over issues. Add custom fields
+for commit count, age, etc. Populate from the existing GitHub issues.
+
+**Pros.** Built-in, free, good for work tracking.
+
+**Cons.** Driven by *issues*, not by our CSV data. StudyBuddy's epic /
+ticket structure doesn't map cleanly to GitHub issues (tickets live in
+epic markdown files, not as issues). Would only work if we file every
+ticket as a GitHub issue — substantial process change.
+
+**Verdict:** better fit for Thittam (where features already live as
+issues) than StudyBuddy.
+
+### Option E — third-party BI (Metabase / Grafana / Datadog)
+
+Connect a BI tool to the CSVs or the GitHub API. Build drilldown
+dashboards with alerting.
+
+**Pros.** Real analytics features, alerts, scheduled digests.
+
+**Cons.** Outside GitHub; new credentials surface; hosting concerns
+(self-host Metabase or pay for hosted); overkill for a single-person
+project.
+
+**Verdict:** revisit only if the team grows past ~5 people with
+conflicting views on "what the data means."
+
+---
+
+## How to pick
+
+| If your need is… | Use |
+|---|---|
+| Quick glance when I'm in the repo anyway | **C** (active) |
+| Shareable dashboard URL for a stakeholder | A |
+| Visual at the top of the README / PROGRESS.md | B |
+| "Which tickets have 2+ commits this quarter?" with filters | Google Sheets via `=IMPORTDATA(...)` (already set up) |
+| Cross-project metrics + alerts | E |
+
+The CSV siblings support A, B, and the Sheets use case simultaneously —
+adding one of those later doesn't break the others.


### PR DESCRIPTION
Activates **Option C** per docs/PROGRESS_consumption.md — the nightly progress workflow now writes a top-of-highlights block to its own \`\$GITHUB_STEP_SUMMARY\`, visible on the workflow run page. Summary includes:

- totals (epics, commits)
- top-10 redesign hot-spots (tickets with 2+ commits)
- most-active epics (top 5)
- links to the generated artifacts

Also: fixed the commit step so it stages PROGRESS_epics.csv and PROGRESS_tickets.csv alongside PROGRESS.md (previous version only staged the markdown, so the CSVs were re-generated each night but never committed).

New doc docs/PROGRESS_consumption.md catalogues all five dashboard options (GitHub Pages, PNG charts, step summary, Projects v2, third-party BI) with setup sketches and tradeoffs. Option C flagged as active.