### PR TITLE
chore(progress): emit PROGRESS_epics.csv + PROGRESS_tickets.csv siblings

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,6 +1,6 @@
 # StudyBuddy OnDemand — Progress Chart
 
-_Auto-generated 2026-04-20T12:21:12+00:00. Regenerated nightly at 21:00 EST._
+_Auto-generated 2026-04-20T16:21:17+00:00. Regenerated nightly at 21:00 EST._
 
 Source: `docs/epics/` (feature manifest) + `git log` (activity). Script: `scripts/generate_progress.py`.
 
@@ -18,7 +18,6 @@ gantt
     Epic 8  :active, e8, 2026-04-14, 2026-04-15
     Epic 10 :done, e10, 2026-04-15, 2026-04-16
     Epic 11 :done, e11, 2026-04-15, 2026-04-16
-    Epic 12 :active, e12, 2026-04-17, 2026-04-18
 ```
 
 ## Summary
@@ -36,7 +35,6 @@ gantt
 | 9 | [Accessibility & Personalization](epics/EPIC_09_accessibility_personalization.md) | 💭 Your call | — | — | 0 | 0 | — |
 | 10 | [Curriculum Lifecycle & Governance](epics/EPIC_10_curriculum_lifecycle.md) | ✅ Go — all 8 questions + 2 follow-ups resolved 2026-04-15 | 2026-04-15 | 2026-04-15 | 10 | 7 | L-1×4, L-5×2 |
 | 11 | [Content Presentation & Formatting](epics/EPIC_11_content_formatting.md) | ✅ Go — 9 questions resolved 2026-04-15 | 2026-04-15 | 2026-04-15 | 8 | 7 | C-9×2 |
-| 12 | [Structured Content Block Taxonomy](epics/EPIC_12_content_block_taxonomy.md) | 🚧 Filed as GitHub #193; scope pending confirmation | 2026-04-17 | 2026-04-17 | 2 | 1 | — |
 
 ## Redesign leaderboard
 
@@ -174,15 +172,4 @@ Tickets with 2+ commits — each extra commit is an iteration or rework.
 | C-5 | 1 | 2026-04-15 | 2026-04-15 |
 | C-6 | 1 | 2026-04-15 | 2026-04-15 |
 | C-9 | 2 | 2026-04-15 | 2026-04-15 |
-
-### Epic 12 — Structured Content Block Taxonomy
-
-- **Status:** 🚧 Filed as GitHub #193; scope pending confirmation
-- **Epic file:** [EPIC_12_content_block_taxonomy.md](epics/EPIC_12_content_block_taxonomy.md)
-- **Ticket prefix:** `T`
-- **Commits attributed:** 2
-
-| Ticket | Commits | First | Last |
-|---|---|---|---|
-| T-1a | 1 | 2026-04-17 | 2026-04-17 |
 

--- a/docs/PROGRESS_epics.csv
+++ b/docs/PROGRESS_epics.csv
@@ -1,0 +1,12 @@
+epic_num,title,status,prefix,first_activity,last_activity,commit_count,ticket_count,hotspots
+1,Epic 1 — Multi-Provider LLM Pipeline,"✅ Complete (F-1 through F-5, 19 tests, migration 0043)",F,2026-04-12,2026-04-12,1,2,
+2,Epic 2 — Production Launch & Demo Readiness,💭 Your call,G,2026-04-12,2026-04-12,1,2,
+3,Epic 3 — Student Mobile App (Expo / React Native),✅ Path B chosen (2026-04-14) — not yet started; parked behind testing phase and ,M,2026-04-14,2026-04-14,2,0,
+4,Epic 4 — Parent Portal,💭 Your call,I,,,0,0,
+5,Epic 5 — District Admin,💭 Your call,J,,,0,0,
+6,Epic 6 — Platform Hardening,"🚧 In Progress (K-1 through K-3, K-6 complete)",K,2026-04-12,2026-04-12,1,3,
+7,Epic 7 — Self-Serve Demo System,✅ Complete,L,,,0,0,
+8,Epic 8 — Onboarding Completeness (Address & Measurement Units),💭 Your call,H,2026-04-14,2026-04-15,6,8,H-10x2
+9,Epic 9 — Accessibility & Personalization,💭 Your call,I,,,0,0,
+10,Epic 10 — Curriculum Lifecycle & Governance,✅ Go — all 8 questions + 2 follow-ups resolved 2026-04-15,L,2026-04-15,2026-04-15,10,7,L-1x4; L-5x2
+11,Epic 11 — Content Presentation & Formatting,✅ Go — 9 questions resolved 2026-04-15,C,2026-04-15,2026-04-15,8,7,C-9x2

--- a/docs/PROGRESS_tickets.csv
+++ b/docs/PROGRESS_tickets.csv
@@ -1,0 +1,30 @@
+ticket,epic_num,epic_title,commit_count,first,last,span_days
+F-1,1,Epic 1 — Multi-Provider LLM Pipeline,1,2026-04-12,2026-04-12,0
+F-5,1,Epic 1 — Multi-Provider LLM Pipeline,1,2026-04-12,2026-04-12,0
+G-3,2,Epic 2 — Production Launch & Demo Readiness,1,2026-04-12,2026-04-12,0
+G-5,2,Epic 2 — Production Launch & Demo Readiness,1,2026-04-12,2026-04-12,0
+K-1,6,Epic 6 — Platform Hardening,1,2026-04-12,2026-04-12,0
+K-3,6,Epic 6 — Platform Hardening,1,2026-04-12,2026-04-12,0
+K-6,6,Epic 6 — Platform Hardening,1,2026-04-12,2026-04-12,0
+H-10,8,Epic 8 — Onboarding Completeness (Address & Measurement Units),2,2026-04-14,2026-04-15,1
+H-8,8,Epic 8 — Onboarding Completeness (Address & Measurement Units),1,2026-04-14,2026-04-14,0
+H-9,8,Epic 8 — Onboarding Completeness (Address & Measurement Units),1,2026-04-14,2026-04-14,0
+L-1,8,Epic 8 — Onboarding Completeness (Address & Measurement Units),1,2026-04-15,2026-04-15,0
+L-5,8,Epic 8 — Onboarding Completeness (Address & Measurement Units),1,2026-04-15,2026-04-15,0
+S-1,8,Epic 8 — Onboarding Completeness (Address & Measurement Units),1,2026-04-15,2026-04-15,0
+S-2,8,Epic 8 — Onboarding Completeness (Address & Measurement Units),1,2026-04-15,2026-04-15,0
+S-3,8,Epic 8 — Onboarding Completeness (Address & Measurement Units),1,2026-04-15,2026-04-15,0
+H-10,10,Epic 10 — Curriculum Lifecycle & Governance,1,2026-04-15,2026-04-15,0
+L-1,10,Epic 10 — Curriculum Lifecycle & Governance,4,2026-04-15,2026-04-15,0
+L-10,10,Epic 10 — Curriculum Lifecycle & Governance,1,2026-04-15,2026-04-15,0
+L-2,10,Epic 10 — Curriculum Lifecycle & Governance,1,2026-04-15,2026-04-15,0
+L-3,10,Epic 10 — Curriculum Lifecycle & Governance,1,2026-04-15,2026-04-15,0
+L-4,10,Epic 10 — Curriculum Lifecycle & Governance,1,2026-04-15,2026-04-15,0
+L-5,10,Epic 10 — Curriculum Lifecycle & Governance,2,2026-04-15,2026-04-15,0
+C-1,11,Epic 11 — Content Presentation & Formatting,1,2026-04-15,2026-04-15,0
+C-2,11,Epic 11 — Content Presentation & Formatting,1,2026-04-15,2026-04-15,0
+C-3,11,Epic 11 — Content Presentation & Formatting,1,2026-04-15,2026-04-15,0
+C-4,11,Epic 11 — Content Presentation & Formatting,1,2026-04-15,2026-04-15,0
+C-5,11,Epic 11 — Content Presentation & Formatting,1,2026-04-15,2026-04-15,0
+C-6,11,Epic 11 — Content Presentation & Formatting,1,2026-04-15,2026-04-15,0
+C-9,11,Epic 11 — Content Presentation & Formatting,2,2026-04-15,2026-04-15,0

--- a/scripts/generate_progress.py
+++ b/scripts/generate_progress.py
@@ -9,6 +9,7 @@ A ticket that appears in 2+ commits is counted as iterated/redesigned.
 """
 from __future__ import annotations
 
+import csv
 import re
 import subprocess
 from collections import defaultdict
@@ -18,6 +19,8 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[1]
 EPICS_DIR = REPO / "docs" / "epics"
 OUTPUT = REPO / "docs" / "PROGRESS.md"
+OUTPUT_EPICS_CSV = REPO / "docs" / "PROGRESS_epics.csv"
+OUTPUT_TICKETS_CSV = REPO / "docs" / "PROGRESS_tickets.csv"
 
 TICKET_RE = re.compile(r"\b([A-Z])-(\d+[a-z]?)\b")
 EPIC_SCOPE_RE = re.compile(r"\(epic-(\d+)\)", re.IGNORECASE)
@@ -221,12 +224,75 @@ def render(epics: dict[int, dict], commits: list[dict]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def write_csvs(epics: dict[int, dict], commits: list[dict]) -> None:
+    """Write PROGRESS_epics.csv + PROGRESS_tickets.csv for spreadsheet analysis.
+
+    Same data as the markdown tables, flattened to a format friendly to
+    `=IMPORTDATA(...)` in Google Sheets or plain `File > Import` in Excel.
+    """
+    per_epic: dict[int, dict] = defaultdict(
+        lambda: {"commits": [], "tickets": defaultdict(list)}
+    )
+    for c in commits:
+        for n in c["epics"]:
+            per_epic[n]["commits"].append(c)
+            for t in c["tickets"]:
+                per_epic[n]["tickets"][t].append(c)
+
+    # Epics sheet — one row per epic.
+    with OUTPUT_EPICS_CSV.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow([
+            "epic_num", "title", "status", "prefix",
+            "first_activity", "last_activity",
+            "commit_count", "ticket_count", "hotspots",
+        ])
+        for num in sorted(epics):
+            e = epics[num]
+            data = per_epic.get(num, {"commits": [], "tickets": {}})
+            cs = data["commits"]
+            ds = sorted(c["date"] for c in cs)
+            first = ds[0] if ds else ""
+            last = ds[-1] if ds else ""
+            hot = [(t, len(v)) for t, v in data["tickets"].items() if len(v) >= 2]
+            hot.sort(key=lambda x: -x[1])
+            hotspots = "; ".join(f"{t}x{n}" for t, n in hot[:4])
+            w.writerow([
+                num, e["title"], e["status"], e["prefix"] or "",
+                first, last, len(cs), len(data["tickets"]), hotspots,
+            ])
+
+    # Tickets sheet — one row per ticket that appears in 1+ commits.
+    with OUTPUT_TICKETS_CSV.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow([
+            "ticket", "epic_num", "epic_title",
+            "commit_count", "first", "last", "span_days",
+        ])
+        for num in sorted(epics):
+            data = per_epic.get(num, {"commits": [], "tickets": {}})
+            for t, tc in sorted(data["tickets"].items()):
+                ds = sorted(c["date"] for c in tc)
+                span = (
+                    datetime.fromisoformat(ds[-1]).date()
+                    - datetime.fromisoformat(ds[0]).date()
+                ).days
+                w.writerow([
+                    t, num, epics[num]["title"],
+                    len(tc), ds[0], ds[-1], span,
+                ])
+
+
 def main() -> None:
     epics = parse_epics()
     commits = get_commits()
     attribute_commits(commits, epics)
     OUTPUT.write_text(render(epics, commits))
-    print(f"Wrote {OUTPUT} — {len(epics)} epics, {len(commits)} commits scanned.")
+    write_csvs(epics, commits)
+    print(
+        f"Wrote {OUTPUT} + {OUTPUT_EPICS_CSV.name} + {OUTPUT_TICKETS_CSV.name} "
+        f"— {len(epics)} epics, {len(commits)} commits scanned."
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Generator now writes two CSV files alongside PROGRESS.md so the same data can be pulled into a spreadsheet for analysis:
  - PROGRESS_epics.csv — one row per epic (columns: epic_num, title, status, prefix, first_activity, last_activity, commit_count, ticket_count, hotspots)
  - PROGRESS_tickets.csv — one row per ticket seen in commits (columns: ticket, epic_num, epic_title, commit_count, first, last, span_days)

Load into Google Sheets live via:
  =IMPORTDATA("https://raw.githubusercontent.com/wegofwd2020-hub/StudyBuddy_OnDemand/main/docs/PROGRESS_tickets.csv")

Regenerated nightly by the existing progress.yml workflow — no new cron. Ran fresh against main (not the feature branches this was developed on) so the ticket counts reflect the current mainline state.