### PR TITLE
chore(branding): Epic 13 minimum STEM drop + positioning framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,75 @@
 # StudyBuddy OnDemand — CLAUDE.md
 
-Backend-powered STEM tutoring platform for Grades 5–12. Students get instant
-pre-generated AI content (lessons, quizzes, audio) without needing an Anthropic
-API key. Schools and teachers can upload custom curricula. Subscription-based.
+Backend-powered AI education platform for Grades 5–12. StudyBuddy is the
+information bridge between classroom lessons and the current world. Students
+get instant pre-generated content (lessons, quizzes, audio) in English, French,
+and Spanish — no Anthropic API key required on the client. Schools and teachers
+can upload custom curricula. Subscription-based.
+
+---
+
+## Positioning
+
+StudyBuddy has two framings that serve different audiences. Both are correct;
+use the one matched to the reader. Full decision log in
+[`docs/BRANDING_TAGLINE_OPTIONS.md`](docs/BRANDING_TAGLINE_OPTIONS.md); epic spec
+in [`docs/epics/EPIC_13_branding_refresh.md`](docs/epics/EPIC_13_branding_refresh.md).
+
+### Consumer framing — "information bridge"
+
+- **Tagline:** *"Your bridge from lessons to a world that's always current."*
+- **Sub-headline:** *"An AI study buddy that connects your lessons to the world — and keeps learning alongside you."*
+
+Use this framing on: landing page, emails, help-widget responses, marketing
+pages, anything user-facing for parents / students / teachers / school admins.
+
+### Engineering mental model — "scoped retrieval over the world of knowledge"
+
+Every content generation is a **scoped query** against the LLM, parametrised
+by six dimensions that together form the product's IP:
+
+| Scope dimension | What it enforces |
+|---|---|
+| Topic / subject / unit | Curriculum alignment |
+| Grade | Reading level, conceptual depth, age-appropriateness |
+| Language | en / fr / es / vernacular |
+| Curriculum context | What the student has already covered |
+| Format | Lesson / quiz / tutorial / experiment |
+| Real-world framing | The bridge — connect to something current the student recognises |
+
+The LLM is the commodity. The **scoping layer** is the product IP. When
+touching `pipeline/prompts.py`, `pipeline/build_grade.py`, or any LLM-calling
+code: think "I'm tuning a scoped-retrieval system," not "I'm writing a content
+library."
+
+**Structural consequence — why "current" holds:** a *library* is curated by
+selection (static, goes stale); a *search engine* is curated by query
+(dynamic, re-runs each time). StudyBuddy is the second. This is why the
+"always current" tagline claim is defensible, not cosmetic.
+
+### Audience translation matrix
+
+| Audience | Use which framing |
+|---|---|
+| Parents, students, teachers, school admins | Information bridge |
+| Developers, architects, internal technical discussions | Scoped retrieval |
+| VCs / B2B pitch decks | Scoped retrieval first (30 sec), then bridge metaphor |
+
+### Load-bearing word — "current" (not "today's")
+
+Tagline uses **"current"** deliberately. **Do not** swap it for "today's",
+"latest", or any dated alternative. Reason: "today's" anchors to a specific
+date (a snapshot); "current" anchors to "whenever the student is using the
+product" (evergreen). The tagline has to cover three phases:
+
+1. **Now** — pre-generated content per curriculum
+2. **Soon** — teachers generate more content as a course progresses
+3. **Roadmap** — AI Agent where students query and learn more on demand
+
+"Today's" breaks at Phase 2/3. "Current" is the agent's actual promise. If
+"current" feels awkward in a sentence, restructure the sentence (e.g. *"a
+world that's always current"*, *"keeping lessons current with the world"*) —
+do not swap the word.
 
 ---
 

--- a/backend/src/email/service.py
+++ b/backend/src/email/service.py
@@ -86,7 +86,7 @@ Password  : {password}
 
 Your account is active for {ttl_hours} hours.
 
-Grade 8 STEM content is pre-loaded and ready to explore.
+Grade 8 content is pre-loaded and ready to explore.
 
 — The StudyBuddy Team
 """
@@ -116,7 +116,7 @@ _CREDENTIALS_HTML = """\
   </table>
   <p style="color:#666;font-size:13px">
     Your account is active for <strong>{ttl_hours} hours</strong>.<br />
-    Grade 8 STEM content is pre-loaded and ready to explore.
+    Grade 8 content is pre-loaded and ready to explore.
   </p>
   <p style="color:#666;font-size:13px">— The StudyBuddy Team</p>
 </body>

--- a/backend/src/help/service.py
+++ b/backend/src/help/service.py
@@ -92,7 +92,7 @@ def _render_account_context(account_state: dict | None) -> str:
 
 # Structured output template the LLM must follow
 _PROMPT_TEMPLATE = """\
-You are a help assistant for StudyBuddy OnDemand, a K-12 STEM tutoring platform.
+You are a help assistant for StudyBuddy OnDemand, an AI-powered education platform for Grades 5–12.
 
 Persona: {persona_label}
 Current page: {page}

--- a/docs/BRANDING_I18N_DRAFT.md
+++ b/docs/BRANDING_I18N_DRAFT.md
@@ -1,0 +1,111 @@
+# Branding Refresh — FR / ES Translation Drafts
+
+> **Status:** draft translations by Claude (machine-quality). **Needs native-speaker review
+> before commit.** This doc is the companion to
+> [EPIC_13_branding_refresh.md](epics/EPIC_13_branding_refresh.md) (T-BR-2).
+>
+> Last updated 2026-04-21.
+
+---
+
+## Scope
+
+Every `web/i18n/*.json` key that currently contains **"STEM" / "STIM" / "tutorat" / "tutoría"**
+branding, plus any key where the English is changing (T-BR-5) and the translations must
+therefore follow. Keys whose current translation is already neutral (e.g. `social_proof_heading`,
+`cta_heading`) are shown for completeness but marked **no change**.
+
+---
+
+## Canonical copy (the source of truth)
+
+After T-BR-5 lands, the English copy will be:
+
+| Key | New English |
+|---|---|
+| `landing.hero_heading` | `Study Buddy` (brand name — unchanged) |
+| `landing.hero_tagline` | `Your bridge from lessons to a world that's always current.` |
+| `landing.hero_subheading` | `An AI study buddy that connects your lessons to the world — and keeps learning alongside you.` |
+| `landing.features_heading` | `A teacher can set their own study material using AI` (unchanged) |
+| `landing.social_proof_heading` | `Trusted by students, teachers, and parents` (unchanged) |
+| `landing.cta_heading` | `Ready to get started?` (unchanged) |
+| `landing.cta_subheading` | `Join thousands of students mastering their subjects.` (unchanged in English — was never STEM in `en.json`) |
+| `tagline` (line 291) | `Your bridge from lessons to a world that's always current.` |
+
+All FR / ES translations below are targeted at **this** English, not the current interim copy.
+
+---
+
+## Structural note — key parity
+
+Before translating, verify that `fr.json` and `es.json` contain the **same keys** as `en.json`.
+Based on the 2026-04-21 grep:
+
+- `en.json` has `hero_heading` (brand name) + `hero_tagline` (catchphrase) + `hero_subheading`
+- `fr.json` and `es.json` currently **pack the tagline into `hero_heading`** and have no `hero_tagline` key. That is a structural drift, not just a copy issue.
+
+**Action:** T-BR-2 must **add a `hero_tagline` key** to `fr.json` and `es.json` (currently missing),
+and split the tagline out of `hero_heading`. Otherwise the landing page will render inconsistently
+across locales.
+
+---
+
+## French (fr.json)
+
+| Line | Key | Current FR (STIM/STEM) | Proposed new FR | Notes |
+|---|---|---|---|---|
+| 29 | `landing.hero_heading` | "Le tutorat STEM disponible dès que les élèves en ont besoin" | **"Study Buddy"** | Brand name — do not translate. Structural change: tagline moves to `hero_tagline`. |
+| *(add)* | `landing.hero_tagline` | *(missing — new key)* | **"Votre pont entre vos leçons et un monde toujours actuel."** | Canonical tagline. Alt: *"Le pont entre vos leçons et un monde qui reste actuel."* |
+| 30 | `landing.hero_subheading` | "Leçons, quiz et audio instantanés pour les classes 5 à 12. Sans attente. Sans clé API. Juste l'apprentissage." | **"Un compagnon d'apprentissage IA qui relie vos leçons au monde — et qui continue d'apprendre à vos côtés."** | Uses *"compagnon d'apprentissage"* — consistent with the existing hero watermark translation of "StudyBuddy." |
+| 31 | `landing.hero_cta_primary` | "Commencer l'essai gratuit" | **no change** | Neutral. |
+| 32 | `landing.hero_cta_secondary` | "Voir comment ça marche" | **no change** | Neutral. |
+| 33 | `landing.features_heading` | "Tout ce dont les élèves ont besoin pour maîtriser les STIM" | **"Tout ce dont un enseignant a besoin pour créer son matériel pédagogique avec l'IA."** | Mirrors the neutral English; also drops *"STIM"*. Alt closer to EN: *"Un enseignant peut créer son propre matériel pédagogique grâce à l'IA."* |
+| 46 | `landing.social_proof_heading` | "Approuvé par les élèves, les enseignants et les parents" | **no change** | Already neutral. |
+| 47 | `landing.cta_heading` | "Prêt à commencer ?" | **no change** | Neutral. |
+| 48 | `landing.cta_subheading` | "Rejoignez des milliers d'élèves qui améliorent leurs notes en STIM." | **"Rejoignez des milliers d'élèves qui maîtrisent toutes leurs matières."** | Drops *"en STIM"*, mirrors EN's *"mastering their subjects"*. |
+| 49 | `landing.cta_btn` | "Démarrer votre essai gratuit" | **no change** | Neutral. |
+| 197 | `tagline` | "Tutorat STIM pour les classes 5 à 12" | **"Votre pont entre vos leçons et un monde toujours actuel."** | Canonical tagline. |
+
+---
+
+## Spanish (es.json)
+
+| Line | Key | Current ES (STEM) | Proposed new ES | Notes |
+|---|---|---|---|---|
+| 29 | `landing.hero_heading` | "Tutoría STEM disponible en el momento en que los estudiantes la necesitan" | **"Study Buddy"** | Brand name — do not translate. Structural change: tagline moves to `hero_tagline`. |
+| *(add)* | `landing.hero_tagline` | *(missing — new key)* | **"Tu puente entre las lecciones y un mundo siempre actual."** | Canonical tagline. Alt: *"El puente entre tus lecciones y un mundo que se mantiene actual."* |
+| 30 | `landing.hero_subheading` | "Lecciones, cuestionarios y audio instantáneos para los grados 5 a 12. Sin esperas. Sin claves de API. Solo aprendizaje." | **"Un compañero de aprendizaje con IA que conecta tus lecciones con el mundo — y sigue aprendiendo a tu lado."** | Uses *"compañero de aprendizaje"* — consistent with the existing hero watermark translation of "StudyBuddy." |
+| 31 | `landing.hero_cta_primary` | "Comenzar prueba gratuita" | **no change** | Neutral. |
+| 32 | `landing.hero_cta_secondary` | "Ver cómo funciona" | **no change** | Neutral. |
+| 33 | `landing.features_heading` | "Todo lo que los estudiantes necesitan para dominar STEM" | **"Un profesor puede crear su propio material de estudio con IA."** | Mirrors neutral EN. Alt: *"Todo lo que un profesor necesita para crear su material con IA."* |
+| 46 | `landing.social_proof_heading` | "Confiado por estudiantes, profesores y padres" | **no change** *(minor: could polish to "De confianza para…")* | Already neutral; minor polish optional. |
+| 47 | `landing.cta_heading` | "¿Listo para comenzar?" | **no change** | Neutral. |
+| 48 | `landing.cta_subheading` | "Únete a miles de estudiantes que mejoran sus calificaciones en STEM." | **"Únete a miles de estudiantes que dominan todas sus materias."** | Drops *"en STEM"*, mirrors EN's *"mastering their subjects"*. |
+| 49 | `landing.cta_btn` | "Comienza tu prueba gratuita" | **no change** | Neutral. |
+| 197 | `tagline` | "Tutoría STEM para los grados 5 a 12" | **"Tu puente entre las lecciones y un mundo siempre actual."** | Canonical tagline. |
+
+---
+
+## Translation quality caveats
+
+The translations above were drafted by Claude. They are **grammatically correct and
+semantically faithful**, but may not be **idiomatically optimal** for native speakers.
+Specific flags for a reviewer to consider:
+
+| Concern | FR | ES |
+|---|---|---|
+| Bridge metaphor idiom | *"Votre pont entre"* is direct and works, but a native speaker may prefer *"Le pont entre…"* (with article) or a metaphor that reads more naturally in French — e.g. *"Le lien entre vos leçons et le monde actuel."* | *"Tu puente entre"* works. Native speakers may prefer *"El puente entre…"* (article) or *"El enlace entre…"* (the link between). |
+| "Always current" | *"toujours actuel"* is clear but slightly literal; alternatives: *"qui reste actuel"*, *"toujours d'actualité"* | *"siempre actual"* is clear; alternatives: *"que se mantiene al día"*, *"siempre al día"* |
+| "AI study buddy" | *"compagnon d'apprentissage IA"* — "IA" adjective placement after the noun is idiomatic; *"compagnon IA d'apprentissage"* would be wrong. | *"compañero de aprendizaje con IA"* — using *con IA* (with AI) is cleaner than *de IA*. |
+| Em-dash rendering | French typographic convention uses spaces around em-dashes (` — `). Confirm the existing JSON preserves this. | Spanish convention also uses ` — `. Confirm. |
+
+**Recommendation:** ship T-BR-5 (English) first; then have a native French speaker and a native
+Spanish speaker each do a 15-minute review of this table before T-BR-2 lands. Much cheaper than
+a post-launch rewrite if a translation reads off to a user.
+
+---
+
+## Quick links
+
+- Epic & tickets: [EPIC_13_branding_refresh.md](epics/EPIC_13_branding_refresh.md)
+- Full decision log: [BRANDING_TAGLINE_OPTIONS.md](BRANDING_TAGLINE_OPTIONS.md)

--- a/docs/BRANDING_TAGLINE_OPTIONS.md
+++ b/docs/BRANDING_TAGLINE_OPTIONS.md
@@ -1,0 +1,273 @@
+# StudyBuddy OnDemand — Tagline Options
+
+> Brainstorming doc to pick a canonical one-liner for the rebrand from
+> "STEM tutoring platform" → "AI-powered education enhancement tool."
+>
+> Once a pick is made, the chosen tagline + sub-headline roll out to:
+> `README.md`, `CLAUDE.md`, `web/app/layout.tsx` metadata, `web/i18n/{en,fr,es}.json`,
+> `backend/src/help/service.py` system prompt, and `backend/src/email/service.py`.
+>
+> Status: **✅ DECIDED 2026-04-21** — pick is **C+1**. Execution tracked in
+> [EPIC_13_branding_refresh.md](epics/EPIC_13_branding_refresh.md).
+>
+> **Canonical tagline:** *"Your bridge from lessons to a world that's always current."*
+> **Canonical sub-headline:** *"An AI study buddy that connects your lessons to the world — and keeps learning alongside you."*
+
+---
+
+## Engineering mental model — "scoped retrieval over the world of knowledge"
+
+> "StudyBuddy is a sophisticated search engine where the contents are managed by providing
+> reference to topic, grade, language every time a query goes out into the world." — founder, 2026-04-21
+
+This is the **engineering / internal mental model** that sits behind the consumer bridge
+metaphor. Both framings are correct; they serve different audiences.
+
+A plain LLM call is an *unscoped* query against the world of knowledge. StudyBuddy's pipeline
+is a **scoped query**, parametrised by six dimensions that together form the product's IP:
+
+| Scope dimension | What it enforces |
+|---|---|
+| Topic / subject / unit | Curriculum alignment — matches what the teacher is teaching |
+| Grade | Reading level, conceptual depth, age-appropriateness |
+| Language | en / fr / es / vernacular |
+| Curriculum context | What the student has already covered — so we don't re-explain prerequisites |
+| Format | Lesson / quiz / tutorial / experiment — different prompts, different validators |
+| Real-world framing | The bridge — connect the topic to something current the student recognises |
+
+Structural consequence — **this is why "current" is defensible, not cosmetic:**
+
+- A *library* is curated by **selection** — pick content once, shelve it, serve it. Static.
+- A *search engine* is curated by **query** — every query re-runs against a live index. Dynamic.
+- StudyBuddy is the second. The retrieval re-runs every time the query runs, so the output
+  can reflect the current state of the world, not a frozen 2024 library.
+
+**Audience translation matrix:**
+
+| Audience | Does "sophisticated search engine" land? |
+|---|---|
+| Engineering / internal docs / CLAUDE.md | Yes — the cleanest mental model |
+| Pitch deck / VCs / B2B schools | Partial — useful for 30 seconds, then move to pedagogy |
+| Parents / students / teachers | No — pulls them to Google associations, away from "lesson" |
+
+**How to use this model:**
+- CLAUDE.md + ARCHITECTURE.md should adopt it explicitly as the architectural frame.
+- Pitch decks and technical marketing can lead with it.
+- Consumer copy (landing, emails, help widget) keeps the **bridge** metaphor — the bridge is
+  the *visible effect* of scoped retrieval, which is exactly what parents and students want.
+
+---
+
+## Founder direction — the "information bridge" concept
+
+> "I really want people to think of StudyBuddy as the **information bridge** between
+> their lessons and the real world." — founder, 2026-04-21
+>
+> Raw tagline proposal: *"We bring current world explanation to your learnings."*
+
+This direction is stronger than the original Angles A–E because it gives the product a
+**concrete mental model** — a bridge — rather than a feature list or an outcome claim.
+Two insights worth preserving verbatim in the final copy:
+
+| Insight | Why it sticks |
+|---|---|
+| **"Bridge"** as the product metaphor | Not tutor, not helper, not library — a *conduit*. Positions StudyBuddy as the connective tissue between two things the student already has (the lesson) and already cares about (the world). Defensible; visual; reusable in product copy, diagrams, and pitch decks. |
+| **"Current world"** (not "real world") | Static content libraries can claim "real world." Only a live AI agent can claim **current** — today's news, fresh science, this week's events applied to classic lessons. This is the actual moat. |
+
+The raw phrasing has three issues that block direct use:
+1. **"your learnings"** — corporate jargon; students say "lessons."
+2. **"current world explanation"** — awkward noun phrase.
+3. **"We bring …"** — passive corporate voice; no rhythm.
+
+Angle F (below) preserves the bridge + current-world concept with cleaner wording.
+
+---
+
+## Positioning — what the new tagline must convey
+
+| Must convey | Must NOT imply |
+|---|---|
+| Works across any academic subject (not just STEM) | STEM-only, science-only, maths-only |
+| AI agent generates content (not just a static library) | Human tutor, live tutoring sessions |
+| Enhances existing curriculum / lessons (additive to school) | Replaces the teacher or the classroom |
+| Real-world context, relevance, application | Abstract, academic-only, textbook-only |
+| Grades 5–12 / K-12 scope | Adult learners, university |
+| The "Buddy" metaphor — companion, helper, alongside the student | Authority figure, examiner, assessor |
+
+---
+
+## Shortlist — top recommendations
+
+These are the strongest candidates. Each is a **H1 tagline + sub-headline** pair so it can slot
+into landing hero, email welcome line, and help-assistant self-description in one go.
+
+**B+1 and B+7 (Angle F, below) are the current front-runners** based on the founder's "information
+bridge" direction. S1–S4 are retained for comparison but rank lower.
+
+| # | Tagline (H1) | Sub-headline | Best for |
+|---|---|---|---|
+| **C+1** ⭐ | **Your bridge from lessons to a world that's always current.** | An AI study buddy that connects your lessons to the world — and keeps learning alongside you. | Landing hero — explicit bridge, future-proof against the agent roadmap |
+| **C+1b** | **Your bridge from lessons to a world that's always current.** | Every lesson matched to your grade, your subject, your language — and always connected to the world now. | Landing hero — sub hints at the scoped-retrieval model without jargon (14 words, longer) |
+| **C+2** | **Keeping your lessons current with the world.** | Your AI study buddy for every subject, Grades 5–12. | Metadata / SEO / help-widget self-description — tight, active voice |
+| **C+3** | **Your bridge between lessons and a world that keeps changing.** | An AI study buddy that grows with you as your learning grows. | Fallback if "always current" reads redundant |
+| B+1 | Your bridge from lessons to today's world. | — | **Superseded by C+1** — "today's" implies a snapshot; fails the agent-roadmap test. |
+| S1 | Learn more from every lesson. | AI-enhanced academic content for Grades 5–12, connected to the real world. | Kept for comparison — outcome-first, lacks the bridge metaphor |
+| S2 | Where academic lessons meet the real world. | Your AI study buddy for any subject, Grades 5–12. | Kept for comparison — mechanism-first but "real" instead of "current" |
+| S3 | Your AI study buddy — for every lesson, every subject. | Instant lessons, quizzes, and real-world context, ready when you are. | Kept for comparison — lean on brand name, no bridge concept |
+| S4 | Academic lessons, enhanced. | An AI agent that adds real-world context to every subject, Grades 5–12. | Kept for comparison — shortest, but "enhanced" is abstract |
+
+---
+
+## Long list — all options, grouped by angle
+
+### Angle A — Buddy / companion metaphor (leverages brand name)
+
+| # | Tagline | Note |
+|---|---|---|
+| A1 | Your AI study buddy — for every lesson, every subject. | See S3. |
+| A2 | The study buddy that turns textbook lessons into the real world. | Long; strong concept. |
+| A3 | Learning is better with a buddy. | Warm; but weak on mechanism. |
+| A4 | A study buddy for every subject you'll ever have. | Inclusive; generic verb. |
+| A5 | Never study alone. | Emotional; lacks "AI" / "academic" signal. |
+
+### Angle B — Real-world connection (mechanism-first)
+
+| # | Tagline | Note |
+|---|---|---|
+| B1 | Where academic lessons meet the real world. | See S2. |
+| B2 | Every lesson, connected to the world outside the classroom. | Slightly long but precise. |
+| B3 | Classroom content, real-world context — powered by AI. | Three-part; good for B2B school pitch. |
+| B4 | Bringing real-world context to every academic lesson. | Plain, clear. |
+| B5 | From the textbook to the real world. | Short; poetic; ambiguous without context. |
+
+### Angle C — AI agent / enhancement (mechanism + product category)
+
+| # | Tagline | Note |
+|---|---|---|
+| C1 | An AI agent that enhances every academic lesson. | Literal but self-explanatory. |
+| C2 | Academic lessons, enhanced. | See S4. |
+| C3 | AI-enhanced learning for any subject, any grade. | Good alt to current "AI-powered study material". |
+| C4 | One AI agent. Every subject. Every grade. | Punchy; three-beat rhythm. |
+| C5 | The AI agent behind every great lesson. | Implies ubiquity; slightly ambitious. |
+
+### Angle D — Outcome-focused (what the student gets)
+
+| # | Tagline | Note |
+|---|---|---|
+| D1 | Learn more from every lesson. | See S1. |
+| D2 | Turn lessons into understanding. | Warm; verb-led. |
+| D3 | Lessons that stick. For every student. | Two-sentence; strong for parents. |
+| D4 | Deeper understanding — on demand. | Plays on the product name "OnDemand". |
+| D5 | Helping students get more from every class. | Plain; works in translation. |
+
+### Angle E — Inclusive / all-subjects (direct anti-STEM signal)
+
+| # | Tagline | Note |
+|---|---|---|
+| E1 | Any subject. Any grade. One AI agent. | Mirrors C4. |
+| E2 | From maths to history, we've got every subject covered. | Explicit but colloquial. |
+| E3 | AI-powered learning for every subject, Grades 5–12. | Safe; literal; not memorable. |
+| E4 | Every subject, every student, every day. | Three-beat; good for internal morale. |
+
+### Angle F — Information bridge / "current world" (founder direction) ⭐
+
+Preserves the founder's core insight: StudyBuddy is the **bridge** between classroom lessons
+and the **current world** — where "current" means *continuously up-to-date as the student's
+learning progresses and the AI agent extends it*, not a dated snapshot. These rank highest in
+the shortlist because they give the product a concrete, defensible, future-proof mental model.
+
+| # | Tagline | Note |
+|---|---|---|
+| **C+1** ⭐ | Your bridge from lessons to a world that's always current. | Explicit bridge; "always current" disambiguates from electrical sense and signals the agent roadmap. Current top pick. |
+| **C+2** | Keeping your lessons current with the world. | "Current" as adjective-phrase reads as "up-to-date"; active verb "keeping" hints at the agent. Tightest (7 words). |
+| **C+3** | Your bridge between lessons and a world that keeps changing. | Avoids the word "current" but encodes its meaning. Fallback if "always current" feels redundant. |
+| B+1 | Your bridge from lessons to today's world. | Superseded by C+1 — "today's" implies a dated snapshot; breaks when the agent ships. |
+| B+7 | From the textbook to today's world. | Superseded — same "today's" issue as B+1. |
+| B+3 | Textbook lessons. Today's world. One study buddy. | Superseded — retain the three-beat structure idea for ad copy but re-phrase with "always current." |
+| B+4 | Every lesson, explained by today's world. | Risk: "explained by" implies the world teaches, which is charming but odd. |
+| B+5 | The bridge between your lessons and the world today. | Literal bridge; longest; "the world today" has the same snapshot issue. |
+| B+8 | Connecting your lessons to the world that matters now. | Emotive; "the world that matters now" is slightly over-written. |
+
+**"Current world" vs. "today's world" — why we went back to "current":**
+
+Initial draft proposed swapping "current" → "today's" for readability. Founder overruled on
+strategic grounds (2026-04-21), and the reasoning is load-bearing — preserve it:
+
+> **"Today's"** anchors to a specific date (a snapshot). **"Current"** anchors to "whenever
+> the student is using it" (an evergreen property). The tagline has to cover three product
+> phases, not just today's library:
+>
+> | Phase | What "current" has to cover |
+> |---|---|
+> | Now | Pre-generated content per curriculum |
+> | Soon | Teachers generating more content as a course progresses |
+> | Roadmap | AI Agent where students query and learn more as they go |
+>
+> "Today's world" breaks the moment Phase 2/3 ships. "Current world" is the agent's promise.
+
+The awkwardness of the founder's raw phrasing (*"current world explanation to your learnings"*)
+was **syntax**, not the word "current" itself. In constructions like *"a world that's always
+current"* or *"keeping your lessons current with the world,"* the word reads cleanly and
+disambiguates from the electrical-current connotation.
+
+Translation: FR *"toujours actuel"* / *"qui reste d'actualité"*, ES *"siempre actual"* /
+*"que se mantiene al día"* — all translate cleanly.
+
+**Why drop "we bring":** The founder's original "*We bring* current world explanation to your
+learnings" uses corporate passive voice. Declarative taglines without a "we" read as
+statements of fact — stronger, and they work as both marketing copy and help-assistant
+self-descriptions without pronoun gymnastics.
+
+---
+
+## Rejected directions — and why
+
+| Direction | Why not |
+|---|---|
+| "AI tutor for K-12" | Uses "tutor" which implies 1:1 live tutoring. Regulatory + expectations mismatch. |
+| "Personalised learning for Gen Z" | Demographic-locked; dates badly. |
+| "The Khan Academy of AI" | Positions vs. a competitor; weakens own brand. |
+| "Homework, solved" | Implies answer-giving — works against pedagogy + can spook schools/parents. |
+| "Your 24/7 tutor" | Same "tutor" problem, plus implies live service SLAs. |
+| "Master every subject" | Over-promises; also not what the product actually does. |
+| "Replace your textbook" | Antagonises schools. Product augments, does not replace. |
+
+---
+
+## Decision criteria — how to pick
+
+Rank candidates against these (1 = weak, 5 = strong):
+
+| Criterion | Weight | Why it matters |
+|---|---|---|
+| Translates cleanly to FR + ES | High | Three-locale launch; idioms that don't travel cost a rewrite per locale |
+| Fits in 60 chars for meta description / og:title | High | Search + social preview truncation |
+| Survives reading out loud | Medium | Audio help-widget response, video ad voiceover |
+| Explicit about "academic / curriculum" scope | Medium | Parents + school admins need to know it's aligned with school work |
+| Signals AI without being AI-slop | Medium | Differentiator, but "AI" in every sentence reads cheap |
+| Leaves room for product to grow | Low | Avoid picking a tagline that blocks parent-portal or district-admin expansion |
+
+---
+
+## Open questions for the founder
+
+1. **"Buddy" metaphor — lean in or play down?** The brand name invites it, but leaning in too hard (A3, A5) costs the AI-agent positioning. S3 tries to split the difference.
+2. **Do we keep "Grades 5–12" in the tagline, or move it to the sub?** S1/S3/S4 move it to the sub; S2 keeps it. Moving it to the sub opens the tagline for future grade expansion without a rewrite.
+3. **"Real world" vs. "real life" vs. "the world outside the classroom"?** All three are in play in the long list. "Real world" is shortest and most translatable; "real life" is warmer; "world outside the classroom" is most precise but bulky.
+4. **How much does the help assistant's self-description need to match the landing tagline?** If the help LLM says *"I'm the AI study buddy for your lessons,"* that can differ from the marketing tagline as long as it reflects the same positioning. Worth a separate short prompt line.
+
+---
+
+## Next step
+
+Pick one shortlist entry (B+1, B+7, B+3, or an S-variant) or nominate a synthesis, then file
+`T-BR-5` to lock the copy and roll it through the 6 surfaces listed at the top.
+
+Current recommendation: **C+1** — *"Your bridge from lessons to a world that's always current."*
+with sub *"An AI study buddy that connects your lessons to the world — and keeps learning
+alongside you."*
+
+This preserves the founder's bridge metaphor and the founder's chosen word "current," while
+fixing the syntactic awkwardness of the original raw phrasing. The "always" disambiguates
+"current" from its electrical-current reading, and the sub-headline's *"keeps learning alongside
+you"* quietly signals the forthcoming AI Agent roadmap without making a hard promise.

--- a/docs/epics/EPIC_13_branding_refresh.md
+++ b/docs/epics/EPIC_13_branding_refresh.md
@@ -1,6 +1,6 @@
 # Epic 13 — Branding Refresh: STEM → Education Enhancement
 
-**Status:** 🚧 Scope locked 2026-04-21; execution tickets pending
+**Status:** 🚧 In progress — T-BR-3 + T-BR-4 shipped 2026-04-21 (`95c514c`); T-BR-2 partial STEM-drop shipped (`c938210`); T-BR-1 + T-BR-5 pending
 
 ---
 
@@ -149,6 +149,8 @@ Canonical tagline translations:
 
 ### T-BR-3 — Backend student-facing AI + transactional email copy
 
+**Status:** ✅ Shipped 2026-04-21 in commit `95c514c` (minimum STEM-drop; help prompt now reads *"an AI-powered education platform for Grades 5–12"*, email drops "STEM" from "Grade 8 content is pre-loaded"). Full C+1 tagline alignment for the help prompt deferred to T-BR-5 rollout.
+
 **Files:**
 - `backend/src/help/service.py` line 95 — help-assistant system prompt.
 - `backend/src/email/service.py` lines 89, 119 — welcome / credentials email.
@@ -172,6 +174,8 @@ Canonical tagline translations:
 ---
 
 ### T-BR-4 — School portal UI copy
+
+**Status:** ✅ Shipped 2026-04-21 in commit `95c514c`. All four surfaces updated (including the low-priority placeholder). Zero STEM references remain in `web/app/(school)` or `web/lib/content/help-mindmaps.ts`.
 
 **Files:**
 - `web/lib/content/help-mindmaps.ts` lines 301, 319

--- a/docs/epics/EPIC_13_branding_refresh.md
+++ b/docs/epics/EPIC_13_branding_refresh.md
@@ -1,6 +1,6 @@
 # Epic 13 — Branding Refresh: STEM → Education Enhancement
 
-**Status:** 🚧 In progress — T-BR-3 + T-BR-4 shipped 2026-04-21 (`95c514c`); T-BR-2 partial STEM-drop shipped (`c938210`); T-BR-1 + T-BR-5 pending
+**Status:** 🚧 In progress — T-BR-1, T-BR-3, T-BR-4 shipped 2026-04-21; T-BR-2 partial STEM-drop shipped (`c938210`); T-BR-5 (English canonical + C+1 rollout) + T-BR-2 remainder pending
 
 ---
 
@@ -90,6 +90,8 @@ libraries curate by *selection* (static); search engines curate by *query*
 ## Tickets
 
 ### T-BR-1 — CLAUDE.md: description + positioning section
+
+**Status:** ✅ Shipped 2026-04-21. Line 3 description rewritten; new `## Positioning` section inserted before `## Project Status` with consumer framing (information bridge + canonical tagline), engineering mental model (scoped retrieval with six-dimension table), audience translation matrix, and the load-bearing-word explainer for "current".
 
 **File:** `CLAUDE.md`
 

--- a/docs/epics/EPIC_13_branding_refresh.md
+++ b/docs/epics/EPIC_13_branding_refresh.md
@@ -1,0 +1,261 @@
+# Epic 13 — Branding Refresh: STEM → Education Enhancement
+
+**Status:** 🚧 Scope locked 2026-04-21; execution tickets pending
+
+---
+
+## What it is
+
+Rebrand StudyBuddy OnDemand from a **"STEM tutoring platform"** to an
+**AI-powered education enhancement tool** — the "information bridge" between a
+student's classroom lessons and the current world, scoped to their grade,
+subject, and language.
+
+Two framings that will live side by side:
+
+| Framing | Audience | Where it surfaces |
+|---|---|---|
+| **Information bridge** (consumer) | Parents, students, teachers, school admins | Landing page, emails, help widget, marketing |
+| **Scoped retrieval over the world of knowledge** (engineering) | Developers, architects, pitch decks | CLAUDE.md, ARCHITECTURE.md, technical pitch material |
+
+Both are correct; they serve different audiences. See
+[BRANDING_TAGLINE_OPTIONS.md](../BRANDING_TAGLINE_OPTIONS.md) for the full
+decision log.
+
+---
+
+## Decisions (locked 2026-04-21)
+
+### Canonical copy
+
+- **Tagline (H1):** *"Your bridge from lessons to a world that's always current."*
+- **Sub-headline:** *"An AI study buddy that connects your lessons to the world — and keeps learning alongside you."*
+
+### Why "current" and not "today's"
+
+"Today's" anchors to a specific date (a snapshot). **"Current" anchors to
+"whenever the student is using the product"** (an evergreen property). The
+tagline has to cover three product phases:
+
+1. **Now** — pre-generated content per curriculum
+2. **Soon** — teachers generate more content as a course progresses
+3. **Roadmap** — AI Agent where students query and learn more on demand
+
+"Today's world" breaks the moment Phase 2/3 ships. "Current world" is the
+agent's actual promise.
+
+### Engineering mental model — "scoped retrieval"
+
+> StudyBuddy is a sophisticated search engine where every query is scoped by
+> (topic × grade × language × curriculum context × format × real-world framing)
+> before it goes out to the LLM / world of knowledge.
+
+| Scope dimension | What it enforces |
+|---|---|
+| Topic / subject / unit | Curriculum alignment |
+| Grade | Reading level, conceptual depth, age-appropriateness |
+| Language | en / fr / es / vernacular |
+| Curriculum context | What the student has already covered |
+| Format | Lesson / quiz / tutorial / experiment |
+| Real-world framing | The bridge — connect to something current the student recognises |
+
+This framing explains structurally why the "always current" claim holds:
+libraries curate by *selection* (static); search engines curate by *query*
+(dynamic). StudyBuddy is the second.
+
+---
+
+## Scope — what's in and what's out
+
+**In scope**
+- Copy changes on user-facing surfaces (landing, emails, help assistant,
+  school portal, i18n for en/fr/es).
+- CLAUDE.md positioning section for future agent sessions.
+- README.md top line.
+- Site metadata (title, description).
+
+**Out of scope**
+- Stream codes in the database (`stem`, `science`, `commerce`, `humanities`,
+  `english`) — these are curriculum categories, not branding.
+- Data files (`data/grade*_stem.json`, `mobile/data/grade*_stem.json`,
+  `cbse_grade*_stem.json`) — curriculum fixtures.
+- Migrations 0044 / 0045 (streams registry).
+- Logo / visual identity / font choices.
+- Icon set.
+- Repository name (`StudyBuddy_OnDemand` — already brand-neutral).
+- New marketing pages beyond what already exists.
+
+---
+
+## Tickets
+
+### T-BR-1 — CLAUDE.md: description + positioning section
+
+**File:** `CLAUDE.md`
+
+**Changes:**
+1. Line 3 — replace "Backend-powered STEM tutoring platform for Grades 5–12.
+   Students get instant pre-generated AI content…" with the new description.
+2. Insert a new **Positioning** section (near the top, before "Project Status")
+   covering:
+   - **Consumer framing:** the information-bridge metaphor + canonical tagline.
+   - **Engineering mental model:** scoped retrieval over the world of knowledge,
+     with the six scope dimensions table.
+   - **Audience translation matrix:** when to use which framing.
+   - **Load-bearing word:** why "current" and not "today's" (the three-phase
+     roadmap reasoning).
+
+**Acceptance:**
+- No occurrence of "STEM tutoring platform" in CLAUDE.md.
+- Any future agent reading the top 200 lines of CLAUDE.md understands both
+  the consumer and engineering framings well enough to avoid describing the
+  product as "a content library" or "a tutoring service."
+
+**Severity:** MEDIUM (developer-facing, but load-bearing for every future agent session).
+
+---
+
+### T-BR-2 — Non-English locales: FR + ES hero, features, CTA, tagline
+
+**Files:** `web/i18n/fr.json`, `web/i18n/es.json`
+
+**Changes:** Both locales currently contain "Tutoría STEM" / "Tutorat STIM"
+branding that was missed when `en.json` was rebranded. Update:
+
+| Locale | Key | Lines |
+|---|---|---|
+| `fr.json` | `landing.hero_heading`, `landing.hero_subheading`, `landing.features_heading`, `landing.cta_subheading`, `landing.cta_btn`, `tagline` | 29, 30, 33, 48, 49, 197 |
+| `es.json` | Same keys | 29, 30, 33, 48, 197 |
+
+Target — mirror `en.json`'s framing (see `en.json` line 29–50, 291). **Full
+side-by-side translation table (all keys, both locales) lives in
+[../BRANDING_I18N_DRAFT.md](../BRANDING_I18N_DRAFT.md)** — including the
+structural note that `fr.json` / `es.json` are currently missing the
+`hero_tagline` key that `en.json` has.
+
+Canonical tagline translations:
+- FR: *"Votre pont entre vos leçons et un monde toujours actuel."*
+- ES: *"Tu puente entre las lecciones y un mundo siempre actual."*
+
+**Acceptance:**
+- Zero occurrences of "STEM", "STIM", "tutorat", or "tutoría" in the landing,
+  features, cta, or tagline keys of FR / ES.
+- Landing page renders correctly in all three locales (Playwright persona spec
+  passes).
+
+**Severity:** HIGH (user-facing in 2 of 3 locales).
+
+---
+
+### T-BR-3 — Backend student-facing AI + transactional email copy
+
+**Files:**
+- `backend/src/help/service.py` line 95 — help-assistant system prompt.
+- `backend/src/email/service.py` lines 89, 119 — welcome / credentials email.
+
+**Changes:**
+- Help system prompt currently reads *"You are a help assistant for StudyBuddy
+  OnDemand, a K-12 STEM tutoring platform."* Replace with a description that
+  uses the information-bridge framing and drops "STEM tutoring platform."
+- Welcome email currently reads *"Grade 8 STEM content is pre-loaded and ready
+  to explore."* (appears twice). Replace with grade-appropriate copy that
+  doesn't narrow to STEM.
+
+**Acceptance:**
+- Help-widget smoke test: ask "what is StudyBuddy?" — response does not describe
+  the product as STEM-only or as a tutoring service.
+- Provision one test student via school-admin flow; received credentials email
+  does not mention "STEM."
+
+**Severity:** HIGH (every help-widget response + every provisioned student's first email).
+
+---
+
+### T-BR-4 — School portal UI copy
+
+**Files:**
+- `web/lib/content/help-mindmaps.ts` lines 301, 319
+- `web/app/(school)/school/catalog/page.tsx` line 151
+- `web/app/(school)/school/curriculum/definitions/new/page.tsx` line 55 (low-priority placeholder)
+
+**Changes:**
+- `help-mindmaps.ts:301` — "Complete STEM learning experience with your school or subscription" → drop "STEM".
+- `help-mindmaps.ts:319` — "All STEM subjects" → "All supported subjects" (or similar).
+- `catalog/page.tsx:151` — "Each package covers a full grade's STEM content across multiple subjects and units." → drop "STEM".
+- `definitions/new/page.tsx:55` — placeholder *"Grade 8 STEM — Semester 1"* → *"Grade 8 — Semester 1"* (optional; cosmetic).
+
+**Acceptance:**
+- No STEM references render in `/school/catalog` or the help mind-maps for
+  school-admin personas.
+- Existing Playwright school-admin persona spec continues to pass.
+
+**Severity:** HIGH (user-facing for school admins and teachers).
+
+---
+
+### T-BR-5 — English canonical surfaces (README, metadata, en.json)
+
+**Files:**
+- `README.md` line 3
+- `web/app/layout.tsx` lines 33–37 (site metadata `title` + `description`)
+- `web/i18n/en.json` keys `landing.hero_heading`, `landing.hero_tagline`,
+  `landing.hero_subheading`, `tagline` (lines 29–31, 291)
+
+**Changes:** Apply the canonical tagline + sub-headline consistently across all
+three surfaces so hero, SEO metadata, and README all convey the same positioning.
+The canonical pair:
+
+- **H1:** *"Your bridge from lessons to a world that's always current."*
+- **Sub:** *"An AI study buddy that connects your lessons to the world — and keeps learning alongside you."*
+
+Note: `README.md` line 3 already reads *"Backend-powered education enhancement
+platform for students"* — acceptable, but could be sharpened with the bridge
+metaphor for consistency.
+
+**Acceptance:**
+- `/` landing hero, browser tab title, OG preview, and README all reflect the
+  same tagline + positioning.
+- Help-widget self-description (T-BR-3) aligns with this tagline.
+
+**Severity:** HIGH (primary consumer surface).
+
+---
+
+## Rollout order
+
+1. **T-BR-5** first (English surfaces are the canonical reference for translations).
+2. **T-BR-2** next (translate FR/ES against the locked English copy).
+3. **T-BR-3** and **T-BR-4** in parallel (independent surfaces).
+4. **T-BR-1** last (CLAUDE.md is for future agent sessions — no user impact if
+   it lags the user-facing changes by a day).
+
+Suggested single PR, since the changes are tightly coupled and small. If a PR
+split is preferred: one for English surfaces (T-BR-5), one for translations +
+UI (T-BR-2/3/4), one for CLAUDE.md (T-BR-1).
+
+---
+
+## Open questions
+
+1. **FR/ES translation quality:** Do we want a native speaker to review the
+   translated tagline before commit, or is machine-translation-quality OK for
+   now with a follow-up review later?
+2. **README line 3 — change or leave?** It already reads "education enhancement
+   platform" and is acceptable. Worth a sharpening pass (bridge metaphor), or
+   leave for now?
+3. **Help-widget system prompt tone:** Should the help assistant introduce
+   itself using the tagline (*"I'm the AI study buddy that bridges your lessons
+   to the current world"*), or keep the help prompt purely functional and let
+   the tagline live in marketing surfaces only?
+4. **Do we file GitHub issues?** The epic markdown is the canonical spec; each
+   ticket could also be filed as a GitHub issue for tracking. Recommend: yes
+   for T-BR-2/3/4/5 (execution work); no separate issue for T-BR-1 (CLAUDE.md
+   updates tend to ride along with whichever PR touches code).
+
+---
+
+## References
+
+- [BRANDING_TAGLINE_OPTIONS.md](../BRANDING_TAGLINE_OPTIONS.md) — full decision log, all 20+ tagline options, rejected directions.
+- Memory `project_branding_current_word.md` — why "current" is load-bearing.
+- Memory `project_scoped_retrieval_model.md` — the six-dimension scope framework.

--- a/docs/epics/INDEX.md
+++ b/docs/epics/INDEX.md
@@ -23,6 +23,7 @@ the decision notes become the spec and we develop from there.
 | 9 | Accessibility & Personalization | [EPIC_09_accessibility_personalization.md](EPIC_09_accessibility_personalization.md) | 🚧 Umbrella for GitHub issue #189 (3 axe rules disabled in persona e2e suite pending app-side fix) |
 | 10 | Curriculum Lifecycle & Governance | [EPIC_10_curriculum_lifecycle.md](EPIC_10_curriculum_lifecycle.md) | 🚧 L-1–L-5 backend shipped (migrations 0046–0048, archive + unarchive + usage endpoints, audit events); L-6 sweeper paused; L-7 super-admin archive view + L-8 school UI + L-9 per-jurisdiction audit + L-10 TTL override pending |
 | 11 | Content Presentation & Formatting | [EPIC_11_content_formatting.md](EPIC_11_content_formatting.md) | 🚧 C-1 through C-4, C-6, C-9 shipped; C-5 regen in progress (Grade 11 Commerce done, Grade 11 Science resume in flight); C-7 PDF smoke + C-8 mobile parity pending |
+| 13 | Branding Refresh: STEM → Education Enhancement | [EPIC_13_branding_refresh.md](EPIC_13_branding_refresh.md) | 🚧 Scope locked 2026-04-21 (C+1 tagline + scoped-retrieval model); T-BR-1..5 pending execution |
 
 ---
 

--- a/web/app/(school)/school/catalog/page.tsx
+++ b/web/app/(school)/school/catalog/page.tsx
@@ -148,7 +148,7 @@ export default function CatalogPage() {
 
       <p className="text-sm text-gray-500">
         Platform-built curriculum packages available for assignment to your classrooms.
-        Each package covers a full grade&apos;s STEM content across multiple subjects and units.
+        Each package covers a full grade&apos;s content across multiple subjects and units.
         Assign packages to classrooms from the{" "}
         <a href="/school/classrooms" className="text-indigo-600 underline-offset-2 hover:underline">
           Classrooms

--- a/web/app/(school)/school/curriculum/definitions/new/page.tsx
+++ b/web/app/(school)/school/curriculum/definitions/new/page.tsx
@@ -52,7 +52,7 @@ function StepBasics({
           id="def_name"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          placeholder="Grade 8 STEM — Semester 1"
+          placeholder="Grade 8 — Semester 1"
         />
         <p className="text-xs text-gray-400">
           Choose a name students and teachers will recognise.

--- a/web/i18n/es.json
+++ b/web/i18n/es.json
@@ -26,11 +26,12 @@
     "start_free": "Comenzar gratis"
   },
   "landing": {
-    "hero_heading": "Tutoría STEM disponible en el momento en que los estudiantes la necesitan",
-    "hero_subheading": "Lecciones, cuestionarios y audio instantáneos para los grados 5 a 12. Sin esperas. Sin claves de API. Solo aprendizaje.",
+    "hero_heading": "Study Buddy",
+    "hero_tagline": "Material de estudio con IA",
+    "hero_subheading": "Lecciones, cuestionarios y audio instantáneos cuando estén disponibles. Solo aprendizaje.",
     "hero_cta_primary": "Comenzar prueba gratuita",
     "hero_cta_secondary": "Ver cómo funciona",
-    "features_heading": "Todo lo que los estudiantes necesitan para dominar STEM",
+    "features_heading": "Un profesor puede crear su propio material de estudio con IA",
     "feature_instant_title": "Contenido instantáneo",
     "feature_instant_desc": "Las lecciones y cuestionarios pregenerados se cargan en milisegundos — sin tiempo de espera de IA.",
     "feature_audio_title": "Lecciones de audio",
@@ -45,7 +46,7 @@
     "feature_schools_desc": "Los profesores obtienen informes de progreso en tiempo real, alertas y herramientas de currículo personalizadas.",
     "social_proof_heading": "Confiado por estudiantes, profesores y padres",
     "cta_heading": "¿Listo para comenzar?",
-    "cta_subheading": "Únete a miles de estudiantes que mejoran sus calificaciones en STEM.",
+    "cta_subheading": "Únete a miles de estudiantes que dominan todas sus materias.",
     "cta_btn": "Comienza tu prueba gratuita"
   },
   "pricing": {
@@ -194,7 +195,7 @@
     "500_body": "Estamos trabajando para solucionar esto. Por favor, inténtalo de nuevo en breve."
   },
   "footer": {
-    "tagline": "Tutoría STEM para los grados 5 a 12",
+    "tagline": "Material de estudio con IA para los grados 5 a 12",
     "product": "Producto",
     "company": "Empresa",
     "legal": "Legal",

--- a/web/i18n/fr.json
+++ b/web/i18n/fr.json
@@ -26,11 +26,12 @@
     "start_free": "Démarrer gratuitement"
   },
   "landing": {
-    "hero_heading": "Le tutorat STEM disponible dès que les élèves en ont besoin",
-    "hero_subheading": "Leçons, quiz et audio instantanés pour les classes 5 à 12. Sans attente. Sans clé API. Juste l'apprentissage.",
+    "hero_heading": "Study Buddy",
+    "hero_tagline": "Matériel d'étude alimenté par l'IA",
+    "hero_subheading": "Leçons, quiz et audio instantanés quand disponibles. Juste l'apprentissage.",
     "hero_cta_primary": "Commencer l'essai gratuit",
     "hero_cta_secondary": "Voir comment ça marche",
-    "features_heading": "Tout ce dont les élèves ont besoin pour maîtriser les STIM",
+    "features_heading": "Un enseignant peut créer son propre matériel d'étude grâce à l'IA",
     "feature_instant_title": "Contenu instantané",
     "feature_instant_desc": "Les leçons et quiz pré-générés se chargent en millisecondes — sans temps d'attente IA.",
     "feature_audio_title": "Leçons audio",
@@ -45,7 +46,7 @@
     "feature_schools_desc": "Les enseignants reçoivent des rapports de progression en temps réel, des alertes et des outils de curriculum personnalisé.",
     "social_proof_heading": "Approuvé par les élèves, les enseignants et les parents",
     "cta_heading": "Prêt à commencer ?",
-    "cta_subheading": "Rejoignez des milliers d'élèves qui améliorent leurs notes en STIM.",
+    "cta_subheading": "Rejoignez des milliers d'élèves qui maîtrisent toutes leurs matières.",
     "cta_btn": "Démarrer votre essai gratuit"
   },
   "pricing": {
@@ -194,7 +195,7 @@
     "500_body": "Nous travaillons à résoudre ce problème. Veuillez réessayer dans un instant."
   },
   "footer": {
-    "tagline": "Tutorat STIM pour les classes 5 à 12",
+    "tagline": "Matériel d'étude alimenté par l'IA pour les classes 5 à 12",
     "product": "Produit",
     "company": "Entreprise",
     "legal": "Mentions légales",

--- a/web/lib/content/help-mindmaps.ts
+++ b/web/lib/content/help-mindmaps.ts
@@ -298,7 +298,7 @@ export const HELP_MINDMAPS: PersonaMindMap[] = [
   {
     id: "full-student",
     title: "Full Student",
-    subtitle: "Complete STEM learning experience with your school or subscription",
+    subtitle: "Complete learning experience with your school or subscription",
     color: "bg-purple-700",
     diagram: `mindmap
   root((Full Student))
@@ -316,7 +316,7 @@ export const HELP_MINDMAPS: PersonaMindMap[] = [
         Custom grade mapping
       Default platform content
         Grades 5 through 12
-        All STEM subjects
+        All supported subjects
     Learning Flow
       Lesson
         Full text + diagrams


### PR DESCRIPTION
## Summary

- **Drop "STEM tutoring platform" branding from 4 user-facing surfaces:** FR/ES i18n locales, backend help-assistant prompt + welcome email, school portal UI (catalog description, help mindmaps, curriculum-definition placeholder)
- **Rewrite `CLAUDE.md` line 3 + add new `## Positioning` section** covering consumer framing (information bridge + canonical tagline), engineering mental model (scoped retrieval over world of knowledge with six scope dimensions), audience translation matrix, and the load-bearing-word explainer for "current" (vs. "today's") — so future agent sessions start from the right mental model
- **File Epic 13 branding-refresh spec** with 5 tickets (T-BR-1..5), a full decision log in `docs/BRANDING_TAGLINE_OPTIONS.md` (20+ tagline options, C+1 picked), and FR/ES translation drafts for the future C+1 rollout in `docs/BRANDING_I18N_DRAFT.md` (flagged for native-speaker review)

## Scope decision

**Minimum STEM-drop only.** FR/ES copy mirrors the current neutral English framing ("AI-powered study material") so all three locales stay internally consistent right now. The full C+1 bridge-tagline rollout across EN + FR + ES (T-BR-5 + T-BR-2 remainder) is deferred to a follow-on PR pending:

1. Native-speaker review of the drafted FR/ES translations
2. Final sign-off on the canonical tagline one-liner for EN (README + site metadata + en.json hero)

**Out of scope** (deliberately untouched — curriculum categories, not branding):
- Stream codes `stem` / `science` / `commerce` / `humanities` / `english` in the DB
- Data files `data/grade*_stem.json`, `cbse_grade*_stem.json`, `mobile/data/grade*_stem.json`
- Migrations 0044 / 0045 (streams registry)

## Commits

1. `f9cbd79` chore(branding): drop STEM/STIM from fr/es i18n + file Epic 13
2. `b7d9c9f` chore(branding): drop STEM from help widget, welcome email, school portal
3. `c007699` docs(epic-13): mark T-BR-3 + T-BR-4 shipped
4. `6f5972b` chore(branding): T-BR-1 — rebrand CLAUDE.md + add Positioning section

## Test plan

- [ ] Landing page renders correctly in all three locales (en / fr / es); hero, tagline, features heading, cta, and footer show no STEM / STIM / tutorat / tutoría references.
- [ ] Help widget smoke test: ask "what is StudyBuddy?" — response does not describe the product as STEM-only or as a tutoring service.
- [ ] Provision one student via the school-admin flow; confirm the credentials email no longer says "Grade 8 STEM content".
- [ ] Browse `/school/catalog` — package description no longer says "STEM content".
- [ ] Browse `/school/curriculum/definitions/new` — placeholder no longer says "Grade 8 STEM — Semester 1".
- [ ] Existing Playwright persona specs still pass on chromium + persona-student / persona-teacher / persona-admin projects.

Related: decision log in `docs/BRANDING_TAGLINE_OPTIONS.md`; epic + remaining tickets in `docs/epics/EPIC_13_branding_refresh.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)