### PR TITLE
fix(tests): Issue #254 P0 — /data hardcode + ANTHROPIC_API_KEY CI env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,13 @@ jobs:
       SENTRY_DSN: ""
       METRICS_TOKEN: test-metrics-token
       CONTENT_STORE_PATH: /tmp/studybuddy-test-content
+      # DATA_DIR — admin/router.py writes uploaded grade JSONs here (was hardcoded /data).
+      # Tests need a writable path; /data is read-only on CI runners.
+      DATA_DIR: /tmp/studybuddy-test-data
+      # ANTHROPIC_API_KEY — required at import time by pipeline/config.py's
+      # PipelineSettings (pydantic-settings). Tests mock the settings object, so
+      # no live API calls happen. Value just needs to be non-empty.
+      ANTHROPIC_API_KEY: sk-ant-dummy-for-tests
       APP_ENV: test
 
     steps:

--- a/backend/config.py
+++ b/backend/config.py
@@ -80,6 +80,10 @@ class Settings(BaseSettings):
     METRICS_TOKEN: str
 
     # ── Content Store ─────────────────────────────────────────────────────────
+    # DATA_DIR is the bind-mounted volume root in Docker (/data). It holds
+    # uploaded grade-JSON files and, by convention, the content store below it.
+    # Tests and non-Docker dev override via env.
+    DATA_DIR: str = "/data"
     CONTENT_STORE_PATH: str = "/data/content"
     # "local" uses CONTENT_STORE_PATH on the local filesystem (default, single-host).
     # "s3" uses S3_BUCKET_NAME + S3_KEY_PREFIX (multi-host production).

--- a/backend/src/admin/router.py
+++ b/backend/src/admin/router.py
@@ -38,9 +38,11 @@ Routes (all prefixed /api/v1 in main.py):
 from __future__ import annotations
 
 import json
+import os
 import uuid
 from typing import Annotated
 
+from config import settings
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile
 
 from src.admin.schemas import (
@@ -873,7 +875,6 @@ async def upload_grade_json(
     Validate a grade JSON file, save it under /data/, and seed the curricula +
     curriculum_units tables.
     """
-    import os
 
     from src.admin.streams_router import resolve_stream_for_upload
 
@@ -943,8 +944,8 @@ async def upload_grade_json(
         # File naming: when stream is set, each stream lands in its own file so
         # a subsequent Commerce upload can't clobber an earlier Science upload.
         file_suffix = resolved_stream or "stem"
-        dest_path = f"/data/grade{grade}_{file_suffix}.json"
-        os.makedirs("/data", exist_ok=True)
+        dest_path = os.path.join(settings.DATA_DIR, f"grade{grade}_{file_suffix}.json")
+        os.makedirs(settings.DATA_DIR, exist_ok=True)
         with open(dest_path, "wb") as fh:
             fh.write(raw)
 


### PR DESCRIPTION
## Summary

Fixes 4 of 6 pre-existing Backend Tests failures catalogued in #254. The two remaining (`test_refresh_materialized_views` and `test_check_build_allowance_no_quota_row`) are #254 P2 and tracked separately.

## What breaks today

**`test_admin_streams.py::test_upload_grade_{upserts_new_stream_on_use,resolves_existing_stream}` — 2 failures**

`admin/router.py:946-947` hardcoded `/data` for grade-JSON uploads:
```python
dest_path = f"/data/grade{grade}_{file_suffix}.json"
os.makedirs("/data", exist_ok=True)
```

Works in Docker (bind-mounted `/data`). Fails on CI runners because `/data` doesn't exist and the test process can't create it at the filesystem root — actually bites real dev setups too when the `./data:/data` volume isn't wired up.

**`test_multi_provider_pipeline.py::test_build_grade_{multi_provider_dry_run,single_provider_default}` — 2 failures**

Tests do `with patch("pipeline.config.settings")`. The `patch()` helper imports the module first; importing `pipeline.config` executes `settings = PipelineSettings()` at module scope; `PipelineSettings` is pydantic-settings with `ANTHROPIC_API_KEY` required. Backend Tests CI never set it, so import fails before the mock can attach.

## What this PR does

### Product code change (`backend/config.py`, `backend/src/admin/router.py`)
- New setting `DATA_DIR: str = "/data"` on `Settings` — default unchanged from today's behaviour in production.
- `admin/router.py` uploads use `os.path.join(settings.DATA_DIR, f"grade{grade}_{file_suffix}.json")` and `os.makedirs(settings.DATA_DIR, exist_ok=True)` instead of the hardcoded path.
- Adds the missing `import os` and `from config import settings` in `admin/router.py` (ruff-clean).

### CI change (`.github/workflows/test.yml`)
Adds two env vars to the `backend-test` job only:
```yaml
DATA_DIR: /tmp/studybuddy-test-data
ANTHROPIC_API_KEY: sk-ant-dummy-for-tests
```

Neither is a secret. The Anthropic key is a non-empty placeholder; tests mock the settings object so no live API call happens. `DATA_DIR` just needs a writable path; `/tmp/...` matches the pattern of `CONTENT_STORE_PATH: /tmp/studybuddy-test-content` already in the job.

## Expected CI delta

| Test | Before | After |
|---|---|---|
| `test_upload_grade_upserts_new_stream_on_use` | FAIL (PermissionError) | PASS |
| `test_upload_grade_resolves_existing_stream` | FAIL (PermissionError) | PASS |
| `test_build_grade_multi_provider_dry_run` | FAIL (ValidationError) | PASS |
| `test_build_grade_single_provider_default` | FAIL (ValidationError) | PASS |
| `test_refresh_materialized_views` | FAIL (UniqueViolation) | FAIL — unchanged, #254 P2 |
| `test_check_build_allowance_no_quota_row` | FAIL (assert True is False) | FAIL — unchanged, #254 P2 |

Frontend Lint is also red on this PR, but that's 17 pre-existing TS/ESLint errors I haven't touched — out of scope here.

## Test plan

- [x] `ruff check src/admin/router.py` clean locally
- [x] `python -c "from src.admin import router"` imports cleanly
- [ ] CI Backend Tests count drops from 6 fails to 2 (the two P2 items tracked in #254)
- [ ] Manual: run `pytest tests/test_admin_streams.py tests/test_multi_provider_pipeline.py` locally with `DATA_DIR` set → 4 pass that were failing

## Follow-ups (not this PR)

- #254 P1: the unawaited `invalidate_cdn_path` at `admin/service.py:728`
- #254 P2: mv_class_summary schema mismatch; `check_build_allowance` stale test assumption

🤖 Generated with [Claude Code](https://claude.com/claude-code)