### PR TITLE
fix(admin): dispatch CDN invalidation via Celery (Issue #254 P1)

### DIFF
--- a/backend/src/admin/service.py
+++ b/backend/src/admin/service.py
@@ -721,13 +721,22 @@ async def _expire_content_cache(redis, curriculum_id: str, subject: str) -> None
 
 
 def _invalidate_cdn(curriculum_id: str) -> None:
-    """Fire-and-forget CloudFront invalidation for a curriculum."""
-    try:
-        from src.content.service import invalidate_cdn_path
+    """
+    Dispatch a Celery task to invalidate CloudFront paths for this curriculum.
 
-        invalidate_cdn_path(curriculum_id)
+    Fire-and-forget: runs on the `io` queue so the admin request path never
+    blocks on CloudFront.  Previous implementation called the async
+    `invalidate_cdn_path` without `await`, producing an unawaited coroutine
+    that was silently swallowed — meaning CDN invalidation never actually
+    ran (Issue #254 P1).
+    """
+    try:
+        from src.auth.tasks import invalidate_cdn_task
+
+        invalidate_cdn_task.apply_async(kwargs={"curriculum_id": curriculum_id}, queue="io")
     except Exception as exc:
-        log.warning("cdn_invalidation_failed curriculum_id=%s error=%s", curriculum_id, exc)
+        # Dispatch failure must never break the admin publish/rollback request.
+        log.warning("cdn_invalidation_dispatch_failed curriculum_id=%s error=%s", curriculum_id, exc)
 
 
 # ── Block version (creates block record + marks version blocked) ───────────────

--- a/backend/src/admin/service.py
+++ b/backend/src/admin/service.py
@@ -736,7 +736,9 @@ def _invalidate_cdn(curriculum_id: str) -> None:
         invalidate_cdn_task.apply_async(kwargs={"curriculum_id": curriculum_id}, queue="io")
     except Exception as exc:
         # Dispatch failure must never break the admin publish/rollback request.
-        log.warning("cdn_invalidation_dispatch_failed curriculum_id=%s error=%s", curriculum_id, exc)
+        log.warning(
+            "cdn_invalidation_dispatch_failed curriculum_id=%s error=%s", curriculum_id, exc
+        )
 
 
 # ── Block version (creates block record + marks version blocked) ───────────────

--- a/backend/src/auth/tasks.py
+++ b/backend/src/auth/tasks.py
@@ -190,6 +190,25 @@ def write_audit_log_task(
         raise self.retry(exc=exc, countdown=30)
 
 
+@celery_app.task(name="src.auth.tasks.invalidate_cdn_task", bind=True, max_retries=2)
+def invalidate_cdn_task(self, curriculum_id: str) -> None:
+    """
+    Fire-and-forget CloudFront invalidation for a curriculum.
+
+    Runs on the `io` queue so the FastAPI request path never blocks on the
+    CloudFront API call.  Silently no-ops when CLOUDFRONT_DISTRIBUTION_ID is
+    unset (local dev).
+
+    Retries up to 2× on transient CloudFront errors.
+    """
+    from src.core.cdn import invalidate_curriculum
+
+    try:
+        _run_async(invalidate_curriculum(curriculum_id, settings.CLOUDFRONT_DISTRIBUTION_ID))
+    except Exception as exc:
+        raise self.retry(exc=exc, countdown=60)
+
+
 @celery_app.task(name="src.auth.tasks.write_progress_answer_task", bind=True, max_retries=3)
 def write_progress_answer_task(
     self,

--- a/backend/src/content/service.py
+++ b/backend/src/content/service.py
@@ -19,7 +19,6 @@ import json
 import uuid as _uuid
 
 import asyncpg
-from config import settings
 
 from src.core.cache_keys import content_key, csv_key, cur_key, ent_key, quiz_set_key, school_ent_key
 from src.core.storage import StorageBackend
@@ -381,44 +380,3 @@ async def get_unit_subject(
     return row["subject"] if row else None
 
 
-async def invalidate_cdn_path(curriculum_id: str, unit_id: str | None = None) -> None:
-    """
-    Invalidate CloudFront CDN paths after a content version bump.
-
-    Per CLAUDE.md non-negotiable rule #7: CDN invalidation must accompany
-    Redis cache invalidation on content bumps.
-
-    Pattern invalidated:
-      - unit_id provided:  curricula/{curriculum_id}/{unit_id}/*
-      - unit_id omitted:   curricula/{curriculum_id}/*
-
-    Silently skips if CLOUDFRONT_DISTRIBUTION_ID is not set (local dev).
-    """
-    distribution_id = settings.CLOUDFRONT_DISTRIBUTION_ID
-    if not distribution_id:
-        log.debug("cloudfront_distribution_id_absent_skipping_invalidation")
-        return
-
-    if unit_id:
-        path = f"/curricula/{curriculum_id}/{unit_id}/*"
-    else:
-        path = f"/curricula/{curriculum_id}/*"
-
-    try:
-        import time
-
-        import boto3
-
-        cf = boto3.client("cloudfront")
-        cf.create_invalidation(
-            DistributionId=distribution_id,
-            InvalidationBatch={
-                "Paths": {"Quantity": 1, "Items": [path]},
-                "CallerReference": str(int(time.time())),
-            },
-        )
-        log.info("cdn_invalidation_created distribution=%s path=%s", distribution_id, path)
-    except Exception as exc:
-        log.warning(
-            "cdn_invalidation_failed distribution=%s path=%s error=%s", distribution_id, path, exc
-        )

--- a/backend/src/content/service.py
+++ b/backend/src/content/service.py
@@ -378,5 +378,3 @@ async def get_unit_subject(
             curriculum_id,
         )
     return row["subject"] if row else None
-
-

--- a/backend/tests/test_cdn_invalidation.py
+++ b/backend/tests/test_cdn_invalidation.py
@@ -13,13 +13,11 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from src.core.cdn import invalidate_curriculum, invalidate_paths, invalidate_unit
-
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -341,3 +339,55 @@ async def test_purge_grace_expired_skips_cdn_when_no_distribution(tmp_path: Path
     assert len(results) == 1
     # boto3 client was never instantiated — no CloudFront call.
     boto3_mock.client.assert_not_called()
+
+
+# ── _invalidate_cdn dispatcher (Issue #254 P1) ────────────────────────────────
+
+
+def test_invalidate_cdn_dispatches_celery_task_on_io_queue():
+    """
+    admin.service._invalidate_cdn must apply_async the Celery task on the 'io'
+    queue with the given curriculum_id.  Previously it called an async
+    function without await — producing an unawaited coroutine that was
+    silently swallowed (Issue #254 P1).
+    """
+    from src.admin.service import _invalidate_cdn
+
+    with patch("src.auth.tasks.invalidate_cdn_task") as mock_task:
+        _invalidate_cdn("default-2026-g8")
+
+    mock_task.apply_async.assert_called_once_with(
+        kwargs={"curriculum_id": "default-2026-g8"},
+        queue="io",
+    )
+
+
+def test_invalidate_cdn_swallows_dispatch_failures():
+    """
+    Dispatch errors must not break the admin request path (publish/rollback).
+    """
+    from src.admin.service import _invalidate_cdn
+
+    with patch("src.auth.tasks.invalidate_cdn_task") as mock_task:
+        mock_task.apply_async.side_effect = RuntimeError("broker unreachable")
+        # Must not raise.
+        _invalidate_cdn("default-2026-g8")
+
+
+def test_invalidate_cdn_task_calls_invalidate_curriculum():
+    """
+    The Celery task body delegates to src.core.cdn.invalidate_curriculum with
+    the configured distribution_id.
+    """
+    from src.auth.tasks import invalidate_cdn_task
+
+    with patch("src.auth.tasks._run_async") as mock_run, \
+         patch("src.core.cdn.invalidate_curriculum") as mock_invalidate, \
+         patch("src.auth.tasks.settings") as mock_settings:
+        mock_settings.CLOUDFRONT_DISTRIBUTION_ID = "EDIST1234"
+
+        # Celery tasks bound with bind=True expose .run() for direct invocation.
+        invalidate_cdn_task.run("default-2026-g8")
+
+    mock_run.assert_called_once()
+    mock_invalidate.assert_called_once_with("default-2026-g8", "EDIST1234")


### PR DESCRIPTION
## Summary

Fixes the unawaited-coroutine bug flagged in #254 (P1 priority). `admin.service._invalidate_cdn` called `content.service.invalidate_cdn_path()` without `await` — an `async def` function. The result was an unawaited coroutine silently swallowed by the surrounding `try/except`, which meant **CloudFront invalidation has never actually run from the admin publish/rollback flows in production**.

Net effect of the bug: stale content at CDN edges could survive a version bump until the CloudFront default TTL (up to 24h) naturally expires.

## What changed

### 1. New Celery task — `src/auth/tasks.py`
```python
@celery_app.task(name="src.auth.tasks.invalidate_cdn_task", bind=True, max_retries=2)
def invalidate_cdn_task(self, curriculum_id: str) -> None:
    from src.core.cdn import invalidate_curriculum
    try:
        _run_async(invalidate_curriculum(curriculum_id, settings.CLOUDFRONT_DISTRIBUTION_ID))
    except Exception as exc:
        raise self.retry(exc=exc, countdown=60)
```

Runs on the `io` queue — matches the "writes never block reads" rule from CLAUDE.md. Fire-and-forget from the caller.

### 2. Dispatcher rewrite — `src/admin/service.py`
`_invalidate_cdn` now does `.apply_async(kwargs={...}, queue="io")` instead of the broken sync call to an async function. Existing callers (`publish_version`, `rollback_version`) don't change.

### 3. Dead-code deletion — `src/content/service.py`
`invalidate_cdn_path` was a duplicate of the tested helpers in `src/core/cdn.py` (`invalidate_paths` / `invalidate_curriculum` / `invalidate_unit`), older and buggy. Its only callers were the admin service (via `_invalidate_cdn`) and the Celery task — both now route through the canonical `src/core/cdn.py` module. Removed the function and its unused `from config import settings` import.

### 4. Tests — `backend/tests/test_cdn_invalidation.py`
Three new unit tests:
- `test_invalidate_cdn_dispatches_celery_task_on_io_queue` — verifies dispatcher wiring
- `test_invalidate_cdn_swallows_dispatch_failures` — verifies admin request path isn't broken by a broken broker
- `test_invalidate_cdn_task_calls_invalidate_curriculum` — verifies task body delegates correctly

All three are pure unit tests (mocked broker + mocked boto3). No DB required.

## Verification

```
$ docker compose exec -T api ruff check src/ tests/
All checks passed!

$ grep -rn "invalidate_cdn_path" backend/
# no matches — legacy fully removed

$ docker compose exec -T api python -c "from src.auth import tasks; print(tasks.invalidate_cdn_task.name)"
src.auth.tasks.invalidate_cdn_task
```

## Context

- #254 P0 fix (`/data` hardcode + `ANTHROPIC_API_KEY`) is in PR #256 (open).
- Remaining #254 items (P2): `test_refresh_materialized_views` MV schema mismatch, `test_check_build_allowance_no_quota_row` stale assertion. Not in scope here.

## Test plan

- [ ] Backend Lint passes
- [ ] Backend Tests: the three new tests pass, existing admin/publish and admin/rollback tests still pass (they patch `_invalidate_cdn` so mechanism change is invisible to them)
- [ ] Post-merge smoke: in a staging env with `CLOUDFRONT_DISTRIBUTION_ID` set, publish a version and confirm an invalidation request appears in the CloudFront console

🤖 Generated with [Claude Code](https://claude.com/claude-code)