### PR TITLE
docs: update DEV_ACCOUNTS.md link after docs-repo reorg

### DIFF
--- a/LOCAL_TESTING_GUIDE.md
+++ b/LOCAL_TESTING_GUIDE.md
@@ -2,7 +2,7 @@
 
 This guide has been merged into the docs repo as the single source of truth:
 
-→ **[studybuddy-docs/DEV_ACCOUNTS.md](https://github.com/wegofwd2020-hub/studybuddy-docs/blob/main/DEV_ACCOUNTS.md)**
+→ **[studybuddy-docs/docs/dev/DEV_ACCOUNTS.md](https://github.com/wegofwd2020-hub/studybuddy-docs/blob/main/docs/dev/DEV_ACCOUNTS.md)**
 
 Per Rule #15 (Separate Documentation Repository), persona walk-throughs, seed
 scripts, account credentials, and phase test plans now live in `studybuddy-docs`.


### PR DESCRIPTION
## Summary

Companion to [studybuddy-docs commit `2d87c62`](https://github.com/wegofwd2020-hub/studybuddy-docs/commit/2d87c62) which moved four developer-setup guides into `docs/dev/`. This PR updates the one inbound link this repo had to the old location.

## What changed

- `LOCAL_TESTING_GUIDE.md` — `blob/main/DEV_ACCOUNTS.md` → `blob/main/docs/dev/DEV_ACCOUNTS.md`

## Why

Keeps the docs-repo root scoped to audience-visible product/architecture docs (the ones OnDemand CLAUDE.md's Document Map points at). Developer setup material now lives in `docs/dev/` — mirrors the `docs/promos/` reorg from last week.

## Test plan

- [ ] Click the link in `LOCAL_TESTING_GUIDE.md` after merge and confirm it resolves (docs-repo move lands on `epic-13/branding-refresh` and needs that PR to merge for the link to go live on `main` of the docs repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)