### PR TITLE
chore(branding): Epic 13 C+1 launch — bridge tagline across EN/FR/ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StudyBuddy AI — OnDemand Edition
 
-**Backend-powered STEM tutoring platform for students Grades 5–12.**
+**Backend-powered education enhancement platform for students.**
 
 ---
 
@@ -8,7 +8,7 @@
 
 StudyBuddy OnDemand is the next generation of the [StudyBuddy Free](https://github.com/wegofwd2020-hub/studybuddy_free) standalone app.
 
-The Free edition proved the concept — students can navigate a grade-aware STEM curriculum, read AI-generated lesson synopses, take adaptive quizzes, and receive personalised remediation. However, it has fundamental limitations:
+The Free edition proved the concept — students can navigate a grade-aware curriculum, read AI-generated lesson synopses, take adaptive quizzes, and receive personalised remediation. However, it has fundamental limitations:
 
 | Problem | Root Cause |
 |---|---|

--- a/docs/epics/EPIC_13_branding_refresh.md
+++ b/docs/epics/EPIC_13_branding_refresh.md
@@ -1,6 +1,6 @@
 # Epic 13 — Branding Refresh: STEM → Education Enhancement
 
-**Status:** 🚧 In progress — T-BR-1, T-BR-3, T-BR-4 shipped 2026-04-21; T-BR-2 partial STEM-drop shipped (`c938210`); T-BR-5 (English canonical + C+1 rollout) + T-BR-2 remainder pending
+**Status:** ✅ Complete 2026-04-21 — all five tickets shipped. Minimum-scope PR #246 landed T-BR-1/T-BR-3/T-BR-4 + T-BR-2 partial; C+1 launch PR lands T-BR-5 + T-BR-2 remainder across EN/FR/ES locales and site metadata (native-speaker review completed; drafted translations validated as-is).
 
 ---
 
@@ -119,6 +119,8 @@ libraries curate by *selection* (static); search engines curate by *query*
 
 ### T-BR-2 — Non-English locales: FR + ES hero, features, CTA, tagline
 
+**Status:** ✅ Fully shipped — partial STEM-drop in `c938210` (mirrored interim EN framing); C+1 tagline + sub-headline + footer tagline rolled out in the C+1 launch PR after native-speaker review validated the drafted translations from `docs/BRANDING_I18N_DRAFT.md` as-is.
+
 **Files:** `web/i18n/fr.json`, `web/i18n/es.json`
 
 **Changes:** Both locales currently contain "Tutoría STEM" / "Tutorat STIM"
@@ -200,6 +202,8 @@ Canonical tagline translations:
 ---
 
 ### T-BR-5 — English canonical surfaces (README, metadata, en.json)
+
+**Status:** ✅ Shipped in the C+1 launch PR. Canonical tagline + sub-headline applied consistently across `en.json` hero + footer, site metadata (title.default + description), and README (using the pre-existing WIP rebrand of line 3 to "education enhancement platform"). Backend help prompt kept at the T-BR-3 neutral framing (does not need the full C+1 tagline).
 
 **Files:**
 - `README.md` line 3

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -30,11 +30,11 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   title: {
-    default: "StudyBuddy \u2014 AI-powered study material for Grades 5\u201312",
+    default: "StudyBuddy \u2014 Your bridge from lessons to a world that's always current",
     template: "%s | StudyBuddy",
   },
   description:
-    "Instant AI-powered lessons, quizzes, and audio for any subject. Available in English, French, and Spanish.",
+    "An AI study buddy that connects your lessons to the world \u2014 and keeps learning alongside you. Available in English, French, and Spanish.",
 };
 
 export default async function RootLayout({

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -27,8 +27,8 @@
   },
   "landing": {
     "hero_heading": "Study Buddy",
-    "hero_tagline": "AI-powered study material",
-    "hero_subheading": "Instant lessons, quizzes, and audio where available. Just learning.",
+    "hero_tagline": "Your bridge from lessons to a world that's always current.",
+    "hero_subheading": "An AI study buddy that connects your lessons to the world — and keeps learning alongside you.",
     "hero_cta_primary": "Start free trial",
     "hero_cta_secondary": "See how it works",
     "features_heading": "A teacher can set their own study material using AI",
@@ -288,7 +288,7 @@
     "500_body": "We're working on fixing this. Please try again shortly."
   },
   "footer": {
-    "tagline": "AI-powered study material for Grades 5–12",
+    "tagline": "Your bridge from lessons to a world that's always current.",
     "product": "Product",
     "company": "Company",
     "legal": "Legal",

--- a/web/i18n/es.json
+++ b/web/i18n/es.json
@@ -27,8 +27,8 @@
   },
   "landing": {
     "hero_heading": "Study Buddy",
-    "hero_tagline": "Material de estudio con IA",
-    "hero_subheading": "Lecciones, cuestionarios y audio instantáneos cuando estén disponibles. Solo aprendizaje.",
+    "hero_tagline": "Tu puente entre las lecciones y un mundo siempre actual.",
+    "hero_subheading": "Un compañero de aprendizaje con IA que conecta tus lecciones con el mundo — y sigue aprendiendo a tu lado.",
     "hero_cta_primary": "Comenzar prueba gratuita",
     "hero_cta_secondary": "Ver cómo funciona",
     "features_heading": "Un profesor puede crear su propio material de estudio con IA",
@@ -195,7 +195,7 @@
     "500_body": "Estamos trabajando para solucionar esto. Por favor, inténtalo de nuevo en breve."
   },
   "footer": {
-    "tagline": "Material de estudio con IA para los grados 5 a 12",
+    "tagline": "Tu puente entre las lecciones y un mundo siempre actual.",
     "product": "Producto",
     "company": "Empresa",
     "legal": "Legal",

--- a/web/i18n/fr.json
+++ b/web/i18n/fr.json
@@ -27,8 +27,8 @@
   },
   "landing": {
     "hero_heading": "Study Buddy",
-    "hero_tagline": "Matériel d'étude alimenté par l'IA",
-    "hero_subheading": "Leçons, quiz et audio instantanés quand disponibles. Juste l'apprentissage.",
+    "hero_tagline": "Votre pont entre vos leçons et un monde toujours actuel.",
+    "hero_subheading": "Un compagnon d'apprentissage IA qui relie vos leçons au monde — et qui continue d'apprendre à vos côtés.",
     "hero_cta_primary": "Commencer l'essai gratuit",
     "hero_cta_secondary": "Voir comment ça marche",
     "features_heading": "Un enseignant peut créer son propre matériel d'étude grâce à l'IA",
@@ -195,7 +195,7 @@
     "500_body": "Nous travaillons à résoudre ce problème. Veuillez réessayer dans un instant."
   },
   "footer": {
-    "tagline": "Matériel d'étude alimenté par l'IA pour les classes 5 à 12",
+    "tagline": "Votre pont entre vos leçons et un monde toujours actuel.",
     "product": "Produit",
     "company": "Entreprise",
     "legal": "Mentions légales",


### PR DESCRIPTION
## Summary

Completes **Epic 13** by rolling the canonical C+1 tagline + sub-headline across all three locales and the site metadata. Native-speaker review of the FR/ES translations in `docs/BRANDING_I18N_DRAFT.md` was completed and the drafts validated as-is.

**Canonical copy:**
- **Tagline:** *"Your bridge from lessons to a world that's always current."*
- **Sub-headline:** *"An AI study buddy that connects your lessons to the world — and keeps learning alongside you."*

Why "current" (not "today's"): it's an evergreen property that covers the three-phase product roadmap (now = pre-gen content, soon = teacher-added content, roadmap = query-based AI Agent). Full reasoning in `docs/BRANDING_TAGLINE_OPTIONS.md`.

## What changed

| File | Change |
|---|---|
| `web/i18n/en.json` | `landing.hero_tagline`, `landing.hero_subheading`, `footer.tagline` → C+1 canonical copy |
| `web/i18n/fr.json` | Same three keys — validated FR translations: *"Votre pont entre vos leçons et un monde toujours actuel."* / *"Un compagnon d'apprentissage IA qui relie vos leçons au monde — et qui continue d'apprendre à vos côtés."* |
| `web/i18n/es.json` | Same three keys — validated ES translations: *"Tu puente entre las lecciones y un mundo siempre actual."* / *"Un compañero de aprendizaje con IA que conecta tus lecciones con el mundo — y sigue aprendiendo a tu lado."* |
| `web/app/layout.tsx` | Site `metadata.title.default` + `metadata.description` aligned to C+1 (browser tab title + OG preview) |
| `README.md` | Line 3 + one body mention — drops remaining "STEM tutoring platform" / "grade-aware STEM curriculum" (pre-existing WIP, now canonicalised) |
| `docs/epics/EPIC_13_branding_refresh.md` | Epic marked ✅ Complete; T-BR-2 and T-BR-5 status lines updated |

**Not touched** (intentional — minimum code-change surface):
- `backend/src/help/service.py` help-assistant prompt → stays at T-BR-3 neutral framing ("AI-powered education platform for Grades 5–12"); doesn't need the full tagline
- `backend/src/email/service.py` welcome email → stays at T-BR-3 neutral framing
- Stream codes in the DB, `data/grade*_stem.json` fixtures, migrations 0044/0045 → curriculum categories, not branding

## Architecture note

All UI strings on the landing page are in `web/i18n/*.json` (loaded by `next-intl` at runtime). This means future copy tweaks are pure JSON edits — no React/TS code change, no test churn, no schema changes. The metadata title/description in `layout.tsx` is currently hardcoded; a future cleanup could move it to i18n too, but it's low value given how rarely that copy changes.

## Test plan

- [ ] Landing page (`/`) renders canonical tagline + sub-headline in `en`, `fr`, `es`.
- [ ] Browser tab title reads "StudyBuddy — Your bridge from lessons to a world that's always current".
- [ ] Social preview (share to Slack/Twitter) shows the new description.
- [ ] Footer tagline shows C+1 copy in all three locales.
- [ ] Playwright persona specs (chromium + persona-student / persona-teacher / persona-admin) pass.
- [ ] No STEM/STIM references render anywhere user-facing (full-repo grep confirms zero).

## Epic 13 status after this PR

| Ticket | Status |
|---|---|
| T-BR-1 CLAUDE.md | ✅ Merged in #246 |
| T-BR-2 FR/ES locales | ✅ Complete — partial in #246, remainder in this PR |
| T-BR-3 backend help + email | ✅ Merged in #246 |
| T-BR-4 school portal UI | ✅ Merged in #246 |
| T-BR-5 English canonical | ✅ In this PR |

**Epic 13 complete.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)