### PR TITLE
fix(reports): align mv_class_summary unique index with GROUP BY (Issue #254 P2)

### DIFF
--- a/backend/alembic/versions/0049_mv_class_summary_unique_index_fix.py
+++ b/backend/alembic/versions/0049_mv_class_summary_unique_index_fix.py
@@ -59,14 +59,14 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Restore the original 3-col index.  Note: downgrading on a schema
-    # where real multi-subject rows exist will fail because the index
-    # violates uniqueness.  That's expected — the whole point of this
-    # migration is that the 3-col shape was wrong.
+    # Drop the 4-col index.  The original 3-col index is NOT recreated
+    # because doing so against any real multi-subject data triggers the
+    # same UniqueViolation this migration was written to fix — which
+    # also broke the pytest session-teardown downgrade chain.
+    #
+    # Migration 0010's downgrade drops mv_class_summary entirely, so
+    # the index absence is transient.  Non-CONCURRENTLY REFRESH still
+    # works on the MV without the unique index; CONCURRENTLY REFRESH
+    # is the only thing that'd need it, and that path is disabled
+    # while the downgrade chain walks back to 0010.
     op.execute("DROP INDEX IF EXISTS mv_class_summary_pk")
-    op.execute(
-        """
-        CREATE UNIQUE INDEX IF NOT EXISTS mv_class_summary_pk
-            ON mv_class_summary(school_id, curriculum_id, unit_id)
-        """
-    )

--- a/backend/alembic/versions/0049_mv_class_summary_unique_index_fix.py
+++ b/backend/alembic/versions/0049_mv_class_summary_unique_index_fix.py
@@ -1,0 +1,72 @@
+"""0049 — mv_class_summary: align unique index with GROUP BY (Issue #254 P2)
+
+Migration 0010 created the mv_class_summary materialised view with a
+GROUP BY of four columns:
+
+    GROUP BY se.school_id, ps.curriculum_id, ps.unit_id, ps.subject
+
+but a unique index over only three columns:
+
+    CREATE UNIQUE INDEX mv_class_summary_pk
+        ON mv_class_summary(school_id, curriculum_id, unit_id)
+
+Whenever a (school_id, curriculum_id, unit_id) tuple has more than one
+distinct `ps.subject` value, the MV produces multiple rows with the same
+three-column key and `REFRESH MATERIALIZED VIEW` (non-CONCURRENTLY) fails
+on index creation with `UniqueViolationError: could not create unique
+index "mv_class_summary_pk"`.
+
+This migration drops the 3-column index and recreates it over all four
+GROUP BY columns so the index matches the authored grain.
+
+Why this is the right fix (as opposed to dropping `subject` from the
+GROUP BY):
+  - No `SELECT FROM mv_class_summary` callers exist in the application
+    source — only REFRESH callers.  So the shape is purely structural.
+  - `subject` is a real dimension in the source (progress_sessions has
+    its own subject column independent of curriculum_unit mapping).
+    Keeping it at the unit level preserves information.
+
+Effect on REFRESH:
+  - Non-CONCURRENTLY refreshes continue to work.
+  - CONCURRENT refreshes also work because the unique index still exists;
+    only its columns changed.  Postgres requires at least one unique
+    index for CONCURRENTLY refresh, and this migration keeps that
+    invariant.
+
+Revision ID: 0049
+Revises: 0048
+Create Date: 2026-04-23
+"""
+
+from alembic import op
+
+revision = "0049"
+down_revision = "0048"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop the mismatched 3-col unique index and recreate with 4 cols.
+    op.execute("DROP INDEX IF EXISTS mv_class_summary_pk")
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS mv_class_summary_pk
+            ON mv_class_summary(school_id, curriculum_id, unit_id, subject)
+        """
+    )
+
+
+def downgrade() -> None:
+    # Restore the original 3-col index.  Note: downgrading on a schema
+    # where real multi-subject rows exist will fail because the index
+    # violates uniqueness.  That's expected — the whole point of this
+    # migration is that the 3-col shape was wrong.
+    op.execute("DROP INDEX IF EXISTS mv_class_summary_pk")
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS mv_class_summary_pk
+            ON mv_class_summary(school_id, curriculum_id, unit_id)
+        """
+    )


### PR DESCRIPTION
## Summary

Last of the six Backend Tests failures catalogued in #254. Single-migration fix for a schema mismatch in the Phase 11 reports materialised view.

## Root cause

Migration `0010_phase11_reports.py:81-106` created `mv_class_summary` with a 4-column GROUP BY but a 3-column unique index:

```sql
GROUP BY se.school_id, ps.curriculum_id, ps.unit_id, ps.subject  -- 4 cols
...
CREATE UNIQUE INDEX mv_class_summary_pk
    ON mv_class_summary(school_id, curriculum_id, unit_id)        -- 3 cols
```

If any tuple of the first three columns has more than one distinct `ps.subject`, the MV produces multiple rows with the same 3-col key, and `REFRESH MATERIALIZED VIEW` fails on unique-index creation with `asyncpg.exceptions.UniqueViolationError`.

The failing test's key `(…, default-2026-g8, G8-MATH-001)` confirmed the divergence.

## Fix

New migration `0049_mv_class_summary_unique_index_fix.py` drops the 3-col index and recreates it over all four GROUP BY columns.

## Why this shape (not drop `subject` from GROUP BY)

- **No `SELECT` callers exist** for this MV — only `REFRESH` callers (verified via grep). So the column set is purely structural.
- `progress_sessions.subject` is a real dimension independent of the `curriculum_units` mapping; keeping it at the unit grain preserves information.
- CONCURRENT refreshes still work — Postgres needs **any** unique index; only the columns changed.

## Safety

If existing MV data ever had rows that would violate the new 4-col uniqueness, the `CREATE INDEX` would fail. But that's impossible by construction: the MV's own GROUP BY already dedupes on those four columns, so it can't produce duplicates for the new index to reject.

## Expected CI delta

Backend Tests on this PR: **2 remaining P2 failures → 0**. (Assuming the first P2 PR #259 has also merged or will land alongside.)

| Backend Tests timeline | Count |
|---|---|
| Pre-#254 P0 (before PR #256) | 6 failures |
| Post-#256 merge | 2 failures |
| Post-#259 merge | 1 failure (this one) |
| Post-this PR | 0 failures |

## Test plan

- [x] `ruff check alembic/versions/0049_...py` — clean
- [ ] CI Backend Tests: `test_refresh_materialized_views` passes
- [ ] On a deploy environment with existing MV data, `alembic upgrade head` completes without unique-violation errors (would only fail if production MV was in an impossible state)

## Related

- #254 triage — this issue
- PR #256 — #254 P0 fixes (merged)
- PR #257 — #254 P1 CDN fix (merged)
- PR #259 — #254 P2 `check_build_allowance` (open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)