### PR TITLE
chore(web): clear pre-existing ESLint errors + Prettier drift

### DIFF
--- a/web/.prettierignore
+++ b/web/.prettierignore
@@ -1,0 +1,16 @@
+# Generated files — do not format.
+lib/api/types.gen.ts
+openapi.json
+
+# Build output
+.next/
+out/
+dist/
+
+# Dependencies
+node_modules/
+
+# Test output
+test-results/
+playwright-report/
+coverage/

--- a/web/app/(admin)/admin/analytics/page.tsx
+++ b/web/app/(admin)/admin/analytics/page.tsx
@@ -64,7 +64,7 @@ export default function AdminAnalyticsPage() {
                 </tr>
                 <tr>
                   <td className="px-4 py-3 text-gray-700">MRR (CAD)</td>
-                  <td className="px-4 py-3 text-right font-mono tabular-nums text-gray-900">
+                  <td className="px-4 py-3 text-right font-mono text-gray-900 tabular-nums">
                     {sub.mrr_usd
                       ? `$${parseFloat(sub.mrr_usd).toLocaleString("en-CA", { minimumFractionDigits: 2 })}`
                       : "—"}
@@ -85,7 +85,9 @@ export default function AdminAnalyticsPage() {
                 <tr>
                   <td className="px-4 py-3 text-gray-700">Churn rate</td>
                   <td className="px-4 py-3 text-right font-mono text-gray-900">
-                    {sub.churn_rate != null ? `${(sub.churn_rate * 100).toFixed(2)}%` : "—"}
+                    {sub.churn_rate != null
+                      ? `${(sub.churn_rate * 100).toFixed(2)}%`
+                      : "—"}
                   </td>
                 </tr>
               </tbody>

--- a/web/app/(admin)/admin/audit/page.tsx
+++ b/web/app/(admin)/admin/audit/page.tsx
@@ -128,11 +128,14 @@ export default function AdminAuditPage() {
         <div className="py-16 text-center text-gray-400">
           <FileText className="mx-auto mb-3 h-10 w-10 opacity-40" />
           <p className="text-sm font-medium text-gray-600">
-            {actionFilter ? `No entries matching "${actionFilter}".` : "No audit events recorded yet."}
+            {actionFilter
+              ? `No entries matching "${actionFilter}".`
+              : "No audit events recorded yet."}
           </p>
           {!actionFilter && (
             <p className="mt-1 text-xs text-gray-400">
-              Events are recorded automatically when admins approve, publish, block, or annotate content.
+              Events are recorded automatically when admins approve, publish, block, or
+              annotate content.
             </p>
           )}
         </div>

--- a/web/app/(admin)/admin/content-review/[version_id]/page.tsx
+++ b/web/app/(admin)/admin/content-review/[version_id]/page.tsx
@@ -18,7 +18,6 @@ import {
 import { useAdmin, hasPermission } from "@/lib/hooks/useAdmin";
 import { cn } from "@/lib/utils";
 import {
-  AlertTriangle,
   ArrowLeft,
   CheckCircle,
   XCircle,
@@ -81,7 +80,8 @@ export default function AdminContentReviewDetailPage() {
     enabled: !!item && item.alex_warnings_count > 0,
   });
 
-  const unacknowledgedCount = warnings?.unacknowledged_count ?? item?.alex_warnings_count ?? 0;
+  const unacknowledgedCount =
+    warnings?.unacknowledged_count ?? item?.alex_warnings_count ?? 0;
   const approveBlocked = (item?.alex_warnings_count ?? 0) > 0 && unacknowledgedCount > 0;
 
   const canSelfAssign = admin && hasPermission(admin.role, "tester");
@@ -146,7 +146,7 @@ export default function AdminContentReviewDetailPage() {
                 {item.status}
               </span>
             </div>
-            <div className="mt-1 flex items-center gap-2 flex-wrap">
+            <div className="mt-1 flex flex-wrap items-center gap-2">
               <p className="text-sm text-gray-500">
                 {item.curriculum_id} · Version {item.version_number}
               </p>
@@ -162,7 +162,8 @@ export default function AdminContentReviewDetailPage() {
                   )}
                 >
                   <ShieldAlert className="h-3 w-3" />
-                  {item.alex_warnings_count} AlexJS warning{item.alex_warnings_count !== 1 ? "s" : ""}
+                  {item.alex_warnings_count} AlexJS warning
+                  {item.alex_warnings_count !== 1 ? "s" : ""}
                 </span>
               ) : (
                 <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-semibold text-green-700">
@@ -190,11 +191,13 @@ export default function AdminContentReviewDetailPage() {
 
           {/* Assignment panel */}
           <div className="rounded-xl border border-gray-200 bg-white px-4 py-3">
-            <div className="flex items-center gap-2 flex-wrap">
+            <div className="flex flex-wrap items-center gap-2">
               <UserCheck className="h-4 w-4 flex-shrink-0 text-gray-400" />
               <span className="text-sm font-medium text-gray-700">Assigned reviewer</span>
               {item.assigned_to_email ? (
-                <span className="ml-1 text-sm text-gray-900">{item.assigned_to_email}</span>
+                <span className="ml-1 text-sm text-gray-900">
+                  {item.assigned_to_email}
+                </span>
               ) : (
                 <span className="ml-1 text-sm text-gray-400">Unassigned</span>
               )}
@@ -262,8 +265,8 @@ export default function AdminContentReviewDetailPage() {
                     {item.alex_warnings_count !== 1 ? "s" : ""} — review before approving
                   </p>
                   <p className="mt-0.5 text-xs text-red-700">
-                    Open each unit&apos;s viewer and acknowledge or mark false-positive every
-                    warning before the Approve button becomes available.
+                    Open each unit&apos;s viewer and acknowledge or mark false-positive
+                    every warning before the Approve button becomes available.
                   </p>
                   {warnings && (
                     <div className="mt-2 flex items-center gap-2">
@@ -275,8 +278,9 @@ export default function AdminContentReviewDetailPage() {
                           }}
                         />
                       </div>
-                      <span className="whitespace-nowrap text-xs font-medium text-red-800">
-                        {warnings.total_count - warnings.unacknowledged_count} / {warnings.total_count} acknowledged
+                      <span className="text-xs font-medium whitespace-nowrap text-red-800">
+                        {warnings.total_count - warnings.unacknowledged_count} /{" "}
+                        {warnings.total_count} acknowledged
                       </span>
                     </div>
                   )}
@@ -383,7 +387,11 @@ export default function AdminContentReviewDetailPage() {
                   <button
                     disabled={acting || approveBlocked}
                     onClick={() => performAction(() => approveReview(version_id))}
-                    title={approveBlocked ? `${unacknowledgedCount} warning${unacknowledgedCount !== 1 ? "s" : ""} must be acknowledged first` : undefined}
+                    title={
+                      approveBlocked
+                        ? `${unacknowledgedCount} warning${unacknowledgedCount !== 1 ? "s" : ""} must be acknowledged first`
+                        : undefined
+                    }
                     className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
                   >
                     <CheckCircle className="h-4 w-4" />
@@ -391,7 +399,8 @@ export default function AdminContentReviewDetailPage() {
                   </button>
                   {approveBlocked && (
                     <p className="text-xs text-red-600">
-                      {unacknowledgedCount} warning{unacknowledgedCount !== 1 ? "s" : ""} unacknowledged
+                      {unacknowledgedCount} warning{unacknowledgedCount !== 1 ? "s" : ""}{" "}
+                      unacknowledged
                     </p>
                   )}
                 </div>

--- a/web/app/(admin)/admin/content-review/[version_id]/unit/[unit_id]/page.tsx
+++ b/web/app/(admin)/admin/content-review/[version_id]/unit/[unit_id]/page.tsx
@@ -68,8 +68,8 @@ function useAnnotations(effectiveKey: string) {
 // ── AlexJS warnings banner ────────────────────────────────────────────────────
 
 const ALEX_CHECKLIST = [
-  "Ableist or euphemistic language (e.g. \"crazy\", \"lame\", \"blind to\")",
-  "Gendered terms where neutral alternatives exist (e.g. \"mankind\", \"stewardess\")",
+  'Ableist or euphemistic language (e.g. "crazy", "lame", "blind to")',
+  'Gendered terms where neutral alternatives exist (e.g. "mankind", "stewardess")',
   "Potentially insensitive cultural or racial references",
   "Overly binary gender assumptions in examples",
   "Medical or mental-health language used casually",
@@ -131,16 +131,12 @@ function AlexWarningsBanner({ count }: { count: number }) {
     <>
       <div
         ref={bannerRef}
-        className={cn(
-          "mb-6 rounded-xl border-2 p-4",
-          colours.border,
-          colours.bg,
-        )}
+        className={cn("mb-6 rounded-xl border-2 p-4", colours.border, colours.bg)}
       >
         <div className="flex items-start gap-3">
           <ShieldAlert className={cn("mt-0.5 h-5 w-5 flex-shrink-0", colours.icon)} />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 flex-wrap">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
               <p className={cn("text-sm font-bold", colours.title)}>
                 {count} AlexJS warning{count !== 1 ? "s" : ""} — {severity} severity
               </p>
@@ -165,14 +161,20 @@ function AlexWarningsBanner({ count }: { count: number }) {
                 colours.toggle,
               )}
             >
-              {expanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+              {expanded ? (
+                <ChevronUp className="h-3.5 w-3.5" />
+              ) : (
+                <ChevronDown className="h-3.5 w-3.5" />
+              )}
               {expanded ? "Hide" : "Show"} what to look for
             </button>
             {expanded && (
               <ul className={cn("mt-2 space-y-1 text-xs", colours.body)}>
                 {ALEX_CHECKLIST.map((item) => (
                   <li key={item} className="flex items-start gap-1.5">
-                    <AlertTriangle className={cn("mt-0.5 h-3 w-3 flex-shrink-0", colours.icon)} />
+                    <AlertTriangle
+                      className={cn("mt-0.5 h-3 w-3 flex-shrink-0", colours.icon)}
+                    />
                     {item}
                   </li>
                 ))}
@@ -184,9 +186,14 @@ function AlexWarningsBanner({ count }: { count: number }) {
 
       {/* Sticky pill visible when banner is out of view */}
       {sticky && (
-        <div className="fixed right-6 top-4 z-50 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold text-white shadow-lg cursor-pointer"
-          style={{ backgroundColor: isHigh ? "#dc2626" : isMedium ? "#d97706" : "#f97316" }}
-          onClick={() => bannerRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })}
+        <div
+          className="fixed top-4 right-6 z-50 flex cursor-pointer items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold text-white shadow-lg"
+          style={{
+            backgroundColor: isHigh ? "#dc2626" : isMedium ? "#d97706" : "#f97316",
+          }}
+          onClick={() =>
+            bannerRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
+          }
           title="AlexJS warnings — click to scroll to banner"
         >
           <ShieldAlert className="h-3.5 w-3.5" />
@@ -610,7 +617,8 @@ function InlineWarningsPanel({
   return (
     <div className="mb-5 rounded-lg border border-red-200 bg-red-50 p-4">
       <p className="mb-3 text-xs font-semibold text-red-800">
-        {warnings.length} AlexJS warning{warnings.length !== 1 ? "s" : ""} in this content type
+        {warnings.length} AlexJS warning{warnings.length !== 1 ? "s" : ""} in this content
+        type
         {unacked.length > 0 && (
           <span className="ml-1.5 rounded-full bg-red-200 px-1.5 py-0.5 text-red-800">
             {unacked.length} unacknowledged
@@ -804,9 +812,7 @@ export default function AdminUnitContentPage() {
             </div>
 
             {meta.alex_warnings_count > 0 && (
-              <AlexWarningsBanner
-                count={meta.alex_warnings_count}
-              />
+              <AlexWarningsBanner count={meta.alex_warnings_count} />
             )}
 
             <div className="flex gap-6">

--- a/web/app/(admin)/admin/content-review/page.tsx
+++ b/web/app/(admin)/admin/content-review/page.tsx
@@ -3,7 +3,12 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { BatchApproveResult, assignReview, batchApproveGrade, getReviewQueue } from "@/lib/api/admin";
+import {
+  BatchApproveResult,
+  assignReview,
+  batchApproveGrade,
+  getReviewQueue,
+} from "@/lib/api/admin";
 import { useAdmin, hasPermission } from "@/lib/hooks/useAdmin";
 import { cn } from "@/lib/utils";
 import { AlertTriangle, CheckCheck, ClipboardList, UserCheck } from "lucide-react";
@@ -53,7 +58,7 @@ const PROVIDER_LABELS: Record<string, string> = {
 };
 
 function ProviderBadge({ provider }: { provider: string | null }) {
-  if (!provider) return <span className="text-gray-300 text-xs">—</span>;
+  if (!provider) return <span className="text-xs text-gray-300">—</span>;
   return (
     <span
       className={cn(
@@ -76,13 +81,16 @@ export default function AdminContentReviewPage() {
   const canSelfAssign = admin && hasPermission(admin.role, "tester");
 
   const assignedToParam =
-    assignFilter === "mine" && admin ? admin.admin_id :
-    assignFilter === "unassigned" ? "unassigned" :
-    undefined;
+    assignFilter === "mine" && admin
+      ? admin.admin_id
+      : assignFilter === "unassigned"
+        ? "unassigned"
+        : undefined;
 
   const { data, isLoading } = useQuery({
     queryKey: ["admin", "content-review", statusFilter, assignFilter, admin?.admin_id],
-    queryFn: () => getReviewQueue(statusFilter || undefined, undefined, undefined, assignedToParam),
+    queryFn: () =>
+      getReviewQueue(statusFilter || undefined, undefined, undefined, assignedToParam),
     staleTime: 30_000,
   });
 
@@ -296,7 +304,9 @@ export default function AdminContentReviewPage() {
                                 {canSelfAssign &&
                                   item.assigned_to_admin_id !== admin?.admin_id && (
                                     <button
-                                      onClick={() => selfAssignMutation.mutate(item.version_id)}
+                                      onClick={() =>
+                                        selfAssignMutation.mutate(item.version_id)
+                                      }
                                       disabled={selfAssignMutation.isPending}
                                       className="rounded bg-indigo-50 px-1.5 py-0.5 text-xs font-medium text-indigo-600 hover:bg-indigo-100 disabled:opacity-50"
                                     >
@@ -369,10 +379,13 @@ export default function AdminContentReviewPage() {
             <h2 className="mb-1 text-lg font-semibold text-gray-900">
               Approve all clean subjects?
             </h2>
-            <p className="mb-4 text-xs text-gray-400 font-mono">{confirm.curriculumId}</p>
+            <p className="mb-4 font-mono text-xs text-gray-400">{confirm.curriculumId}</p>
             <ul className="mb-5 divide-y divide-gray-100 rounded-lg border border-gray-200">
               {confirm.items.map((item) => (
-                <li key={item.version_id} className="flex items-center gap-2 px-3 py-2 text-sm">
+                <li
+                  key={item.version_id}
+                  className="flex items-center gap-2 px-3 py-2 text-sm"
+                >
                   <CheckCheck className="h-3.5 w-3.5 shrink-0 text-green-500" />
                   <span className="font-medium text-gray-800">
                     {item.subject_name ?? item.subject}
@@ -401,7 +414,9 @@ export default function AdminContentReviewPage() {
                 disabled={batchMutation.isPending}
                 className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
               >
-                {batchMutation.isPending ? "Approving…" : `Approve ${confirm.items.length}`}
+                {batchMutation.isPending
+                  ? "Approving…"
+                  : `Approve ${confirm.items.length}`}
               </button>
             </div>
           </div>

--- a/web/app/(admin)/admin/demo-accounts/page.tsx
+++ b/web/app/(admin)/admin/demo-accounts/page.tsx
@@ -470,7 +470,8 @@ export default function AdminDemoAccountsPage() {
           </p>
           {!statusFilter && !emailSearch && (
             <p className="mt-1 text-xs text-gray-400">
-              Demo requests appear here when prospective users submit a trial request from the landing page.
+              Demo requests appear here when prospective users submit a trial request from
+              the landing page.
             </p>
           )}
         </div>

--- a/web/app/(admin)/admin/demo-leads/page.tsx
+++ b/web/app/(admin)/admin/demo-leads/page.tsx
@@ -76,13 +76,7 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-function ApprovePanel({
-  lead,
-  onDone,
-}: {
-  lead: DemoLeadItem;
-  onDone: () => void;
-}) {
+function ApprovePanel({ lead, onDone }: { lead: DemoLeadItem; onDone: () => void }) {
   const [ttlHours, setTtlHours] = useState(24);
   const [result, setResult] = useState<DemoLeadApproveResponse | null>(null);
   const queryClient = useQueryClient();
@@ -101,7 +95,7 @@ function ApprovePanel({
         <p className="mb-3 font-medium text-green-800">
           Approved — email sent to {lead.email}
         </p>
-        <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500">
+        <p className="mb-1 text-xs font-semibold tracking-wide text-gray-500 uppercase">
           Tour URLs
         </p>
         {(
@@ -132,10 +126,7 @@ function ApprovePanel({
             timeStyle: "short",
           })}
         </p>
-        <button
-          onClick={onDone}
-          className="mt-3 text-xs text-gray-500 hover:underline"
-        >
+        <button onClick={onDone} className="mt-3 text-xs text-gray-500 hover:underline">
           Close
         </button>
       </div>
@@ -145,8 +136,8 @@ function ApprovePanel({
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-4 text-sm">
       <p className="mb-3 font-medium text-gray-800">
-        Approve demo for{" "}
-        <span className="font-bold">{lead.name}</span> ({lead.school_org})
+        Approve demo for <span className="font-bold">{lead.name}</span> ({lead.school_org}
+        )
       </p>
       <label className="mb-3 flex items-center gap-3">
         <span className="text-xs text-gray-600">Token TTL (hours)</span>
@@ -178,21 +169,13 @@ function ApprovePanel({
         </button>
       </div>
       {approveMut.isError && (
-        <p className="mt-2 text-xs text-red-600">
-          Error approving lead. Try again.
-        </p>
+        <p className="mt-2 text-xs text-red-600">Error approving lead. Try again.</p>
       )}
     </div>
   );
 }
 
-function RejectPanel({
-  lead,
-  onDone,
-}: {
-  lead: DemoLeadItem;
-  onDone: () => void;
-}) {
+function RejectPanel({ lead, onDone }: { lead: DemoLeadItem; onDone: () => void }) {
   const [reason, setReason] = useState("");
   const queryClient = useQueryClient();
 
@@ -207,15 +190,14 @@ function RejectPanel({
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-4 text-sm">
       <p className="mb-3 font-medium text-gray-800">
-        Reject request from{" "}
-        <span className="font-bold">{lead.name}</span>
+        Reject request from <span className="font-bold">{lead.name}</span>
       </p>
       <textarea
         value={reason}
         onChange={(e) => setReason(e.target.value)}
         placeholder="Reason (optional — not shown to requester)"
         rows={2}
-        className="mb-3 w-full rounded border border-gray-200 px-3 py-2 text-xs focus:outline-none focus:ring-1 focus:ring-red-300"
+        className="mb-3 w-full rounded border border-gray-200 px-3 py-2 text-xs focus:ring-1 focus:ring-red-300 focus:outline-none"
       />
       <div className="flex gap-2">
         <button
@@ -244,9 +226,7 @@ function LeadRow({ lead }: { lead: DemoLeadItem }) {
     <div className="border-b last:border-0">
       <div className="flex items-center gap-3 px-4 py-3">
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium text-gray-900">
-            {lead.name}
-          </p>
+          <p className="truncate text-sm font-medium text-gray-900">{lead.name}</p>
           <p className="truncate text-xs text-gray-500">
             {lead.email} · {lead.school_org}
             {lead.ip_country && (
@@ -282,9 +262,7 @@ function LeadRow({ lead }: { lead: DemoLeadItem }) {
             </p>
           )}
           {lead.status === "rejected" && lead.rejected_reason && (
-            <p className="mb-2 text-xs text-gray-500">
-              Reason: {lead.rejected_reason}
-            </p>
+            <p className="mb-2 text-xs text-gray-500">Reason: {lead.rejected_reason}</p>
           )}
 
           {lead.status === "pending" && !action && (
@@ -340,8 +318,7 @@ export default function DemoLeadsPage() {
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["demo-leads", statusFilter],
-    queryFn: () =>
-      listDemoLeads(statusFilter === "all" ? undefined : statusFilter),
+    queryFn: () => listDemoLeads(statusFilter === "all" ? undefined : statusFilter),
   });
 
   return (
@@ -381,9 +358,7 @@ export default function DemoLeadsPage() {
       {/* Lead list */}
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
         {isLoading && (
-          <div className="px-4 py-8 text-center text-sm text-gray-400">
-            Loading…
-          </div>
+          <div className="px-4 py-8 text-center text-sm text-gray-400">Loading…</div>
         )}
         {isError && (
           <div className="px-4 py-8 text-center text-sm text-red-500">
@@ -392,19 +367,15 @@ export default function DemoLeadsPage() {
         )}
         {data && data.leads.length === 0 && (
           <div className="px-4 py-8 text-center text-sm text-gray-400">
-            No{" "}
-            {statusFilter !== "all" ? statusFilter + " " : ""}
+            No {statusFilter !== "all" ? statusFilter + " " : ""}
             leads.
           </div>
         )}
-        {data &&
-          data.leads.map((lead) => <LeadRow key={lead.lead_id} lead={lead} />)}
+        {data && data.leads.map((lead) => <LeadRow key={lead.lead_id} lead={lead} />)}
       </div>
 
       {data && (
-        <p className="mt-3 text-right text-xs text-gray-400">
-          {data.total} total
-        </p>
+        <p className="mt-3 text-right text-xs text-gray-400">{data.total} total</p>
       )}
     </div>
   );

--- a/web/app/(admin)/admin/demo-settings/page.tsx
+++ b/web/app/(admin)/admin/demo-settings/page.tsx
@@ -35,9 +35,7 @@ function GeoBlockRow({ block }: { block: GeoBlockItem }) {
       <span className="w-12 font-mono text-sm font-bold text-gray-700">
         {block.country_code}
       </span>
-      <span className="flex-1 text-sm text-gray-600">
-        {block.country_name ?? "—"}
-      </span>
+      <span className="flex-1 text-sm text-gray-600">{block.country_name ?? "—"}</span>
       <span className="text-xs text-gray-400">
         {new Date(block.added_at).toLocaleDateString()}
       </span>
@@ -78,10 +76,7 @@ function AddBlockForm() {
 
   const addMut = useMutation({
     mutationFn: () =>
-      addDemoGeoBlock(
-        countryCode.toUpperCase().trim(),
-        countryName.trim() || undefined,
-      ),
+      addDemoGeoBlock(countryCode.toUpperCase().trim(), countryName.trim() || undefined),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["demo-geo-blocks"] });
       setCountryCode("");
@@ -115,7 +110,7 @@ function AddBlockForm() {
           onChange={(e) => setCountryCode(e.target.value)}
           placeholder="e.g. CN"
           maxLength={2}
-          className="w-20 rounded border border-gray-200 px-2.5 py-1.5 font-mono text-sm uppercase focus:outline-none focus:ring-1 focus:ring-gray-400"
+          className="w-20 rounded border border-gray-200 px-2.5 py-1.5 font-mono text-sm uppercase focus:ring-1 focus:ring-gray-400 focus:outline-none"
         />
       </div>
       <div className="flex-1">
@@ -126,7 +121,7 @@ function AddBlockForm() {
           value={countryName}
           onChange={(e) => setCountryName(e.target.value)}
           placeholder="e.g. China"
-          className="w-full rounded border border-gray-200 px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-gray-400"
+          className="w-full rounded border border-gray-200 px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-gray-400 focus:outline-none"
         />
       </div>
       <button
@@ -137,9 +132,7 @@ function AddBlockForm() {
         <Plus className="h-4 w-4" />
         {addMut.isPending ? "Adding…" : "Add block"}
       </button>
-      {error && (
-        <p className="ml-1 text-xs text-red-600">{error}</p>
-      )}
+      {error && <p className="ml-1 text-xs text-red-600">{error}</p>}
     </form>
   );
 }
@@ -165,8 +158,8 @@ export default function DemoSettingsPage() {
           <div>
             <h1 className="text-2xl font-bold text-gray-900">Geo-block settings</h1>
             <p className="mt-0.5 text-sm text-gray-500">
-              Demo tour requests from blocked countries are silently rejected at
-              the IP-lookup stage.
+              Demo tour requests from blocked countries are silently rejected at the
+              IP-lookup stage.
             </p>
           </div>
         </div>
@@ -174,15 +167,13 @@ export default function DemoSettingsPage() {
 
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
         <div className="border-b bg-gray-50 px-4 py-2.5">
-          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+          <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
             Blocked countries ({data?.blocks.length ?? 0})
           </p>
         </div>
 
         {isLoading && (
-          <div className="px-4 py-6 text-center text-sm text-gray-400">
-            Loading…
-          </div>
+          <div className="px-4 py-6 text-center text-sm text-gray-400">Loading…</div>
         )}
         {isError && (
           <div className="px-4 py-6 text-center text-sm text-red-500">

--- a/web/app/(admin)/admin/feedback/page.tsx
+++ b/web/app/(admin)/admin/feedback/page.tsx
@@ -163,7 +163,8 @@ export default function AdminFeedbackPage() {
           </p>
           {!showResolved && (
             <p className="mt-1 text-xs text-gray-400">
-              Students can submit feedback after completing a quiz. It will appear here once received.
+              Students can submit feedback after completing a quiz. It will appear here
+              once received.
             </p>
           )}
         </div>

--- a/web/app/(admin)/admin/help/page.tsx
+++ b/web/app/(admin)/admin/help/page.tsx
@@ -55,7 +55,7 @@ export default function AdminHelpPage() {
 
       {/* Getting started steps */}
       <section>
-        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-400">
+        <h2 className="mb-4 text-sm font-semibold tracking-wide text-gray-400 uppercase">
           Getting Started
         </h2>
         <ol className="space-y-3">
@@ -75,12 +75,15 @@ export default function AdminHelpPage() {
 
       {/* Mind maps */}
       <section>
-        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-400">
+        <h2 className="mb-4 text-sm font-semibold tracking-wide text-gray-400 uppercase">
           Persona Mind Map
         </h2>
         <div className="space-y-4">
           {maps.map((map) => (
-            <div key={map.id} className="overflow-hidden rounded-xl border border-gray-700">
+            <div
+              key={map.id}
+              className="overflow-hidden rounded-xl border border-gray-700"
+            >
               <button
                 className={cn(
                   "flex w-full items-center justify-between px-5 py-4 text-left transition-colors",
@@ -112,7 +115,7 @@ export default function AdminHelpPage() {
 
       {/* Quick reference */}
       <section>
-        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-400">
+        <h2 className="mb-4 text-sm font-semibold tracking-wide text-gray-400 uppercase">
           Quick Reference
         </h2>
         <div className="overflow-hidden rounded-xl border border-gray-700">

--- a/web/app/(admin)/admin/pipeline/upload/page.tsx
+++ b/web/app/(admin)/admin/pipeline/upload/page.tsx
@@ -32,8 +32,7 @@ const RESERVED_CODES = new Set(["none", "other", "all", "default", "null"]);
 function validateCustomCode(code: string): string | null {
   if (!code) return "Required.";
   if (code.length < 3 || code.length > 30) return "3–30 characters.";
-  if (!CODE_PATTERN.test(code))
-    return "Lowercase letters, digits, and hyphens only.";
+  if (!CODE_PATTERN.test(code)) return "Lowercase letters, digits, and hyphens only.";
   if (RESERVED_CODES.has(code)) return `'${code}' is reserved.`;
   return null;
 }
@@ -104,7 +103,10 @@ export default function AdminPipelineUploadPage() {
   // Typeahead: debounced prefix query against the registry.
   const [debouncedCustomCode, setDebouncedCustomCode] = useState("");
   useEffect(() => {
-    const t = setTimeout(() => setDebouncedCustomCode(customCode.trim().toLowerCase()), 200);
+    const t = setTimeout(
+      () => setDebouncedCustomCode(customCode.trim().toLowerCase()),
+      200,
+    );
     return () => clearTimeout(t);
   }, [customCode]);
 
@@ -123,7 +125,9 @@ export default function AdminPipelineUploadPage() {
   }, [streams]);
 
   const isOther = streamSelect === OTHER_VALUE;
-  const customCodeError = isOther ? validateCustomCode(customCode.trim().toLowerCase()) : null;
+  const customCodeError = isOther
+    ? validateCustomCode(customCode.trim().toLowerCase())
+    : null;
   const streamReady =
     streamSelect !== "" &&
     (!isOther || (!customCodeError && customDisplayName.trim().length > 0));

--- a/web/app/(admin)/admin/private-teachers/page.tsx
+++ b/web/app/(admin)/admin/private-teachers/page.tsx
@@ -2,10 +2,7 @@
 
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import {
-  listAdminPrivateTeachers,
-  type AdminPrivateTeacherItem,
-} from "@/lib/api/admin";
+import { listAdminPrivateTeachers, type AdminPrivateTeacherItem } from "@/lib/api/admin";
 import { useAdmin, hasPermission } from "@/lib/hooks/useAdmin";
 import { ShieldOff, Users, CheckCircle2, XCircle, Clock } from "lucide-react";
 
@@ -23,9 +20,7 @@ function PlanBadge({ plan }: { plan: string | null }) {
   return (
     <span
       className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-        isProPlan
-          ? "bg-indigo-100 text-indigo-700"
-          : "bg-blue-100 text-blue-700"
+        isProPlan ? "bg-indigo-100 text-indigo-700" : "bg-blue-100 text-blue-700"
       }`}
     >
       {plan.charAt(0).toUpperCase() + plan.slice(1)}
@@ -35,12 +30,13 @@ function PlanBadge({ plan }: { plan: string | null }) {
 
 function SubStatusBadge({ status }: { status: string | null }) {
   if (!status) {
-    return (
-      <span className="text-xs text-gray-400">—</span>
-    );
+    return <span className="text-xs text-gray-400">—</span>;
   }
 
-  const meta: Record<string, { icon: React.ReactNode; className: string; label: string }> = {
+  const meta: Record<
+    string,
+    { icon: React.ReactNode; className: string; label: string }
+  > = {
     active: {
       icon: <CheckCircle2 className="h-3 w-3 shrink-0" aria-hidden="true" />,
       className: "bg-green-100 text-green-700",
@@ -87,8 +83,7 @@ export default function AdminPrivateTeachersPage() {
 
   const { data, isLoading } = useQuery({
     queryKey: ["admin", "private-teachers", page, nameSearch],
-    queryFn: () =>
-      listAdminPrivateTeachers(page, PAGE_SIZE, nameSearch || undefined),
+    queryFn: () => listAdminPrivateTeachers(page, PAGE_SIZE, nameSearch || undefined),
     staleTime: 30_000,
   });
 
@@ -119,7 +114,8 @@ export default function AdminPrivateTeachersPage() {
     <div className="mx-auto max-w-6xl p-8">
       <h1 className="mb-1 text-2xl font-bold text-gray-900">Private Teachers</h1>
       <p className="mb-6 text-sm text-gray-500">
-        Teachers with their own subscription who upload custom curricula for their students.
+        Teachers with their own subscription who upload custom curricula for their
+        students.
       </p>
 
       {/* Search */}
@@ -193,9 +189,7 @@ export default function AdminPrivateTeachersPage() {
               <tbody className="divide-y divide-gray-100">
                 {teachers.map((item: AdminPrivateTeacherItem) => (
                   <tr key={item.teacher_id} className="hover:bg-gray-50">
-                    <td className="px-4 py-3 font-medium text-gray-900">
-                      {item.name}
-                    </td>
+                    <td className="px-4 py-3 font-medium text-gray-900">{item.name}</td>
                     <td className="max-w-[200px] truncate px-4 py-3 text-gray-600">
                       {item.email}
                     </td>
@@ -205,9 +199,7 @@ export default function AdminPrivateTeachersPage() {
                     <td className="px-4 py-3">
                       <SubStatusBadge status={item.subscription_status} />
                     </td>
-                    <td className="px-4 py-3 text-gray-500">
-                      {item.curricula_count}
-                    </td>
+                    <td className="px-4 py-3 text-gray-500">{item.curricula_count}</td>
                     <td className="px-4 py-3 text-gray-500">
                       {new Date(item.created_at).toLocaleDateString()}
                     </td>

--- a/web/app/(admin)/admin/retention/page.tsx
+++ b/web/app/(admin)/admin/retention/page.tsx
@@ -51,9 +51,17 @@ function StatusBadge({ status }: { status: AdminRetentionItem["retention_status"
     unavailable: { label: "Unavailable", cls: "bg-amber-100 text-amber-700" },
     purged: { label: "Purged", cls: "bg-red-100 text-red-600" },
   } as const;
-  const { label, cls } = map[status] ?? { label: status, cls: "bg-gray-100 text-gray-500" };
+  const { label, cls } = map[status] ?? {
+    label: status,
+    cls: "bg-gray-100 text-gray-500",
+  };
   return (
-    <span className={cn("inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium", cls)}>
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+        cls,
+      )}
+    >
       {label}
     </span>
   );
@@ -63,7 +71,10 @@ function StatusBadge({ status }: { status: AdminRetentionItem["retention_status"
 
 type ActionType = "renew" | "force_expire" | "force_delete";
 
-const ACTION_META: Record<ActionType, { label: string; description: string; confirmWord?: string; danger: boolean }> = {
+const ACTION_META: Record<
+  ActionType,
+  { label: string; description: string; confirmWord?: string; danger: boolean }
+> = {
   renew: {
     label: "Renew",
     description: "Extend this curriculum's expiry by 1 year and reset status to active.",
@@ -71,12 +82,14 @@ const ACTION_META: Record<ActionType, { label: string; description: string; conf
   },
   force_expire: {
     label: "Force expire",
-    description: "Immediately mark this curriculum unavailable with a 180-day grace period. Students lose access now.",
+    description:
+      "Immediately mark this curriculum unavailable with a 180-day grace period. Students lose access now.",
     danger: true,
   },
   force_delete: {
     label: "Force delete",
-    description: "Permanently delete all content rows for this curriculum. This cannot be undone.",
+    description:
+      "Permanently delete all content rows for this curriculum. This cannot be undone.",
     confirmWord: "DELETE",
     danger: true,
   },
@@ -99,7 +112,8 @@ function ActionModal({
   const [confirm, setConfirm] = useState("");
   const meta = ACTION_META[action];
   const needsWord = !!meta.confirmWord;
-  const canSubmit = reason.trim().length >= 5 && (!needsWord || confirm === meta.confirmWord);
+  const canSubmit =
+    reason.trim().length >= 5 && (!needsWord || confirm === meta.confirmWord);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
@@ -113,14 +127,21 @@ function ActionModal({
             )}
             <h2 className="text-base font-semibold text-gray-900">{meta.label}</h2>
           </div>
-          <button onClick={onClose} className="rounded p-1 text-gray-400 hover:bg-gray-100">
+          <button
+            onClick={onClose}
+            className="rounded p-1 text-gray-400 hover:bg-gray-100"
+          >
             <X className="h-4 w-4" />
           </button>
         </div>
 
         <div className="mb-4 rounded-lg border bg-gray-50 p-3 text-sm text-gray-700">
-          <p className="font-medium">{item.school_name} — Grade {item.grade}</p>
-          <p className="text-xs text-gray-500 mt-0.5">{item.name} ({item.year}) · {item.curriculum_id.slice(0, 16)}…</p>
+          <p className="font-medium">
+            {item.school_name} — Grade {item.grade}
+          </p>
+          <p className="mt-0.5 text-xs text-gray-500">
+            {item.name} ({item.year}) · {item.curriculum_id.slice(0, 16)}…
+          </p>
         </div>
 
         <p className="mb-4 text-sm text-gray-600">{meta.description}</p>
@@ -132,13 +153,15 @@ function ActionModal({
             </label>
             <textarea
               rows={2}
-              className="w-full rounded border px-3 py-2 text-sm text-gray-800 placeholder:text-gray-400 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-300"
+              className="w-full rounded border px-3 py-2 text-sm text-gray-800 placeholder:text-gray-400 focus:border-indigo-400 focus:ring-1 focus:ring-indigo-300 focus:outline-none"
               placeholder="School requested removal via support ticket #12345…"
               value={reason}
               onChange={(e) => setReason(e.target.value)}
             />
             {reason.trim().length > 0 && reason.trim().length < 5 && (
-              <p className="mt-0.5 text-xs text-red-500">Reason must be at least 5 characters.</p>
+              <p className="mt-0.5 text-xs text-red-500">
+                Reason must be at least 5 characters.
+              </p>
             )}
           </div>
 
@@ -149,7 +172,7 @@ function ActionModal({
               </label>
               <input
                 type="text"
-                className="w-full rounded border px-3 py-2 text-sm font-mono text-gray-800 placeholder:text-gray-400 focus:border-red-400 focus:outline-none focus:ring-1 focus:ring-red-300"
+                className="w-full rounded border px-3 py-2 font-mono text-sm text-gray-800 placeholder:text-gray-400 focus:border-red-400 focus:ring-1 focus:ring-red-300 focus:outline-none"
                 placeholder={meta.confirmWord}
                 value={confirm}
                 onChange={(e) => setConfirm(e.target.value)}
@@ -193,7 +216,12 @@ function RowActions({
 }) {
   const [open, setOpen] = useState(false);
 
-  const actions: { action: ActionType; label: string; icon: React.ReactNode; disabled?: boolean }[] = [
+  const actions: {
+    action: ActionType;
+    label: string;
+    icon: React.ReactNode;
+    disabled?: boolean;
+  }[] = [
     {
       action: "renew",
       label: "Renew",
@@ -220,7 +248,9 @@ function RowActions({
         className="flex items-center gap-1 rounded px-2 py-1 text-xs text-gray-500 hover:bg-gray-100 hover:text-gray-800"
       >
         Actions
-        <ChevronRight className={cn("h-3 w-3 transition-transform", open && "rotate-90")} />
+        <ChevronRight
+          className={cn("h-3 w-3 transition-transform", open && "rotate-90")}
+        />
       </button>
 
       {open && (
@@ -275,7 +305,11 @@ function SummaryTiles({
         { label: "Active", value: active, cls: "text-green-700" },
         { label: "Unavailable", value: unavailable, cls: "text-amber-600" },
         { label: "Purged", value: purged, cls: "text-red-600" },
-        { label: "Expiring ≤30d", value: expiringSoon, cls: expiringSoon > 0 ? "text-red-600" : "text-gray-400" },
+        {
+          label: "Expiring ≤30d",
+          value: expiringSoon,
+          cls: expiringSoon > 0 ? "text-red-600" : "text-gray-400",
+        },
       ].map(({ label, value, cls }) => (
         <div key={label} className="rounded-xl border bg-white p-4 text-center shadow-sm">
           <p className={cn("text-2xl font-bold", cls)}>{value}</p>
@@ -299,7 +333,9 @@ function RetentionTable({
     return (
       <div className="rounded-xl border bg-white p-10 text-center">
         <Archive className="mx-auto mb-2 h-8 w-8 text-gray-300" />
-        <p className="text-sm text-gray-400">No curriculum versions match the current filters.</p>
+        <p className="text-sm text-gray-400">
+          No curriculum versions match the current filters.
+        </p>
       </div>
     );
   }
@@ -322,8 +358,10 @@ function RetentionTable({
           </thead>
           <tbody className="divide-y">
             {curricula.map((item) => {
-              const urgentExpiry = item.days_until_expiry !== null && item.days_until_expiry <= 30;
-              const urgentPurge = item.days_until_purge !== null && item.days_until_purge <= 30;
+              const urgentExpiry =
+                item.days_until_expiry !== null && item.days_until_expiry <= 30;
+              const urgentPurge =
+                item.days_until_purge !== null && item.days_until_purge <= 30;
 
               return (
                 <tr
@@ -337,12 +375,18 @@ function RetentionTable({
                     <div className="flex items-center gap-1.5">
                       <School className="h-3.5 w-3.5 shrink-0 text-gray-300" />
                       <div>
-                        <p className="font-medium text-gray-900 leading-tight">{item.school_name}</p>
-                        <p className="text-xs text-gray-400 leading-tight">{item.contact_email}</p>
+                        <p className="leading-tight font-medium text-gray-900">
+                          {item.school_name}
+                        </p>
+                        <p className="text-xs leading-tight text-gray-400">
+                          {item.contact_email}
+                        </p>
                       </div>
                     </div>
                   </td>
-                  <td className="px-4 py-3 font-mono text-xs text-gray-600">G{item.grade}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-gray-600">
+                    G{item.grade}
+                  </td>
                   <td className="px-4 py-3">
                     <p className="font-medium text-gray-900">{item.name}</p>
                     <p className="text-xs text-gray-400">{item.year}</p>
@@ -354,7 +398,9 @@ function RetentionTable({
                     <div className={cn("text-xs", urgencyClass(item.days_until_expiry))}>
                       {fmtDate(item.expires_at)}
                       {item.days_until_expiry !== null && (
-                        <span className="ml-1 text-gray-400">({item.days_until_expiry}d)</span>
+                        <span className="ml-1 text-gray-400">
+                          ({item.days_until_expiry}d)
+                        </span>
                       )}
                     </div>
                   </td>
@@ -362,7 +408,9 @@ function RetentionTable({
                     <div className={cn("text-xs", urgencyClass(item.days_until_purge))}>
                       {fmtDate(item.grace_until)}
                       {item.days_until_purge !== null && (
-                        <span className="ml-1 text-gray-400">({item.days_until_purge}d)</span>
+                        <span className="ml-1 text-gray-400">
+                          ({item.days_until_purge}d)
+                        </span>
                       )}
                     </div>
                   </td>
@@ -419,8 +467,15 @@ export default function AdminRetentionPage() {
   });
 
   const actionMutation = useMutation({
-    mutationFn: ({ item, action, reason }: { item: AdminRetentionItem; action: ActionType; reason: string }) =>
-      adminCurriculumAction(item.school_id, item.curriculum_id, action, reason),
+    mutationFn: ({
+      item,
+      action,
+      reason,
+    }: {
+      item: AdminRetentionItem;
+      action: ActionType;
+      reason: string;
+    }) => adminCurriculumAction(item.school_id, item.curriculum_id, action, reason),
     onSuccess: (res) => {
       void queryClient.invalidateQueries({ queryKey: ["admin-retention"] });
       setPendingAction(null);
@@ -493,7 +548,8 @@ export default function AdminRetentionPage() {
         <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
           <Clock className="h-4 w-4 shrink-0" />
           <strong>{data.summary.expiring_soon}</strong> curriculum version
-          {data.summary.expiring_soon > 1 ? "s" : ""} across all schools expire within 30 days.
+          {data.summary.expiring_soon > 1 ? "s" : ""} across all schools expire within 30
+          days.
         </div>
       )}
 
@@ -599,7 +655,10 @@ export default function AdminRetentionPage() {
           </Card>
 
           {/* Table */}
-          <RetentionTable curricula={filtered} onAction={(item, action) => setPendingAction({ item, action })} />
+          <RetentionTable
+            curricula={filtered}
+            onAction={(item, action) => setPendingAction({ item, action })}
+          />
 
           <p className="text-xs text-gray-400">
             Showing {filtered.length} of {data.summary.total} version
@@ -615,7 +674,11 @@ export default function AdminRetentionPage() {
           action={pendingAction.action}
           onClose={() => setPendingAction(null)}
           onConfirm={(reason) =>
-            actionMutation.mutate({ item: pendingAction.item, action: pendingAction.action, reason })
+            actionMutation.mutate({
+              item: pendingAction.item,
+              action: pendingAction.action,
+              reason,
+            })
           }
           isPending={actionMutation.isPending}
         />

--- a/web/app/(admin)/admin/schools/[school_id]/page.tsx
+++ b/web/app/(admin)/admin/schools/[school_id]/page.tsx
@@ -62,7 +62,12 @@ function OverrideForm({
   onSaved,
 }: {
   schoolId: string;
-  existing: { max_students: number | null; max_teachers: number | null; pipeline_quota: number | null; override_reason: string } | null;
+  existing: {
+    max_students: number | null;
+    max_teachers: number | null;
+    pipeline_quota: number | null;
+    override_reason: string;
+  } | null;
   planDefaults: { max_students: number; max_teachers: number; pipeline_quota: number };
   onSaved: () => void;
 }) {
@@ -123,7 +128,9 @@ function OverrideForm({
         <div className="space-y-1.5">
           <Label htmlFor="ov_students">
             Max students
-            <span className="ml-1.5 text-gray-400">(plan: {planDefaults.max_students})</span>
+            <span className="ml-1.5 text-gray-400">
+              (plan: {planDefaults.max_students})
+            </span>
           </Label>
           <Input
             id="ov_students"
@@ -137,7 +144,9 @@ function OverrideForm({
         <div className="space-y-1.5">
           <Label htmlFor="ov_teachers">
             Max teachers
-            <span className="ml-1.5 text-gray-400">(plan: {planDefaults.max_teachers})</span>
+            <span className="ml-1.5 text-gray-400">
+              (plan: {planDefaults.max_teachers})
+            </span>
           </Label>
           <Input
             id="ov_teachers"
@@ -151,7 +160,9 @@ function OverrideForm({
         <div className="space-y-1.5">
           <Label htmlFor="ov_pipeline">
             Pipeline quota / mo
-            <span className="ml-1.5 text-gray-400">(plan: {planDefaults.pipeline_quota})</span>
+            <span className="ml-1.5 text-gray-400">
+              (plan: {planDefaults.pipeline_quota})
+            </span>
           </Label>
           <Input
             id="ov_pipeline"
@@ -176,15 +187,11 @@ function OverrideForm({
         />
       </div>
 
-      {error && (
-        <p className="text-xs text-red-600">{error}</p>
-      )}
+      {error && <p className="text-xs text-red-600">{error}</p>}
 
       <div className="flex items-center gap-3">
         <Button onClick={() => mutation.mutate()} disabled={!canSave} className="gap-2">
-          {mutation.isPending ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : null}
+          {mutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
           {existing ? "Update override" : "Set override"}
         </Button>
         {saved && (
@@ -219,7 +226,9 @@ export default function AdminSchoolDetailPage() {
       setClearSuccess(true);
       setClearError(null);
       setTimeout(() => setClearSuccess(false), 3000);
-      void queryClient.invalidateQueries({ queryKey: ["admin-school-limits", school_id] });
+      void queryClient.invalidateQueries({
+        queryKey: ["admin-school-limits", school_id],
+      });
       void queryClient.invalidateQueries({ queryKey: ["admin-schools"] });
     },
     onError: (err: unknown) => {
@@ -260,15 +269,16 @@ export default function AdminSchoolDetailPage() {
 
   // Derive plan defaults from effective limits and override (reverse-engineer for display)
   const planDefaults = {
-    max_students: data.override?.max_students != null
-      ? data.max_students  // overridden, so effective = override
-      : data.max_students, // not overridden, effective = plan default
-    max_teachers: data.override?.max_teachers != null
-      ? data.max_teachers
-      : data.max_teachers,
-    pipeline_quota: data.override?.pipeline_quota != null
-      ? data.pipeline_quota_monthly
-      : data.pipeline_quota_monthly,
+    max_students:
+      data.override?.max_students != null
+        ? data.max_students // overridden, so effective = override
+        : data.max_students, // not overridden, effective = plan default
+    max_teachers:
+      data.override?.max_teachers != null ? data.max_teachers : data.max_teachers,
+    pipeline_quota:
+      data.override?.pipeline_quota != null
+        ? data.pipeline_quota_monthly
+        : data.pipeline_quota_monthly,
   };
   // If override exists, plan default is the effective value only when that field is NOT overridden.
   // Since we don't store plan defaults separately in the response, show them as-is for non-overridden fields.
@@ -285,7 +295,9 @@ export default function AdminSchoolDetailPage() {
           ← Schools
         </LinkButton>
         <div>
-          <h1 className="text-xl font-bold text-gray-900">School Limits &amp; Override</h1>
+          <h1 className="text-xl font-bold text-gray-900">
+            School Limits &amp; Override
+          </h1>
           <p className="mt-0.5 font-mono text-xs text-gray-400">{school_id}</p>
         </div>
       </div>
@@ -295,7 +307,7 @@ export default function AdminSchoolDetailPage() {
         <CardHeader className="pb-2">
           <CardTitle className="flex items-center gap-2 text-base">
             Effective limits
-            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium capitalize text-gray-600">
+            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 capitalize">
               {data.plan}
             </span>
             {data.has_override && (
@@ -333,8 +345,10 @@ export default function AdminSchoolDetailPage() {
             </span>
             <span>
               Seats used:{" "}
-              <strong className="text-gray-700">{data.seats_used_students}</strong> students,{" "}
-              <strong className="text-gray-700">{data.seats_used_teachers}</strong> teachers
+              <strong className="text-gray-700">{data.seats_used_students}</strong>{" "}
+              students,{" "}
+              <strong className="text-gray-700">{data.seats_used_teachers}</strong>{" "}
+              teachers
             </span>
           </div>
         </CardContent>
@@ -342,7 +356,7 @@ export default function AdminSchoolDetailPage() {
 
       {/* Current override detail */}
       {data.has_override && data.override && (
-        <Card className="border border-amber-200 shadow-sm bg-amber-50/40">
+        <Card className="border border-amber-200 bg-amber-50/40 shadow-sm">
           <CardHeader className="pb-2">
             <CardTitle className="text-base text-amber-800">Current override</CardTitle>
           </CardHeader>
@@ -368,9 +382,12 @@ export default function AdminSchoolDetailPage() {
                 <dt className="text-xs text-gray-400">Overridden fields</dt>
                 <dd className="text-gray-700">
                   {[
-                    data.override.max_students != null && `students → ${data.override.max_students}`,
-                    data.override.max_teachers != null && `teachers → ${data.override.max_teachers}`,
-                    data.override.pipeline_quota != null && `pipeline → ${data.override.pipeline_quota}`,
+                    data.override.max_students != null &&
+                      `students → ${data.override.max_students}`,
+                    data.override.max_teachers != null &&
+                      `teachers → ${data.override.max_teachers}`,
+                    data.override.pipeline_quota != null &&
+                      `pipeline → ${data.override.pipeline_quota}`,
                   ]
                     .filter(Boolean)
                     .join(", ") || "none"}
@@ -399,9 +416,7 @@ export default function AdminSchoolDetailPage() {
                   Override cleared
                 </span>
               )}
-              {clearError && (
-                <span className="text-xs text-red-600">{clearError}</span>
-              )}
+              {clearError && <span className="text-xs text-red-600">{clearError}</span>}
             </div>
           </CardContent>
         </Card>

--- a/web/app/(admin)/admin/schools/page.tsx
+++ b/web/app/(admin)/admin/schools/page.tsx
@@ -46,10 +46,13 @@ export default function AdminSchoolsPage() {
   function handleSearch(value: string) {
     setSearch(value);
     clearTimeout((handleSearch as unknown as { _t?: ReturnType<typeof setTimeout> })._t);
-    (handleSearch as unknown as { _t?: ReturnType<typeof setTimeout> })._t = setTimeout(() => {
-      setDebouncedSearch(value);
-      setPage(1);
-    }, 300);
+    (handleSearch as unknown as { _t?: ReturnType<typeof setTimeout> })._t = setTimeout(
+      () => {
+        setDebouncedSearch(value);
+        setPage(1);
+      },
+      300,
+    );
   }
 
   const { data, isLoading } = useQuery({
@@ -124,11 +127,13 @@ export default function AdminSchoolsPage() {
                         <div className="flex items-center gap-2">
                           <div>
                             <p className="font-medium text-gray-800">{school.name}</p>
-                            <p className="text-xs text-gray-400">{school.contact_email}</p>
+                            <p className="text-xs text-gray-400">
+                              {school.contact_email}
+                            </p>
                           </div>
                           {school.has_override && (
                             <span title="Has limit override">
-                              <AlertTriangle className="h-3.5 w-3.5 text-amber-400 shrink-0" />
+                              <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-400" />
                             </span>
                           )}
                         </div>
@@ -177,7 +182,7 @@ export default function AdminSchoolsPage() {
           <button
             onClick={() => setPage((p) => Math.max(1, p - 1))}
             disabled={page === 1}
-            className="rounded-md border border-gray-200 px-3 py-1.5 text-xs disabled:opacity-40 hover:bg-gray-50"
+            className="rounded-md border border-gray-200 px-3 py-1.5 text-xs hover:bg-gray-50 disabled:opacity-40"
           >
             ← Prev
           </button>
@@ -187,7 +192,7 @@ export default function AdminSchoolsPage() {
           <button
             onClick={() => setPage((p) => Math.min(pageCount, p + 1))}
             disabled={page === pageCount}
-            className="rounded-md border border-gray-200 px-3 py-1.5 text-xs disabled:opacity-40 hover:bg-gray-50"
+            className="rounded-md border border-gray-200 px-3 py-1.5 text-xs hover:bg-gray-50 disabled:opacity-40"
           >
             Next →
           </button>

--- a/web/app/(admin)/admin/streams/[code]/page.tsx
+++ b/web/app/(admin)/admin/streams/[code]/page.tsx
@@ -198,10 +198,10 @@ export default function AdminStreamDetailPage() {
               deletable
                 ? "Delete"
                 : stream.is_system
-                ? "System streams can't be deleted"
-                : stream.curricula_count > 0
-                ? "Merge curricula away before deleting"
-                : "Archive before deleting"
+                  ? "System streams can't be deleted"
+                  : stream.curricula_count > 0
+                    ? "Merge curricula away before deleting"
+                    : "Archive before deleting"
             }
             className={
               deletable
@@ -235,7 +235,9 @@ export default function AdminStreamDetailPage() {
             />
           </div>
           <div>
-            <label className="mb-1 block text-xs font-medium text-gray-500">Display name</label>
+            <label className="mb-1 block text-xs font-medium text-gray-500">
+              Display name
+            </label>
             <input
               type="text"
               value={displayValue}
@@ -244,7 +246,9 @@ export default function AdminStreamDetailPage() {
             />
           </div>
           <div>
-            <label className="mb-1 block text-xs font-medium text-gray-500">Description</label>
+            <label className="mb-1 block text-xs font-medium text-gray-500">
+              Description
+            </label>
             <textarea
               value={descValue}
               onChange={(e) => setEditDesc(e.target.value)}
@@ -274,7 +278,10 @@ export default function AdminStreamDetailPage() {
         ) : (
           <ul className="divide-y divide-gray-100">
             {curricula.map((c) => (
-              <li key={c.curriculum_id} className="flex items-center justify-between py-2 text-sm">
+              <li
+                key={c.curriculum_id}
+                className="flex items-center justify-between py-2 text-sm"
+              >
                 <div>
                   <p className="font-mono text-xs text-gray-500">{c.curriculum_id}</p>
                   <p className="text-gray-900">{c.name ?? `Grade ${c.grade}`}</p>

--- a/web/app/(admin)/admin/streams/new/page.tsx
+++ b/web/app/(admin)/admin/streams/new/page.tsx
@@ -26,8 +26,7 @@ export default function AdminStreamsNewPage() {
   const [error, setError] = useState<string | null>(null);
 
   const clientError = validateCode(code);
-  const canSubmit =
-    !clientError && displayName.trim().length > 0 && !submitting;
+  const canSubmit = !clientError && displayName.trim().length > 0 && !submitting;
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -63,7 +62,8 @@ export default function AdminStreamsNewPage() {
       </Link>
       <h1 className="mb-1 text-2xl font-bold text-gray-900">New Stream</h1>
       <p className="mb-6 text-sm text-gray-500">
-        Custom streams can be referenced from the Upload page as soon as they're created.
+        Custom streams can be referenced from the Upload page as soon as they&apos;re
+        created.
       </p>
 
       <form
@@ -71,9 +71,7 @@ export default function AdminStreamsNewPage() {
         className="space-y-5 rounded-xl border border-gray-200 bg-white p-6"
       >
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-gray-700">
-            Code
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-gray-700">Code</label>
           <input
             type="text"
             value={code}

--- a/web/app/(admin)/admin/streams/page.tsx
+++ b/web/app/(admin)/admin/streams/page.tsx
@@ -3,14 +3,7 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
-import {
-  Archive,
-  ArchiveRestore,
-  Layers,
-  Plus,
-  Search,
-  Trash2,
-} from "lucide-react";
+import { Archive, ArchiveRestore, Layers, Plus, Search, Trash2 } from "lucide-react";
 import {
   archiveStream,
   deleteStream,
@@ -51,9 +44,7 @@ export default function AdminStreamsPage() {
     });
     if (!f) return sorted;
     return sorted.filter(
-      (s) =>
-        s.code.toLowerCase().includes(f) ||
-        s.display_name.toLowerCase().includes(f),
+      (s) => s.code.toLowerCase().includes(f) || s.display_name.toLowerCase().includes(f),
     );
   }, [data, filter]);
 
@@ -114,14 +105,12 @@ export default function AdminStreamsPage() {
       </div>
 
       {isLoading && <p className="text-sm text-gray-500">Loading…</p>}
-      {error && (
-        <p className="text-sm text-red-600">Failed to load streams.</p>
-      )}
+      {error && <p className="text-sm text-red-600">Failed to load streams.</p>}
 
       {data && (
         <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
           <table className="w-full text-sm">
-            <thead className="border-b border-gray-200 bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+            <thead className="border-b border-gray-200 bg-gray-50 text-xs tracking-wide text-gray-500 uppercase">
               <tr>
                 <th className="px-4 py-3 text-left font-medium">Code</th>
                 <th className="px-4 py-3 text-left font-medium">Display name</th>
@@ -194,7 +183,9 @@ export default function AdminStreamsPage() {
                         )}
                         <button
                           onClick={() => {
-                            if (confirm(`Delete stream '${s.code}'? This cannot be undone.`)) {
+                            if (
+                              confirm(`Delete stream '${s.code}'? This cannot be undone.`)
+                            ) {
                               deleteMut.mutate(s.code);
                             }
                           }}
@@ -203,10 +194,10 @@ export default function AdminStreamsPage() {
                             deletable
                               ? "Delete"
                               : s.is_system
-                              ? "System streams can't be deleted"
-                              : s.curricula_count > 0
-                              ? `${s.curricula_count} curriculum(s) still use this stream — merge first`
-                              : "Archive before deleting"
+                                ? "System streams can't be deleted"
+                                : s.curricula_count > 0
+                                  ? `${s.curricula_count} curriculum(s) still use this stream — merge first`
+                                  : "Archive before deleting"
                           }
                           className={cn(
                             "inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs",
@@ -224,7 +215,10 @@ export default function AdminStreamsPage() {
               })}
               {filtered.length === 0 && (
                 <tr>
-                  <td colSpan={6} className="px-4 py-10 text-center text-sm text-gray-500">
+                  <td
+                    colSpan={6}
+                    className="px-4 py-10 text-center text-sm text-gray-500"
+                  >
                     No streams match.
                   </td>
                 </tr>

--- a/web/app/(public)/about/_content.tsx
+++ b/web/app/(public)/about/_content.tsx
@@ -280,9 +280,9 @@ function AuthenticatedAbout({ data }: { data: AboutBuildData }) {
           About StudyBuddy
         </h1>
         <p className="mt-4 max-w-2xl text-lg text-gray-600">
-          StudyBuddy is an AI-powered learning platform for Grades 5–12. Lessons,
-          quizzes, and audio are pre-generated so students get instant responses — no API
-          keys, no wait time, and no internet required for cached content.
+          StudyBuddy is an AI-powered learning platform for Grades 5–12. Lessons, quizzes,
+          and audio are pre-generated so students get instant responses — no API keys, no
+          wait time, and no internet required for cached content.
         </p>
       </div>
 

--- a/web/app/(public)/demo/teacher/login/page.tsx
+++ b/web/app/(public)/demo/teacher/login/page.tsx
@@ -34,7 +34,9 @@ function resolveLoginError(
 /** Decode the teacher_name claim from a JWT (base64url payload, no verification needed client-side). */
 function decodeTeacherName(token: string): string | null {
   try {
-    const payload = JSON.parse(atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")));
+    const payload = JSON.parse(
+      atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")),
+    );
     return typeof payload.teacher_name === "string" ? payload.teacher_name : null;
   } catch {
     return null;

--- a/web/app/(public)/page.tsx
+++ b/web/app/(public)/page.tsx
@@ -5,7 +5,15 @@ import { Card, CardContent } from "@/components/ui/card";
 import { LinkButton } from "@/components/ui/link-button";
 import { DemoRequestModal } from "@/components/demo/DemoRequestModal";
 import { DemoTeacherRequestModal } from "@/components/demo/DemoTeacherRequestModal";
-import { Zap, Volume2, Globe, WifiOff, ClipboardList, School, ArrowRight } from "lucide-react";
+import {
+  Zap,
+  Volume2,
+  Globe,
+  WifiOff,
+  ClipboardList,
+  School,
+  ArrowRight,
+} from "lucide-react";
 
 export default function LandingPage() {
   return (
@@ -34,20 +42,27 @@ export default function LandingPage() {
 // Each phrase captures the "learning companion" concept in its language —
 // the intended meaning behind the StudyBuddy name.
 const STUDY_BUDDY_TRANSLATIONS = [
-  "Learning Companion",          // English
-  "Compañero de Aprendizaje",    // Spanish
-  "Напарник в обучении",         // Russian
-  "Compagnon d'Apprentissage",   // French
-  "Lernbegleiter",               // German
-  "கற்றல் தோழன்",                // Tamil
-  "सीखने का साथी",               // Hindi
-  "అభ్యాస సహచరుడు",             // Telugu
-  "ಕಲಿಕೆಯ ಸಂಗಾತಿ",              // Kannada
-  "പഠന സഹചാരി",                 // Malayalam
+  "Learning Companion", // English
+  "Compañero de Aprendizaje", // Spanish
+  "Напарник в обучении", // Russian
+  "Compagnon d'Apprentissage", // French
+  "Lernbegleiter", // German
+  "கற்றல் தோழன்", // Tamil
+  "सीखने का साथी", // Hindi
+  "అభ్యాస సహచరుడు", // Telugu
+  "ಕಲಿಕೆಯ ಸಂಗಾತಿ", // Kannada
+  "പഠന സഹചാരി", // Malayalam
 ];
 
 // Vary font sizes by position to give a natural scattered feel
-const SIZE_CLASSES = ["text-sm", "text-base", "text-lg", "text-xl", "text-sm", "text-base"];
+const SIZE_CLASSES = [
+  "text-sm",
+  "text-base",
+  "text-lg",
+  "text-xl",
+  "text-sm",
+  "text-base",
+];
 
 function HeroSection() {
   const t = useTranslations("landing");
@@ -58,12 +73,12 @@ function HeroSection() {
       {/* Decorative multilingual watermark — purely visual, hidden from assistive tech */}
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 flex flex-wrap content-start gap-x-10 gap-y-5 p-6 select-none opacity-[0.22]"
+        className="pointer-events-none absolute inset-0 flex flex-wrap content-start gap-x-10 gap-y-5 p-6 opacity-[0.22] select-none"
       >
         {repeated.map((phrase, i) => (
           <span
             key={i}
-            className={`${SIZE_CLASSES[i % SIZE_CLASSES.length]} font-semibold text-blue-800 whitespace-nowrap`}
+            className={`${SIZE_CLASSES[i % SIZE_CLASSES.length]} font-semibold whitespace-nowrap text-blue-800`}
           >
             {phrase}
           </span>
@@ -153,15 +168,15 @@ function TourGatewaySection() {
   return (
     <section className="border-y bg-violet-50 px-4 py-16">
       <div className="mx-auto max-w-3xl text-center">
-        <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-violet-500">
+        <p className="mb-2 text-xs font-semibold tracking-widest text-violet-500 uppercase">
           No account needed
         </p>
         <h2 className="mb-3 text-2xl font-bold text-gray-900 sm:text-3xl">
           See exactly what you can do
         </h2>
         <p className="mb-8 text-base text-gray-500">
-          Walk through the platform from the perspective of a School Admin, Teacher, or Student —
-          before you register.
+          Walk through the platform from the perspective of a School Admin, Teacher, or
+          Student — before you register.
         </p>
         <Link
           href="/tour"

--- a/web/app/(public)/school/change-password/page.tsx
+++ b/web/app/(public)/school/change-password/page.tsx
@@ -25,7 +25,8 @@ export default function ChangePasswordPage() {
 
   // Read token from localStorage (safe — runs client-side only)
   useEffect(() => {
-    const t = localStorage.getItem("sb_teacher_token") ?? localStorage.getItem("sb_token");
+    const t =
+      localStorage.getItem("sb_teacher_token") ?? localStorage.getItem("sb_token");
     if (!t) {
       router.replace("/school/login");
     } else {
@@ -85,9 +86,7 @@ export default function ChangePasswordPage() {
           {isRequired && (
             <div className="mt-2 flex items-start gap-2 rounded-md bg-amber-50 px-3 py-2 text-left text-sm text-amber-800">
               <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
-              <span>
-                You must set a new password before you can access the portal.
-              </span>
+              <span>You must set a new password before you can access the portal.</span>
             </div>
           )}
         </CardHeader>
@@ -103,17 +102,24 @@ export default function ChangePasswordPage() {
                   autoComplete="current-password"
                   required
                   value={currentPassword}
-                  onChange={(e) => { setCurrentPassword(e.target.value); setError(null); }}
+                  onChange={(e) => {
+                    setCurrentPassword(e.target.value);
+                    setError(null);
+                  }}
                   placeholder="Your current / temporary password"
                   className="pr-10"
                 />
                 <button
                   type="button"
                   onClick={() => setShowCurrent((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                  className="absolute top-1/2 right-3 -translate-y-1/2 text-gray-400 hover:text-gray-600"
                   aria-label={showCurrent ? "Hide password" : "Show password"}
                 >
-                  {showCurrent ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  {showCurrent ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
                 </button>
               </div>
             </div>
@@ -127,14 +133,17 @@ export default function ChangePasswordPage() {
                   autoComplete="new-password"
                   required
                   value={newPassword}
-                  onChange={(e) => { setNewPassword(e.target.value); setError(null); }}
+                  onChange={(e) => {
+                    setNewPassword(e.target.value);
+                    setError(null);
+                  }}
                   placeholder="At least 12 characters"
                   className="pr-10"
                 />
                 <button
                   type="button"
                   onClick={() => setShowNew((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                  className="absolute top-1/2 right-3 -translate-y-1/2 text-gray-400 hover:text-gray-600"
                   aria-label={showNew ? "Hide password" : "Show password"}
                 >
                   {showNew ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
@@ -151,13 +160,18 @@ export default function ChangePasswordPage() {
                 autoComplete="new-password"
                 required
                 value={confirmPassword}
-                onChange={(e) => { setConfirmPassword(e.target.value); setError(null); }}
+                onChange={(e) => {
+                  setConfirmPassword(e.target.value);
+                  setError(null);
+                }}
                 placeholder="Repeat new password"
               />
             </div>
 
             {error && (
-              <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>
+              <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+                {error}
+              </p>
             )}
 
             <Button

--- a/web/app/(public)/school/login/page.tsx
+++ b/web/app/(public)/school/login/page.tsx
@@ -82,7 +82,10 @@ export default function SchoolLoginPage() {
                 autoComplete="email"
                 required
                 value={email}
-                onChange={(e) => { setEmail(e.target.value); setError(null); }}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  setError(null);
+                }}
                 placeholder="you@school.edu"
               />
             </div>
@@ -96,23 +99,32 @@ export default function SchoolLoginPage() {
                   autoComplete="current-password"
                   required
                   value={password}
-                  onChange={(e) => { setPassword(e.target.value); setError(null); }}
+                  onChange={(e) => {
+                    setPassword(e.target.value);
+                    setError(null);
+                  }}
                   placeholder="••••••••••••"
                   className="pr-10"
                 />
                 <button
                   type="button"
                   onClick={() => setShowPassword((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                  className="absolute top-1/2 right-3 -translate-y-1/2 text-gray-400 hover:text-gray-600"
                   aria-label={showPassword ? "Hide password" : "Show password"}
                 >
-                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  {showPassword ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
                 </button>
               </div>
             </div>
 
             {error && (
-              <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>
+              <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+                {error}
+              </p>
             )}
 
             <Button

--- a/web/app/(public)/school/register/page.tsx
+++ b/web/app/(public)/school/register/page.tsx
@@ -69,14 +69,14 @@ export default function SchoolRegisterPage() {
       if (status === 409) {
         setError("A school with that email already exists. Try signing in instead.");
       } else if (status === 422) {
-        const detail = (err as { response?: { data?: { detail?: unknown } } })
-          ?.response?.data?.detail;
+        const detail = (err as { response?: { data?: { detail?: unknown } } })?.response
+          ?.data?.detail;
         const msg =
           typeof detail === "string"
             ? detail
             : Array.isArray(detail)
-            ? (detail[0] as { msg?: string })?.msg ?? "Validation error."
-            : "Invalid details. Please check your entries.";
+              ? ((detail[0] as { msg?: string })?.msg ?? "Validation error.")
+              : "Invalid details. Please check your entries.";
         setError(msg);
       } else {
         setError("Something went wrong. Please try again.");
@@ -109,7 +109,10 @@ export default function SchoolRegisterPage() {
               <Input
                 id="school_name"
                 value={schoolName}
-                onChange={(e) => { setSchoolName(e.target.value); setError(null); }}
+                onChange={(e) => {
+                  setSchoolName(e.target.value);
+                  setError(null);
+                }}
                 placeholder="Westview Academy"
                 required
               />
@@ -122,7 +125,10 @@ export default function SchoolRegisterPage() {
                 type="email"
                 autoComplete="email"
                 value={email}
-                onChange={(e) => { setEmail(e.target.value); setError(null); }}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  setError(null);
+                }}
                 placeholder="admin@westview.edu"
                 required
               />
@@ -156,7 +162,10 @@ export default function SchoolRegisterPage() {
                   type={showPassword ? "text" : "password"}
                   autoComplete="new-password"
                   value={password}
-                  onChange={(e) => { setPassword(e.target.value); setError(null); }}
+                  onChange={(e) => {
+                    setPassword(e.target.value);
+                    setError(null);
+                  }}
                   placeholder="At least 12 characters"
                   className="pr-10"
                   required
@@ -164,10 +173,14 @@ export default function SchoolRegisterPage() {
                 <button
                   type="button"
                   onClick={() => setShowPassword((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                  className="absolute top-1/2 right-3 -translate-y-1/2 text-gray-400 hover:text-gray-600"
                   aria-label={showPassword ? "Hide password" : "Show password"}
                 >
-                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  {showPassword ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
                 </button>
               </div>
               <p className="text-xs text-gray-400">Minimum 12 characters</p>
@@ -181,19 +194,24 @@ export default function SchoolRegisterPage() {
                   type={showPassword ? "text" : "password"}
                   autoComplete="new-password"
                   value={confirmPassword}
-                  onChange={(e) => { setConfirmPassword(e.target.value); setError(null); }}
+                  onChange={(e) => {
+                    setConfirmPassword(e.target.value);
+                    setError(null);
+                  }}
                   placeholder="Repeat password"
                   className="pr-10"
                   required
                 />
                 {confirmPassword && password === confirmPassword && (
-                  <Check className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-green-500" />
+                  <Check className="absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 text-green-500" />
                 )}
               </div>
             </div>
 
             {error && (
-              <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>
+              <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+                {error}
+              </p>
             )}
 
             <Button

--- a/web/app/(public)/teacher/dashboard/page.tsx
+++ b/web/app/(public)/teacher/dashboard/page.tsx
@@ -77,9 +77,8 @@ export default function DemoTeacherDashboard() {
           </h1>
           {email && <p className="text-sm text-gray-500">{email}</p>}
           <p className="mt-3 text-sm text-gray-600">
-            This is a 48-hour demo environment. Explore the teacher features below.
-            Your account and any data created here will be removed after the demo
-            period ends.
+            This is a 48-hour demo environment. Explore the teacher features below. Your
+            account and any data created here will be removed after the demo period ends.
           </p>
         </div>
 

--- a/web/app/(public)/tour/page.tsx
+++ b/web/app/(public)/tour/page.tsx
@@ -70,15 +70,15 @@ export default function TourPage() {
     <div className="min-h-screen bg-gray-50">
       {/* Hero */}
       <div className="border-b bg-white px-6 py-14 text-center">
-        <p className="mb-2 text-sm font-semibold uppercase tracking-widest text-violet-600">
+        <p className="mb-2 text-sm font-semibold tracking-widest text-violet-600 uppercase">
           No account needed
         </p>
         <h1 className="text-3xl font-bold text-gray-900 sm:text-4xl">
           Explore the platform
         </h1>
         <p className="mx-auto mt-4 max-w-xl text-base text-gray-500">
-          Choose a role to see exactly what you can do with StudyBuddy OnDemand.
-          Each tour walks through the key capabilities, step by step.
+          Choose a role to see exactly what you can do with StudyBuddy OnDemand. Each tour
+          walks through the key capabilities, step by step.
         </p>
       </div>
 
@@ -96,9 +96,7 @@ export default function TourPage() {
                 <div className={`mb-4 inline-flex w-fit rounded-lg p-3 ${c.icon}`}>
                   <Icon className="h-6 w-6" />
                 </div>
-                <h2 className="mb-1 text-lg font-semibold text-gray-900">
-                  {role.label}
-                </h2>
+                <h2 className="mb-1 text-lg font-semibold text-gray-900">{role.label}</h2>
                 <p className="mb-6 flex-1 text-sm leading-relaxed text-gray-500">
                   {role.description}
                 </p>

--- a/web/app/(public)/tour/school-admin/page.tsx
+++ b/web/app/(public)/tour/school-admin/page.tsx
@@ -74,17 +74,31 @@ const STEPS: Step[] = [
     detail: (
       <>
         <p className="mb-3 text-sm leading-relaxed text-gray-600">
-          StudyBuddy provides a growing catalog of pre-built platform curriculum
-          packages. If your school needs custom content — a specific syllabus, regional
-          requirements, or a language not yet in the catalog — you can define and build
-          it yourself:
+          StudyBuddy provides a growing catalog of pre-built platform curriculum packages.
+          If your school needs custom content — a specific syllabus, regional
+          requirements, or a language not yet in the catalog — you can define and build it
+          yourself:
         </p>
-        <ol className="mb-3 space-y-1.5 pl-5 text-sm text-gray-600" style={{ listStyleType: "decimal" }}>
-          <li>Submit a <strong>Curriculum Definition</strong> — a structured list of subjects and units.</li>
-          <li>A platform reviewer approves the definition (typically within 24 hours).</li>
-          <li>You trigger the AI content build. A cost estimate is shown before you confirm.</li>
-          <li>The pipeline generates content in the background (15–60 minutes per grade).</li>
-          <li>The finished curriculum package appears in your catalog, ready to assign.</li>
+        <ol
+          className="mb-3 space-y-1.5 pl-5 text-sm text-gray-600"
+          style={{ listStyleType: "decimal" }}
+        >
+          <li>
+            Submit a <strong>Curriculum Definition</strong> — a structured list of
+            subjects and units.
+          </li>
+          <li>
+            A platform reviewer approves the definition (typically within 24 hours).
+          </li>
+          <li>
+            You trigger the AI content build. A cost estimate is shown before you confirm.
+          </li>
+          <li>
+            The pipeline generates content in the background (15–60 minutes per grade).
+          </li>
+          <li>
+            The finished curriculum package appears in your catalog, ready to assign.
+          </li>
         </ol>
         <p className="text-sm text-gray-500">
           Build costs depend on your subscription plan. Starter plans include a fixed
@@ -112,21 +126,36 @@ const STEPS: Step[] = [
           <table className="w-full text-sm">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   Action
                 </th>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   Result
                 </th>
               </tr>
             </thead>
             <tbody className="divide-y">
               {[
-                ["Create a classroom", "An empty container with a name, optional grade and teacher"],
-                ["Assign a curriculum package", "Students in the classroom can access that package's content"],
-                ["Reorder packages", "Controls the sequence students work through content"],
-                ["Enrol a student", "Student gains access to all packages assigned to the classroom"],
-                ["Archive a classroom", "Classroom hidden from active views; data preserved"],
+                [
+                  "Create a classroom",
+                  "An empty container with a name, optional grade and teacher",
+                ],
+                [
+                  "Assign a curriculum package",
+                  "Students in the classroom can access that package's content",
+                ],
+                [
+                  "Reorder packages",
+                  "Controls the sequence students work through content",
+                ],
+                [
+                  "Enrol a student",
+                  "Student gains access to all packages assigned to the classroom",
+                ],
+                [
+                  "Archive a classroom",
+                  "Classroom hidden from active views; data preserved",
+                ],
               ].map(([action, result]) => (
                 <tr key={action} className="bg-white">
                   <td className="px-4 py-2.5 font-medium text-gray-800">{action}</td>
@@ -146,30 +175,39 @@ const STEPS: Step[] = [
     detail: (
       <>
         <p className="mb-4 text-sm leading-relaxed text-gray-600">
-          StudyBuddy tracks every lesson view, quiz attempt, and session duration for
-          each student. School Admins see aggregate metrics across the whole school.
-          Teachers see metrics for their assigned students. An "at-risk" flag is raised
-          automatically when a student's activity falls below their class average for
-          seven consecutive days. Admins can download class-level and school-level
-          reports as CSV.
+          StudyBuddy tracks every lesson view, quiz attempt, and session duration for each
+          student. School Admins see aggregate metrics across the whole school. Teachers
+          see metrics for their assigned students. An &ldquo;at-risk&rdquo; flag is raised
+          automatically when a student&apos;s activity falls below their class average for
+          seven consecutive days. Admins can download class-level and school-level reports
+          as CSV.
         </p>
         <div className="overflow-hidden rounded-lg border">
           <table className="w-full text-sm">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   Report
                 </th>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   Contents
                 </th>
               </tr>
             </thead>
             <tbody className="divide-y">
               {[
-                ["Class overview", "Completion rate, quiz average, streak, last activity — per student"],
-                ["At-risk students", "Students flagged as at-risk with days since last activity"],
-                ["Unit performance", "Average quiz score per unit across all students in a class"],
+                [
+                  "Class overview",
+                  "Completion rate, quiz average, streak, last activity — per student",
+                ],
+                [
+                  "At-risk students",
+                  "Students flagged as at-risk with days since last activity",
+                ],
+                [
+                  "Unit performance",
+                  "Average quiz score per unit across all students in a class",
+                ],
                 ["School summary", "Aggregated metrics across all classrooms"],
               ].map(([report, contents]) => (
                 <tr key={report} className="bg-white">
@@ -205,9 +243,7 @@ export default function SchoolAdminTour() {
             <ArrowLeft className="h-4 w-4" />
             All roles
           </Link>
-          <span className="text-sm font-medium text-violet-700">
-            School Admin tour
-          </span>
+          <span className="text-sm font-medium text-violet-700">School Admin tour</span>
           <span className="text-sm text-gray-400">
             {current + 1} / {STEPS.length}
           </span>
@@ -227,8 +263,8 @@ export default function SchoolAdminTour() {
                   i < current
                     ? "h-1.5 bg-violet-400"
                     : i === current
-                    ? "h-2 bg-violet-600"
-                    : "h-1.5 bg-gray-200"
+                      ? "h-2 bg-violet-600"
+                      : "h-1.5 bg-gray-200"
                 }`}
               />
             ))}
@@ -250,7 +286,7 @@ export default function SchoolAdminTour() {
       {/* Step content */}
       <div className="mx-auto max-w-3xl px-6 py-10">
         {/* Step label */}
-        <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-violet-500">
+        <p className="mb-2 text-xs font-semibold tracking-widest text-violet-500 uppercase">
           Step {current + 1} of {STEPS.length}
         </p>
 
@@ -260,9 +296,7 @@ export default function SchoolAdminTour() {
         </h1>
 
         {/* Outcome — the "why it matters" sentence */}
-        <p className="mb-6 text-base font-medium text-violet-700">
-          {step.outcome}
-        </p>
+        <p className="mb-6 text-base font-medium text-violet-700">{step.outcome}</p>
 
         {/* Detail */}
         <div className="mb-8">
@@ -342,7 +376,7 @@ export default function SchoolAdminTour() {
       {/* Step index — quick jump on desktop */}
       <div className="border-t bg-white py-6">
         <div className="mx-auto max-w-3xl px-6">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-gray-400">
+          <p className="mb-3 text-xs font-semibold tracking-widest text-gray-400 uppercase">
             All capabilities
           </p>
           <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
@@ -354,8 +388,8 @@ export default function SchoolAdminTour() {
                   i === current
                     ? "border-violet-300 bg-violet-50 font-semibold text-violet-800"
                     : i < current
-                    ? "border-gray-200 bg-gray-50 text-gray-500"
-                    : "border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50"
+                      ? "border-gray-200 bg-gray-50 text-gray-500"
+                      : "border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50"
                 }`}
               >
                 <span className="mr-1.5 text-xs text-gray-400">{i + 1}.</span>

--- a/web/app/(public)/tour/student/page.tsx
+++ b/web/app/(public)/tour/student/page.tsx
@@ -38,7 +38,7 @@ const STEPS: Step[] = [
     detail: (
       <>
         <p className="mb-3 text-sm leading-relaxed text-gray-600">
-          You don't sign up for StudyBuddy — your school does. Here's how your
+          You don&apos;t sign up for StudyBuddy — your school does. Here&apos;s how your
           account reaches you:
         </p>
         <ol
@@ -46,28 +46,27 @@ const STEPS: Step[] = [
           style={{ listStyleType: "decimal" }}
         >
           <li>
-            Your School Admin provisions your account and the system sends you a
-            welcome email with a temporary password.
+            Your School Admin provisions your account and the system sends you a welcome
+            email with a temporary password.
           </li>
           <li>
-            Open the link in the email and enter your school email address and
-            the temporary password.
+            Open the link in the email and enter your school email address and the
+            temporary password.
           </li>
           <li>
-            You are immediately taken to a{" "}
-            <strong>Change Password screen</strong>. Enter a new permanent
-            password (at least 12 characters) and confirm it.
+            You are immediately taken to a <strong>Change Password screen</strong>. Enter
+            a new permanent password (at least 12 characters) and confirm it.
           </li>
           <li>
-            Click <strong>Save password</strong> — you land on the student
-            dashboard and your content is ready.
+            Click <strong>Save password</strong> — you land on the student dashboard and
+            your content is ready.
           </li>
         </ol>
         <p className="text-sm text-gray-500">
-          You cannot skip the Change Password screen. All portal pages redirect
-          back to it until it is complete. If you later forget your password,
-          the Forgot password link on the login page sends a reset link to your
-          school email — no need to contact anyone.
+          You cannot skip the Change Password screen. All portal pages redirect back to it
+          until it is complete. If you later forget your password, the Forgot password
+          link on the login page sends a reset link to your school email — no need to
+          contact anyone.
         </p>
       </>
     ),
@@ -82,30 +81,41 @@ const STEPS: Step[] = [
     detail: (
       <>
         <p className="mb-3 text-sm leading-relaxed text-gray-600">
-          The content you see is determined entirely by your classroom
-          enrolment. Your teacher assigns curriculum packages to your
-          classroom — you see exactly those subjects, nothing more and nothing
-          less.
+          The content you see is determined entirely by your classroom enrolment. Your
+          teacher assigns curriculum packages to your classroom — you see exactly those
+          subjects, nothing more and nothing less.
         </p>
         <div className="overflow-hidden rounded-lg border">
           <table className="w-full text-sm">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   Content type
                 </th>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   What it is
                 </th>
               </tr>
             </thead>
             <tbody className="divide-y">
               {[
-                ["Lesson", "Text + diagrams explaining the topic. Saves your place automatically."],
-                ["Audio", "A spoken reading of the lesson — tap play and listen instead of reading."],
-                ["Quiz", "Questions on the lesson content. Instant results, unlimited retakes."],
+                [
+                  "Lesson",
+                  "Text + diagrams explaining the topic. Saves your place automatically.",
+                ],
+                [
+                  "Audio",
+                  "A spoken reading of the lesson — tap play and listen instead of reading.",
+                ],
+                [
+                  "Quiz",
+                  "Questions on the lesson content. Instant results, unlimited retakes.",
+                ],
                 ["Tutorial", "Step-by-step worked examples with guided exercises."],
-                ["Experiment", "Interactive lab steps for science units (where applicable)."],
+                [
+                  "Experiment",
+                  "Interactive lab steps for science units (where applicable).",
+                ],
               ].map(([type, desc]) => (
                 <tr key={type} className="bg-white">
                   <td className="px-4 py-2.5 font-medium text-gray-800">{type}</td>
@@ -116,7 +126,7 @@ const STEPS: Step[] = [
           </table>
         </div>
         <p className="mt-3 text-sm text-gray-500">
-          If your home screen is empty or shows "No content available", your
+          If your home screen is empty or shows &ldquo;No content available&rdquo;, your
           teacher may not have assigned a curriculum package yet — contact them.
         </p>
       </>
@@ -129,18 +139,17 @@ const STEPS: Step[] = [
     detail: (
       <>
         <p className="mb-3 text-sm leading-relaxed text-gray-600">
-          Each subject is made up of units. Open any unit to see its lesson,
-          quiz, and tutorial. There is no fixed schedule inside a unit —
-          read the lesson, listen to the audio, do the quiz in any order that
-          works for you.
+          Each subject is made up of units. Open any unit to see its lesson, quiz, and
+          tutorial. There is no fixed schedule inside a unit — read the lesson, listen to
+          the audio, do the quiz in any order that works for you.
         </p>
         <ol
           className="mb-4 space-y-2 pl-5 text-sm text-gray-600"
           style={{ listStyleType: "decimal" }}
         >
           <li>
-            From the home screen, click a <strong>subject card</strong> (e.g.
-            Mathematics, Physical Science).
+            From the home screen, click a <strong>subject card</strong> (e.g. Mathematics,
+            Physical Science).
           </li>
           <li>Click a unit name to open it.</li>
           <li>
@@ -148,17 +157,16 @@ const STEPS: Step[] = [
             <strong>Tutorial</strong> — to switch between content types.
           </li>
           <li>
-            Scroll through the lesson. Your progress saves as you go — no save
-            button.
+            Scroll through the lesson. Your progress saves as you go — no save button.
           </li>
           <li>
-            Close the app or browser at any time. When you return, the lesson
-            opens where you left off.
+            Close the app or browser at any time. When you return, the lesson opens where
+            you left off.
           </li>
         </ol>
         <p className="text-sm text-gray-500">
-          Your lesson view is recorded the moment you open a unit. This
-          contributes to your completion rate and keeps your study streak alive.
+          Your lesson view is recorded the moment you open a unit. This contributes to
+          your completion rate and keeps your study streak alive.
         </p>
       </>
     ),
@@ -170,18 +178,18 @@ const STEPS: Step[] = [
     detail: (
       <>
         <p className="mb-4 text-sm leading-relaxed text-gray-600">
-          Quizzes are designed to help you learn, not just test you. You get the
-          correct answer and an explanation for every question you got wrong, so
-          each attempt builds on the last.
+          Quizzes are designed to help you learn, not just test you. You get the correct
+          answer and an explanation for every question you got wrong, so each attempt
+          builds on the last.
         </p>
         <div className="overflow-hidden rounded-lg border">
           <table className="w-full text-sm">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   How it works
                 </th>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   Detail
                 </th>
               </tr>
@@ -189,9 +197,18 @@ const STEPS: Step[] = [
             <tbody className="divide-y">
               {[
                 ["Attempts", "Unlimited — retake any quiz as many times as you like."],
-                ["Scoring", "Each attempt is scored separately. Only your best score is kept."],
-                ["Results", "Shown immediately after submit — correct answers + explanations for wrong answers."],
-                ["Teacher view", "Your teacher sees your best score per quiz, not individual attempts."],
+                [
+                  "Scoring",
+                  "Each attempt is scored separately. Only your best score is kept.",
+                ],
+                [
+                  "Results",
+                  "Shown immediately after submit — correct answers + explanations for wrong answers.",
+                ],
+                [
+                  "Teacher view",
+                  "Your teacher sees your best score per quiz, not individual attempts.",
+                ],
                 ["Sequence", "Questions may appear in a different order on each retake."],
               ].map(([how, detail]) => (
                 <tr key={how} className="bg-white">
@@ -212,26 +229,35 @@ const STEPS: Step[] = [
     detail: (
       <>
         <p className="mb-4 text-sm leading-relaxed text-gray-600">
-          Every lesson view, quiz attempt, and tutorial session is recorded.
-          Here is what each metric means:
+          Every lesson view, quiz attempt, and tutorial session is recorded. Here is what
+          each metric means:
         </p>
         <div className="overflow-hidden rounded-lg border">
           <table className="w-full text-sm">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   Metric
                 </th>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   Definition
                 </th>
               </tr>
             </thead>
             <tbody className="divide-y">
               {[
-                ["Completion rate", "% of units you've opened at least once across all assigned packages."],
-                ["Quiz average", "Average of your best score per quiz, across all quizzes."],
-                ["Streak", "Consecutive days with any activity — lesson, quiz, or tutorial. Resets if a full day passes with nothing."],
+                [
+                  "Completion rate",
+                  "% of units you've opened at least once across all assigned packages.",
+                ],
+                [
+                  "Quiz average",
+                  "Average of your best score per quiz, across all quizzes.",
+                ],
+                [
+                  "Streak",
+                  "Consecutive days with any activity — lesson, quiz, or tutorial. Resets if a full day passes with nothing.",
+                ],
                 ["Last active", "The most recent date you did anything in the portal."],
               ].map(([metric, def]) => (
                 <tr key={metric} className="bg-white">
@@ -243,9 +269,9 @@ const STEPS: Step[] = [
           </table>
         </div>
         <p className="mt-3 text-sm text-gray-500">
-          If you haven't been active for 7 or more days, your teacher sees an
-          at-risk flag next to your name. It clears automatically the moment you
-          study again — no action needed on your part.
+          If you haven&apos;t been active for 7 or more days, your teacher sees an at-risk
+          flag next to your name. It clears automatically the moment you study again — no
+          action needed on your part.
         </p>
       </>
     ),
@@ -272,9 +298,7 @@ export default function StudentTour() {
             <ArrowLeft className="h-4 w-4" />
             All roles
           </Link>
-          <span className="text-sm font-medium text-green-700">
-            Student tour
-          </span>
+          <span className="text-sm font-medium text-green-700">Student tour</span>
           <span className="text-sm text-gray-400">
             {current + 1} / {STEPS.length}
           </span>
@@ -294,8 +318,8 @@ export default function StudentTour() {
                   i < current
                     ? "h-1.5 bg-green-400"
                     : i === current
-                    ? "h-2 bg-green-600"
-                    : "h-1.5 bg-gray-200"
+                      ? "h-2 bg-green-600"
+                      : "h-1.5 bg-gray-200"
                 }`}
               />
             ))}
@@ -316,7 +340,7 @@ export default function StudentTour() {
 
       {/* Step content */}
       <div className="mx-auto max-w-3xl px-6 py-10">
-        <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-green-500">
+        <p className="mb-2 text-xs font-semibold tracking-widest text-green-500 uppercase">
           Step {current + 1} of {STEPS.length}
         </p>
 
@@ -324,9 +348,7 @@ export default function StudentTour() {
           {step.title}
         </h1>
 
-        <p className="mb-6 text-base font-medium text-green-700">
-          {step.outcome}
-        </p>
+        <p className="mb-6 text-base font-medium text-green-700">{step.outcome}</p>
 
         <div className="mb-8">
           {typeof step.detail === "string" ? (
@@ -375,13 +397,11 @@ export default function StudentTour() {
         ) : (
           /* Final step CTA — students cannot self-register */
           <div className="rounded-xl border border-green-200 bg-green-50 p-6 text-center">
-            <p className="mb-1 text-lg font-bold text-green-900">
-              Ready to get started?
-            </p>
+            <p className="mb-1 text-lg font-bold text-green-900">Ready to get started?</p>
             <p className="mb-5 text-sm text-green-700">
-              Student accounts are set up by your school. Ask your teacher or
-              School Admin for your login details — they'll send you an email
-              with your temporary password.
+              Student accounts are set up by your school. Ask your teacher or School Admin
+              for your login details — they&apos;ll send you an email with your temporary
+              password.
             </p>
             <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
               <Link
@@ -401,7 +421,7 @@ export default function StudentTour() {
             </div>
             <button
               onClick={() => setCurrent((c) => c - 1)}
-              className="mt-4 flex items-center gap-1.5 text-sm text-green-600 hover:underline mx-auto"
+              className="mx-auto mt-4 flex items-center gap-1.5 text-sm text-green-600 hover:underline"
             >
               <ArrowLeft className="h-4 w-4" />
               Review previous step
@@ -413,7 +433,7 @@ export default function StudentTour() {
       {/* Step index — quick jump */}
       <div className="border-t bg-white py-6">
         <div className="mx-auto max-w-3xl px-6">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-gray-400">
+          <p className="mb-3 text-xs font-semibold tracking-widest text-gray-400 uppercase">
             All steps
           </p>
           <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
@@ -425,8 +445,8 @@ export default function StudentTour() {
                   i === current
                     ? "border-green-300 bg-green-50 font-semibold text-green-800"
                     : i < current
-                    ? "border-gray-200 bg-gray-50 text-gray-500"
-                    : "border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50"
+                      ? "border-gray-200 bg-gray-50 text-gray-500"
+                      : "border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50"
                 }`}
               >
                 <span className="mr-1.5 text-xs text-gray-400">{i + 1}.</span>

--- a/web/app/(public)/tour/teacher/page.tsx
+++ b/web/app/(public)/tour/teacher/page.tsx
@@ -38,17 +38,17 @@ const STEPS: Step[] = [
     detail: (
       <>
         <p className="mb-4 text-sm leading-relaxed text-gray-600">
-          As a teacher in the school portal you have access to everything needed
-          to run a personalised, self-paced learning experience for your students:
+          As a teacher in the school portal you have access to everything needed to run a
+          personalised, self-paced learning experience for your students:
         </p>
         <div className="overflow-hidden rounded-lg border">
           <table className="w-full text-sm">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   You can
                 </th>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   Your School Admin handles
                 </th>
               </tr>
@@ -56,9 +56,15 @@ const STEPS: Step[] = [
             <tbody className="divide-y">
               {[
                 ["Create and manage classrooms", "Provisioning teacher accounts"],
-                ["Assign curriculum packages to classrooms", "Provisioning student accounts"],
+                [
+                  "Assign curriculum packages to classrooms",
+                  "Provisioning student accounts",
+                ],
                 ["Enrol students in classrooms", "School subscription and billing"],
-                ["Track per-student progress and quiz scores", "Approving curriculum builds"],
+                [
+                  "Track per-student progress and quiz scores",
+                  "Approving curriculum builds",
+                ],
                 ["Act on at-risk student alerts", "School-wide settings"],
                 ["Download CSV reports", "Promoting teachers to admin"],
               ].map(([can, admin]) => (
@@ -95,22 +101,25 @@ const STEPS: Step[] = [
     detail: (
       <>
         <p className="mb-3 text-sm leading-relaxed text-gray-600">
-          The classroom is the central unit of content delivery. You can have as
-          many classrooms as you need. Here's the lifecycle of a classroom:
+          The classroom is the central unit of content delivery. You can have as many
+          classrooms as you need. Here&apos;s the lifecycle of a classroom:
         </p>
-        <ol className="mb-4 space-y-2 pl-5 text-sm text-gray-600" style={{ listStyleType: "decimal" }}>
+        <ol
+          className="mb-4 space-y-2 pl-5 text-sm text-gray-600"
+          style={{ listStyleType: "decimal" }}
+        >
           <li>
             Go to <strong>Classrooms → Create classroom</strong>. Enter a name (e.g.{" "}
             <em>Grade 8 — Section A</em>) and an optional grade.
           </li>
           <li>
-            Click <strong>Assign package</strong>. Browse the catalog — platform
-            packages and your school's own custom packages are both listed. Assign
-            one or more.
+            Click <strong>Assign package</strong>. Browse the catalog — platform packages
+            and your school&apos;s own custom packages are both listed. Assign one or
+            more.
           </li>
           <li>
-            Reorder packages using the drag handles. Students work through them
-            in that order.
+            Reorder packages using the drag handles. Students work through them in that
+            order.
           </li>
           <li>
             Go to the <strong>Students</strong> tab and enrol your students. Once
@@ -118,8 +127,8 @@ const STEPS: Step[] = [
           </li>
         </ol>
         <p className="text-sm text-gray-500">
-          A classroom with no packages shows no content to students — always
-          assign at least one package before enrolling.
+          A classroom with no packages shows no content to students — always assign at
+          least one package before enrolling.
         </p>
       </>
     ),
@@ -136,7 +145,8 @@ const STEPS: Step[] = [
       "If a student you expect is not in the search results when enrolling, ask your School Admin " +
       "to assign that student to you via Students → the student's name → Assignment.",
     svgSrc: "/assets/tour/student-enrolment-flow.svg",
-    svgAlt: "Student provisioned by admin → assigned to teacher → enrolled in classroom → accesses content",
+    svgAlt:
+      "Student provisioned by admin → assigned to teacher → enrolled in classroom → accesses content",
     svgHeight: 480,
   },
   {
@@ -146,28 +156,40 @@ const STEPS: Step[] = [
     detail: (
       <>
         <p className="mb-4 text-sm leading-relaxed text-gray-600">
-          StudyBuddy records every lesson view, quiz attempt, and session. You see
-          reports scoped to your students only — not the whole school. Each metric
-          is precisely defined so you can interpret it consistently:
+          StudyBuddy records every lesson view, quiz attempt, and session. You see reports
+          scoped to your students only — not the whole school. Each metric is precisely
+          defined so you can interpret it consistently:
         </p>
         <div className="overflow-hidden rounded-lg border">
           <table className="w-full text-sm">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   Metric
                 </th>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   Definition
                 </th>
               </tr>
             </thead>
             <tbody className="divide-y">
               {[
-                ["Completion rate", "% of units in assigned packages the student has opened at least once"],
-                ["Quiz average", "Average of best score per quiz — only the best attempt per quiz counts"],
-                ["Streak", "Consecutive calendar days with at least one lesson view or quiz answer"],
-                ["Last active", "Most recent date of any recorded activity (lesson, quiz, or tutorial)"],
+                [
+                  "Completion rate",
+                  "% of units in assigned packages the student has opened at least once",
+                ],
+                [
+                  "Quiz average",
+                  "Average of best score per quiz — only the best attempt per quiz counts",
+                ],
+                [
+                  "Streak",
+                  "Consecutive calendar days with at least one lesson view or quiz answer",
+                ],
+                [
+                  "Last active",
+                  "Most recent date of any recorded activity (lesson, quiz, or tutorial)",
+                ],
               ].map(([metric, def]) => (
                 <tr key={metric} className="bg-white">
                   <td className="px-4 py-2.5 font-medium text-gray-800">{metric}</td>
@@ -178,8 +200,9 @@ const STEPS: Step[] = [
           </table>
         </div>
         <p className="mt-3 text-sm text-gray-500">
-          Click any student's name to see their full progress detail — unit by unit, quiz by quiz.
-          All reports can be downloaded as CSV for your grade book or admin reports.
+          Click any student&apos;s name to see their full progress detail — unit by unit,
+          quiz by quiz. All reports can be downloaded as CSV for your grade book or admin
+          reports.
         </p>
       </>
     ),
@@ -199,19 +222,28 @@ const STEPS: Step[] = [
           <table className="w-full text-sm">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   Report
                 </th>
-                <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <th className="px-4 py-2.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   Contents
                 </th>
               </tr>
             </thead>
             <tbody className="divide-y">
               {[
-                ["Overview", "Completion rate, quiz average, streak, last activity — one row per student"],
-                ["At-risk", "Flagged students with days since last activity and their classroom"],
-                ["Unit performance", "Average quiz score per unit — highlights units students find difficult"],
+                [
+                  "Overview",
+                  "Completion rate, quiz average, streak, last activity — one row per student",
+                ],
+                [
+                  "At-risk",
+                  "Flagged students with days since last activity and their classroom",
+                ],
+                [
+                  "Unit performance",
+                  "Average quiz score per unit — highlights units students find difficult",
+                ],
               ].map(([report, contents]) => (
                 <tr key={report} className="bg-white">
                   <td className="px-4 py-2.5 font-medium text-gray-800">{report}</td>
@@ -223,7 +255,8 @@ const STEPS: Step[] = [
         </div>
         <p className="mt-3 text-sm text-gray-500">
           Use the Unit performance report alongside the At-risk report: if a student
-          stopped logging in right after a low quiz score, that unit is the likely barrier.
+          stopped logging in right after a low quiz score, that unit is the likely
+          barrier.
         </p>
       </>
     ),
@@ -250,9 +283,7 @@ export default function TeacherTour() {
             <ArrowLeft className="h-4 w-4" />
             All roles
           </Link>
-          <span className="text-sm font-medium text-blue-700">
-            Teacher tour
-          </span>
+          <span className="text-sm font-medium text-blue-700">Teacher tour</span>
           <span className="text-sm text-gray-400">
             {current + 1} / {STEPS.length}
           </span>
@@ -272,8 +303,8 @@ export default function TeacherTour() {
                   i < current
                     ? "h-1.5 bg-blue-400"
                     : i === current
-                    ? "h-2 bg-blue-600"
-                    : "h-1.5 bg-gray-200"
+                      ? "h-2 bg-blue-600"
+                      : "h-1.5 bg-gray-200"
                 }`}
               />
             ))}
@@ -294,7 +325,7 @@ export default function TeacherTour() {
 
       {/* Step content */}
       <div className="mx-auto max-w-3xl px-6 py-10">
-        <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-blue-500">
+        <p className="mb-2 text-xs font-semibold tracking-widest text-blue-500 uppercase">
           Step {current + 1} of {STEPS.length}
         </p>
 
@@ -302,9 +333,7 @@ export default function TeacherTour() {
           {step.title}
         </h1>
 
-        <p className="mb-6 text-base font-medium text-blue-700">
-          {step.outcome}
-        </p>
+        <p className="mb-6 text-base font-medium text-blue-700">{step.outcome}</p>
 
         <div className="mb-8">
           {typeof step.detail === "string" ? (
@@ -353,12 +382,10 @@ export default function TeacherTour() {
         ) : (
           /* Final step CTA */
           <div className="rounded-xl border border-blue-200 bg-blue-50 p-6 text-center">
-            <p className="mb-1 text-lg font-bold text-blue-900">
-              Ready to log in?
-            </p>
+            <p className="mb-1 text-lg font-bold text-blue-900">Ready to log in?</p>
             <p className="mb-5 text-sm text-blue-700">
-              Your School Admin has provisioned your account. Check your email
-              for your temporary password and log in to get started.
+              Your School Admin has provisioned your account. Check your email for your
+              temporary password and log in to get started.
             </p>
             <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
               <Link
@@ -383,7 +410,7 @@ export default function TeacherTour() {
       {/* Step index — quick jump */}
       <div className="border-t bg-white py-6">
         <div className="mx-auto max-w-3xl px-6">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-gray-400">
+          <p className="mb-3 text-xs font-semibold tracking-widest text-gray-400 uppercase">
             All capabilities
           </p>
           <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
@@ -395,8 +422,8 @@ export default function TeacherTour() {
                   i === current
                     ? "border-blue-300 bg-blue-50 font-semibold text-blue-800"
                     : i < current
-                    ? "border-gray-200 bg-gray-50 text-gray-500"
-                    : "border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50"
+                      ? "border-gray-200 bg-gray-50 text-gray-500"
+                      : "border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50"
                 }`}
               >
                 <span className="mr-1.5 text-xs text-gray-400">{i + 1}.</span>

--- a/web/app/(school)/layout.tsx
+++ b/web/app/(school)/layout.tsx
@@ -1,7 +1,11 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { auth0 } from "@/lib/auth0";
-import { getDevSession, getDemoTeacherSession, getLocalTeacherSession } from "@/lib/dev-session";
+import {
+  getDevSession,
+  getDemoTeacherSession,
+  getLocalTeacherSession,
+} from "@/lib/dev-session";
 import { SchoolNav } from "@/components/layout/SchoolNav";
 import { LimitWarningBanner } from "@/components/school/LimitWarningBanner";
 import { LocalAuthGuard } from "@/components/school/LocalAuthGuard";
@@ -25,9 +29,7 @@ export default async function SchoolLayout({ children }: { children: React.React
         {/* LocalAuthGuard validates sb_teacher_token from localStorage,
             enforces first_login redirect (pitfall #24), and renders the
             full portal layout only once the JWT check passes. */}
-        <LocalAuthGuard userName={userName}>
-          {children}
-        </LocalAuthGuard>
+        <LocalAuthGuard userName={userName}>{children}</LocalAuthGuard>
       </QueryProvider>
     );
   }

--- a/web/app/(school)/school/alerts/page.tsx
+++ b/web/app/(school)/school/alerts/page.tsx
@@ -118,9 +118,12 @@ export default function AlertsPage() {
       {!isLoading && visibleAlerts.length === 0 && (
         <div className="flex flex-col items-center gap-3 rounded-xl border border-gray-100 bg-gray-50 py-14 text-gray-400">
           <Bell className="h-10 w-10 opacity-50" />
-          <p className="text-sm font-medium text-gray-600">No active alerts — all clear.</p>
+          <p className="text-sm font-medium text-gray-600">
+            No active alerts — all clear.
+          </p>
           <p className="text-xs text-gray-400">
-            Alerts fire when pass rates, inactivity, or feedback exceed your configured thresholds.
+            Alerts fire when pass rates, inactivity, or feedback exceed your configured
+            thresholds.
           </p>
           <Link
             href="/school/reports/alerts/settings"

--- a/web/app/(school)/school/catalog/page.tsx
+++ b/web/app/(school)/school/catalog/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTeacher } from "@/lib/hooks/useTeacher";
@@ -33,9 +34,7 @@ function SubjectRow({ s }: { s: CatalogSubjectSummary }) {
       ) : (
         <Circle className="h-3.5 w-3.5 shrink-0 text-gray-300" />
       )}
-      <span className="flex-1 text-gray-700">
-        {s.subject_name ?? s.subject}
-      </span>
+      <span className="flex-1 text-gray-700">{s.subject_name ?? s.subject}</span>
       <span className="text-xs text-gray-400">
         {s.unit_count} unit{s.unit_count !== 1 ? "s" : ""}
       </span>
@@ -67,8 +66,8 @@ function CatalogCard({ pkg }: { pkg: CatalogEntry }) {
               )}
             </div>
             <p className="mt-0.5 text-xs text-gray-400">
-              {pkg.year} · {pkg.subject_count} subject{pkg.subject_count !== 1 ? "s" : ""} ·{" "}
-              {pkg.unit_count} unit{pkg.unit_count !== 1 ? "s" : ""}
+              {pkg.year} · {pkg.subject_count} subject{pkg.subject_count !== 1 ? "s" : ""}{" "}
+              · {pkg.unit_count} unit{pkg.unit_count !== 1 ? "s" : ""}
             </p>
           </div>
 
@@ -148,11 +147,14 @@ export default function CatalogPage() {
 
       <p className="text-sm text-gray-500">
         Platform-built curriculum packages available for assignment to your classrooms.
-        Each package covers a full grade&apos;s content across multiple subjects and units.
-        Assign packages to classrooms from the{" "}
-        <a href="/school/classrooms" className="text-indigo-600 underline-offset-2 hover:underline">
+        Each package covers a full grade&apos;s content across multiple subjects and
+        units. Assign packages to classrooms from the{" "}
+        <Link
+          href="/school/classrooms"
+          className="text-indigo-600 underline-offset-2 hover:underline"
+        >
           Classrooms
-        </a>{" "}
+        </Link>{" "}
         page.
       </p>
 
@@ -167,7 +169,7 @@ export default function CatalogPage() {
           onChange={(e) =>
             setGradeFilter(e.target.value === "" ? "" : Number(e.target.value))
           }
-          className="h-9 rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          className="border-input focus-visible:ring-ring h-9 rounded-md border bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:ring-1 focus-visible:outline-none"
         >
           <option value="">All grades</option>
           {ALL_GRADES.map((g) => (

--- a/web/app/(school)/school/classrooms/[classroomId]/page.tsx
+++ b/web/app/(school)/school/classrooms/[classroomId]/page.tsx
@@ -11,23 +11,13 @@ import {
   removePackageFromClassroom,
   assignStudentToClassroom,
   removeStudentFromClassroom,
-  listClassrooms,
   type ClassroomPackageItem,
   type ClassroomStudentItem,
 } from "@/lib/api/school-admin";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  ArrowLeft,
-  BookOpen,
-  Users,
-  Trash2,
-  Plus,
-  GraduationCap,
-} from "lucide-react";
+import { ArrowLeft, BookOpen, Trash2, Plus, GraduationCap } from "lucide-react";
 
 // ── Package row ────────────────────────────────────────────────────────────────
 
@@ -45,7 +35,7 @@ function PackageRow({
   return (
     <div className="flex items-center justify-between rounded-lg border bg-white px-4 py-3 shadow-sm">
       <div className="min-w-0">
-        <p className="font-medium text-gray-900 truncate">
+        <p className="truncate font-medium text-gray-900">
           {pkg.curriculum_name ?? pkg.curriculum_id}
         </p>
         <p className="text-xs text-gray-400">
@@ -53,11 +43,11 @@ function PackageRow({
         </p>
       </div>
       {confirm ? (
-        <div className="flex items-center gap-2 ml-3 shrink-0">
+        <div className="ml-3 flex shrink-0 items-center gap-2">
           <Button
             size="sm"
             variant="outline"
-            className="h-7 border-red-200 text-red-600 text-xs hover:bg-red-50"
+            className="h-7 border-red-200 text-xs text-red-600 hover:bg-red-50"
             onClick={onRemove}
             disabled={removing}
           >
@@ -111,11 +101,11 @@ function StudentRow({
         )}
       </div>
       {confirm ? (
-        <div className="flex items-center gap-2 ml-3 shrink-0">
+        <div className="ml-3 flex shrink-0 items-center gap-2">
           <Button
             size="sm"
             variant="outline"
-            className="h-7 border-red-200 text-red-600 text-xs hover:bg-red-50"
+            className="h-7 border-red-200 text-xs text-red-600 hover:bg-red-50"
             onClick={onRemove}
             disabled={removing}
           >
@@ -163,13 +153,15 @@ export default function ClassroomDetailPage() {
   const [curriculumId, setCurriculumId] = useState("");
   const [pkgError, setPkgError] = useState<string | null>(null);
   const { mutate: addPackage, isPending: addingPkg } = useMutation({
-    mutationFn: () => assignPackageToClassroom(schoolId, classroomId, curriculumId.trim()),
+    mutationFn: () =>
+      assignPackageToClassroom(schoolId, classroomId, curriculumId.trim()),
     onSuccess: () => {
       setCurriculumId("");
       setPkgError(null);
       queryClient.invalidateQueries({ queryKey: ["classroom", schoolId, classroomId] });
     },
-    onError: () => setPkgError("Could not add package. Check the curriculum ID and try again."),
+    onError: () =>
+      setPkgError("Could not add package. Check the curriculum ID and try again."),
   });
 
   // ── Student assignment ──
@@ -193,7 +185,11 @@ export default function ClassroomDetailPage() {
   });
 
   // ── Remove package ──
-  const { mutate: removePkg, isPending: removingPkg, variables: removingPkgId } = useMutation({
+  const {
+    mutate: removePkg,
+    isPending: removingPkg,
+    variables: removingPkgId,
+  } = useMutation({
     mutationFn: (currId: string) =>
       removePackageFromClassroom(schoolId, classroomId, currId),
     onSuccess: () =>
@@ -201,7 +197,11 @@ export default function ClassroomDetailPage() {
   });
 
   // ── Remove student ──
-  const { mutate: removeStu, isPending: removingStu, variables: removingStuId } = useMutation({
+  const {
+    mutate: removeStu,
+    isPending: removingStu,
+    variables: removingStuId,
+  } = useMutation({
     mutationFn: (stuId: string) =>
       removeStudentFromClassroom(schoolId, classroomId, stuId),
     onSuccess: () =>
@@ -222,7 +222,10 @@ export default function ClassroomDetailPage() {
     return (
       <div className="p-6">
         <p className="text-sm text-gray-500">Classroom not found.</p>
-        <Link href="/school/classrooms" className="mt-3 text-sm text-indigo-600 hover:underline">
+        <Link
+          href="/school/classrooms"
+          className="mt-3 text-sm text-indigo-600 hover:underline"
+        >
           ← Back to classrooms
         </Link>
       </div>
@@ -254,7 +257,9 @@ export default function ClassroomDetailPage() {
           )}
         </div>
         {classroom.teacher_name && (
-          <p className="mt-1 text-sm text-gray-500">Lead teacher: {classroom.teacher_name}</p>
+          <p className="mt-1 text-sm text-gray-500">
+            Lead teacher: {classroom.teacher_name}
+          </p>
         )}
       </div>
 
@@ -262,7 +267,7 @@ export default function ClassroomDetailPage() {
       <section>
         <div className="mb-3 flex items-center gap-2">
           <BookOpen className="h-4 w-4 text-indigo-600" />
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+          <h2 className="text-sm font-semibold tracking-wide text-gray-500 uppercase">
             Curriculum packages ({classroom.packages.length})
           </h2>
         </div>
@@ -284,17 +289,25 @@ export default function ClassroomDetailPage() {
 
         {/* Add package form */}
         <div className="mt-4 rounded-lg border border-indigo-100 bg-indigo-50 p-4">
-          <p className="mb-2 text-xs font-medium text-gray-600">Assign a curriculum package</p>
+          <p className="mb-2 text-xs font-medium text-gray-600">
+            Assign a curriculum package
+          </p>
           <div className="flex gap-2">
             <Input
               value={curriculumId}
-              onChange={(e) => { setCurriculumId(e.target.value); setPkgError(null); }}
+              onChange={(e) => {
+                setCurriculumId(e.target.value);
+                setPkgError(null);
+              }}
               placeholder="Curriculum ID (UUID)"
               className="flex-1 text-sm"
             />
             <Button
               size="sm"
-              onClick={() => { setPkgError(null); addPackage(); }}
+              onClick={() => {
+                setPkgError(null);
+                addPackage();
+              }}
               disabled={addingPkg || !curriculumId.trim()}
               className="gap-1"
             >
@@ -309,7 +322,10 @@ export default function ClassroomDetailPage() {
               Curriculum
             </Link>{" "}
             or{" "}
-            <Link href="/school/curriculum/content" className="text-indigo-600 hover:underline">
+            <Link
+              href="/school/curriculum/content"
+              className="text-indigo-600 hover:underline"
+            >
               Content viewer
             </Link>
             .
@@ -321,7 +337,7 @@ export default function ClassroomDetailPage() {
       <section>
         <div className="mb-3 flex items-center gap-2">
           <GraduationCap className="h-4 w-4 text-indigo-600" />
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+          <h2 className="text-sm font-semibold tracking-wide text-gray-500 uppercase">
             Students ({classroom.students.length})
           </h2>
         </div>
@@ -347,13 +363,19 @@ export default function ClassroomDetailPage() {
           <div className="flex gap-2">
             <Input
               value={studentId}
-              onChange={(e) => { setStudentId(e.target.value); setStuError(null); }}
+              onChange={(e) => {
+                setStudentId(e.target.value);
+                setStuError(null);
+              }}
               placeholder="Student ID (UUID)"
               className="flex-1 text-sm"
             />
             <Button
               size="sm"
-              onClick={() => { setStuError(null); addStudent(); }}
+              onClick={() => {
+                setStuError(null);
+                addStudent();
+              }}
               disabled={addingStu || !studentId.trim()}
               className="gap-1 bg-green-600 hover:bg-green-700"
             >

--- a/web/app/(school)/school/classrooms/page.tsx
+++ b/web/app/(school)/school/classrooms/page.tsx
@@ -47,7 +47,8 @@ function ClassroomCard({
       updateClassroom(schoolId, item.classroom_id, {
         status: item.status === "active" ? "archived" : "active",
       }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["classrooms", schoolId] }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["classrooms", schoolId] }),
   });
 
   return (
@@ -72,9 +73,7 @@ function ClassroomCard({
             )}
           </div>
           {item.teacher_name && (
-            <p className="mt-0.5 text-sm text-gray-500">
-              Lead: {item.teacher_name}
-            </p>
+            <p className="mt-0.5 text-sm text-gray-500">Lead: {item.teacher_name}</p>
           )}
           <div className="mt-2 flex items-center gap-4 text-xs text-gray-500">
             <span className="flex items-center gap-1">
@@ -96,7 +95,9 @@ function ClassroomCard({
                   type="button"
                   onClick={() => setConfirmArchive(true)}
                   className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-                  aria-label={item.status === "active" ? "Archive classroom" : "Restore classroom"}
+                  aria-label={
+                    item.status === "active" ? "Archive classroom" : "Restore classroom"
+                  }
                   title={item.status === "active" ? "Archive" : "Restore"}
                 >
                   {item.status === "active" ? (
@@ -111,7 +112,10 @@ function ClassroomCard({
                     size="sm"
                     variant="outline"
                     className="h-7 text-xs"
-                    onClick={() => { setConfirmArchive(false); toggleStatus(); }}
+                    onClick={() => {
+                      setConfirmArchive(false);
+                      toggleStatus();
+                    }}
                     disabled={isPending}
                   >
                     {isPending ? "…" : "Confirm"}
@@ -188,8 +192,10 @@ function CreateClassroomForm({ schoolId }: { schoolId: string }) {
             <select
               id="cls_grade"
               value={grade}
-              onChange={(e) => setGrade(e.target.value === "" ? "" : Number(e.target.value))}
-              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              onChange={(e) =>
+                setGrade(e.target.value === "" ? "" : Number(e.target.value))
+              }
+              className="border-input focus-visible:ring-ring flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:ring-1 focus-visible:outline-none"
             >
               <option value="">No specific grade</option>
               {ALL_GRADES.map((g) => (
@@ -204,7 +210,10 @@ function CreateClassroomForm({ schoolId }: { schoolId: string }) {
         {error && <p className="text-sm text-red-600">{error}</p>}
 
         <Button
-          onClick={() => { setError(null); mutate(); }}
+          onClick={() => {
+            setError(null);
+            mutate();
+          }}
           disabled={isPending || !name.trim()}
           className="gap-2"
         >
@@ -241,12 +250,13 @@ export default function ClassroomsPage() {
 
       <p className="text-sm text-gray-500">
         A classroom binds a group of students to one or more curriculum packages. Create a
-        classroom, assign packages from the catalog or your custom builds, then enrol students.
+        classroom, assign packages from the catalog or your custom builds, then enrol
+        students.
       </p>
 
       {/* ── Active classrooms ── */}
       <section>
-        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
+        <h2 className="mb-3 text-sm font-semibold tracking-wide text-gray-500 uppercase">
           Active classrooms
         </h2>
         {isLoading ? (
@@ -277,7 +287,7 @@ export default function ClassroomsPage() {
       {/* ── Archived classrooms ── */}
       {archived.length > 0 && (
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
+          <h2 className="mb-3 text-sm font-semibold tracking-wide text-gray-500 uppercase">
             Archived
           </h2>
           <div className="space-y-3">

--- a/web/app/(school)/school/curriculum/content/[version_id]/page.tsx
+++ b/web/app/(school)/school/curriculum/content/[version_id]/page.tsx
@@ -72,13 +72,14 @@ export default function SchoolContentVersionPage() {
               </Badge>
             </div>
             <p className="mt-1 text-sm text-gray-500">
-              Grade {version.grade} · {version.curriculum_name} · v{version.version_number} ·{" "}
-              {version.units.length} unit{version.units.length !== 1 ? "s" : ""}
+              Grade {version.grade} · {version.curriculum_name} · v
+              {version.version_number} · {version.units.length} unit
+              {version.units.length !== 1 ? "s" : ""}
             </p>
           </div>
 
           <section>
-            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
+            <h2 className="mb-3 text-sm font-semibold tracking-wide text-gray-500 uppercase">
               Units
             </h2>
             {version.units.length === 0 ? (

--- a/web/app/(school)/school/curriculum/content/[version_id]/unit/[unit_id]/page.tsx
+++ b/web/app/(school)/school/curriculum/content/[version_id]/unit/[unit_id]/page.tsx
@@ -47,8 +47,14 @@ interface AnnotationItem {
   reviewer_email: string | null;
 }
 
-function AnnotationsPanel({ annotations, activeType }: { annotations: AnnotationItem[]; activeType: string }) {
-  const relevant = annotations.filter(a => a.content_type.includes(activeType));
+function AnnotationsPanel({
+  annotations,
+  activeType,
+}: {
+  annotations: AnnotationItem[];
+  activeType: string;
+}) {
+  const relevant = annotations.filter((a) => a.content_type.includes(activeType));
   if (relevant.length === 0) return null;
 
   return (
@@ -58,11 +64,17 @@ function AnnotationsPanel({ annotations, activeType }: { annotations: Annotation
         Review Notes ({relevant.length})
       </h3>
       <div className="space-y-2">
-        {relevant.map(a => (
-          <div key={a.annotation_id} className="rounded-md border border-amber-100 bg-white px-3 py-2">
-            <p className="text-sm text-gray-800 whitespace-pre-wrap">{a.annotation_text}</p>
+        {relevant.map((a) => (
+          <div
+            key={a.annotation_id}
+            className="rounded-md border border-amber-100 bg-white px-3 py-2"
+          >
+            <p className="text-sm whitespace-pre-wrap text-gray-800">
+              {a.annotation_text}
+            </p>
             <p className="mt-1 text-xs text-gray-400">
-              {a.reviewer_email ?? "Reviewer"} · {new Date(a.created_at).toLocaleDateString()}
+              {a.reviewer_email ?? "Reviewer"} ·{" "}
+              {new Date(a.created_at).toLocaleDateString()}
             </p>
           </div>
         ))}
@@ -118,7 +130,9 @@ function TutorialRenderer({ data }: { data: Record<string, unknown> }) {
   ];
 
   const [activeTab, setActiveTab] = useState<string>(tabs[0]?.key ?? "");
-  const activeSection = sections.find((s, i) => (s.section_id ?? String(i)) === activeTab);
+  const activeSection = sections.find(
+    (s, i) => (s.section_id ?? String(i)) === activeTab,
+  );
 
   return (
     <div>
@@ -144,7 +158,10 @@ function TutorialRenderer({ data }: { data: Record<string, unknown> }) {
       {activeTab === "__mistakes__" ? (
         <ul className="space-y-2">
           {mistakes.map((m, i) => (
-            <li key={i} className="flex gap-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">
+            <li
+              key={i}
+              className="flex gap-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-600"
+            >
               <span className="shrink-0">⚠</span>
               <span>{m}</span>
             </li>
@@ -155,14 +172,11 @@ function TutorialRenderer({ data }: { data: Record<string, unknown> }) {
           <Prose text={activeSection.content} />
           {activeSection.examples && activeSection.examples.length > 0 && (
             <div className="space-y-2">
-              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
                 Examples
               </p>
               {activeSection.examples.map((ex, j) => (
-                <div
-                  key={j}
-                  className="rounded-md border border-gray-100 bg-gray-50 p-3"
-                >
+                <div key={j} className="rounded-md border border-gray-100 bg-gray-50 p-3">
                   <SBMarkdown className="text-xs text-gray-800">{ex}</SBMarkdown>
                 </div>
               ))}
@@ -194,7 +208,7 @@ function QuizRenderer({ data }: { data: Record<string, unknown> }) {
   return (
     <div className="space-y-5">
       {setNumber && (
-        <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
+        <p className="text-xs font-medium tracking-wide text-gray-400 uppercase">
           Quiz Set {setNumber} · {questions.length} questions
         </p>
       )}
@@ -204,7 +218,9 @@ function QuizRenderer({ data }: { data: Record<string, unknown> }) {
           className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
         >
           <div className="mb-3 flex gap-2">
-            <span className="mt-0.5 shrink-0 font-mono text-xs text-gray-400">Q{i + 1}.</span>
+            <span className="mt-0.5 shrink-0 font-mono text-xs text-gray-400">
+              Q{i + 1}.
+            </span>
             <Prose text={q.question_text} className="flex-1" />
           </div>
           <ul className="space-y-1.5">
@@ -223,7 +239,9 @@ function QuizRenderer({ data }: { data: Record<string, unknown> }) {
                 </span>
                 <span className="flex-1">{opt.text}</span>
                 {opt.option_id === q.correct_option && (
-                  <span className="ml-auto shrink-0 text-xs text-green-600">✓ correct</span>
+                  <span className="ml-auto shrink-0 text-xs text-green-600">
+                    ✓ correct
+                  </span>
                 )}
               </li>
             ))}
@@ -256,7 +274,9 @@ function ExperimentRenderer({ data }: { data: Record<string, unknown> }) {
           <h3 className="mb-2 text-sm font-semibold text-gray-800">Materials</h3>
           <ul className="grid grid-cols-2 gap-1">
             {materials.map((m, i) => (
-              <li key={i} className="text-sm text-gray-700">• {m}</li>
+              <li key={i} className="text-sm text-gray-700">
+                • {m}
+              </li>
             ))}
           </ul>
         </div>
@@ -406,14 +426,21 @@ export default function SchoolUnitContentPage() {
               ))}
             </div>
           ) : !resolvedType ? (
-            <p className="text-sm text-gray-400 italic">Select a content type on the left.</p>
+            <p className="text-sm text-gray-400 italic">
+              Select a content type on the left.
+            </p>
           ) : !content ? (
-            <p className="text-sm text-gray-400 italic">No content available for this type.</p>
+            <p className="text-sm text-gray-400 italic">
+              No content available for this type.
+            </p>
           ) : (
             <>
               <ContentRenderer contentType={resolvedType} data={content} />
               {meta?.annotations && resolvedType && (
-                <AnnotationsPanel annotations={meta.annotations} activeType={resolvedType} />
+                <AnnotationsPanel
+                  annotations={meta.annotations}
+                  activeType={resolvedType}
+                />
               )}
             </>
           )}

--- a/web/app/(school)/school/curriculum/content/page.tsx
+++ b/web/app/(school)/school/curriculum/content/page.tsx
@@ -72,9 +72,11 @@ export default function SchoolContentPage() {
   // Available grades for the filter pill row
   const availableGrades = useMemo(() => {
     if (!subjects) return [];
-    const base = isAdmin ? subjects : subjects.filter((s) =>
-      assignedGrades ? assignedGrades.includes(s.grade) : true,
-    );
+    const base = isAdmin
+      ? subjects
+      : subjects.filter((s) =>
+          assignedGrades ? assignedGrades.includes(s.grade) : true,
+        );
     return [...new Set(base.map((s) => s.grade))].sort((a, b) => a - b);
   }, [subjects, isAdmin, assignedGrades]);
 
@@ -142,7 +144,9 @@ export default function SchoolContentPage() {
       ) : grouped.length === 0 ? (
         <div className="rounded-lg border border-gray-200 bg-white p-8 text-center">
           <FileText className="mx-auto mb-3 h-10 w-10 text-gray-300" />
-          <p className="text-sm font-medium text-gray-500">No curriculum content found.</p>
+          <p className="text-sm font-medium text-gray-500">
+            No curriculum content found.
+          </p>
           <p className="mt-1 text-xs text-gray-400">
             {!isAdmin && assignedGrades?.length === 0
               ? "You have no grades assigned yet. Ask your school admin to assign grades."
@@ -152,7 +156,7 @@ export default function SchoolContentPage() {
       ) : (
         grouped.map(([grade, items]) => (
           <section key={grade}>
-            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
+            <h2 className="mb-3 text-sm font-semibold tracking-wide text-gray-500 uppercase">
               Grade {grade}
             </h2>
             <div className="space-y-2">
@@ -194,8 +198,9 @@ function SubjectRow({ item }: { item: SchoolContentSubject }) {
           )}
         </div>
         <p className="mt-0.5 text-xs text-gray-500">
-          v{item.version_number} · {item.unit_count} unit{item.unit_count !== 1 ? "s" : ""} ·{" "}
-          Generated {new Date(item.generated_at).toLocaleDateString()}
+          v{item.version_number} · {item.unit_count} unit
+          {item.unit_count !== 1 ? "s" : ""} · Generated{" "}
+          {new Date(item.generated_at).toLocaleDateString()}
         </p>
       </div>
       <ChevronRight className="ml-3 h-4 w-4 shrink-0 text-gray-400" />

--- a/web/app/(school)/school/curriculum/definitions/[definitionId]/page.tsx
+++ b/web/app/(school)/school/curriculum/definitions/[definitionId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import { useTeacher } from "@/lib/hooks/useTeacher";
 import Link from "next/link";
 import {
@@ -14,13 +14,36 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  FileText,
-  ChevronLeft,
-  CheckCircle2,
-  XCircle,
-  Clock,
-} from "lucide-react";
+import { FileText, ChevronLeft, CheckCircle2, XCircle, Clock } from "lucide-react";
+
+// ── Status chip (hoisted out of DefinitionDetailPage so it isn't re-created
+//    on every render — fixes react-hooks/immutability lint rule).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function StatusChip({ status }: { status: string }) {
+  if (status === "approved") {
+    return (
+      <span className="flex items-center gap-1.5 rounded-full bg-green-50 px-3 py-1 text-sm font-medium text-green-700">
+        <CheckCircle2 className="h-4 w-4" />
+        Approved
+      </span>
+    );
+  }
+  if (status === "rejected") {
+    return (
+      <span className="flex items-center gap-1.5 rounded-full bg-red-50 px-3 py-1 text-sm font-medium text-red-700">
+        <XCircle className="h-4 w-4" />
+        Rejected
+      </span>
+    );
+  }
+  return (
+    <span className="flex items-center gap-1.5 rounded-full bg-amber-50 px-3 py-1 text-sm font-medium text-amber-700">
+      <Clock className="h-4 w-4" />
+      Pending approval
+    </span>
+  );
+}
 
 // ── Page ───────────────────────────────────────────────────────────────────────
 
@@ -28,7 +51,6 @@ export default function DefinitionDetailPage() {
   const params = useParams<{ definitionId: string }>();
   const definitionId = params.definitionId;
   const teacher = useTeacher();
-  const router = useRouter();
   const queryClient = useQueryClient();
   const schoolId = teacher?.school_id ?? "";
   const isAdmin = teacher?.role === "school_admin";
@@ -73,7 +95,10 @@ export default function DefinitionDetailPage() {
     return (
       <div className="max-w-2xl p-6">
         <p className="text-sm text-gray-500">Definition not found.</p>
-        <Link href="/school/curriculum/definitions" className="mt-2 text-sm text-indigo-600 hover:underline">
+        <Link
+          href="/school/curriculum/definitions"
+          className="mt-2 text-sm text-indigo-600 hover:underline"
+        >
           ← Back to definitions
         </Link>
       </div>
@@ -81,29 +106,6 @@ export default function DefinitionDetailPage() {
   }
 
   const totalUnits = defn.subjects.reduce((acc, s) => acc + s.units.length, 0);
-
-  function StatusChip() {
-    if (defn!.status === "approved")
-      return (
-        <span className="flex items-center gap-1.5 rounded-full bg-green-50 px-3 py-1 text-sm font-medium text-green-700">
-          <CheckCircle2 className="h-4 w-4" />
-          Approved
-        </span>
-      );
-    if (defn!.status === "rejected")
-      return (
-        <span className="flex items-center gap-1.5 rounded-full bg-red-50 px-3 py-1 text-sm font-medium text-red-700">
-          <XCircle className="h-4 w-4" />
-          Rejected
-        </span>
-      );
-    return (
-      <span className="flex items-center gap-1.5 rounded-full bg-amber-50 px-3 py-1 text-sm font-medium text-amber-700">
-        <Clock className="h-4 w-4" />
-        Pending approval
-      </span>
-    );
-  }
 
   return (
     <div className="max-w-2xl space-y-6 p-6">
@@ -127,7 +129,7 @@ export default function DefinitionDetailPage() {
             <p className="mt-0.5 text-sm text-gray-400">by {defn.submitted_by_name}</p>
           )}
         </div>
-        <StatusChip />
+        <StatusChip status={defn.status} />
       </div>
 
       {/* Summary card */}
@@ -164,7 +166,7 @@ export default function DefinitionDetailPage() {
 
       {/* Subject / unit list */}
       <div className="space-y-4">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+        <h2 className="text-sm font-semibold tracking-wide text-gray-500 uppercase">
           Subjects & units
         </h2>
         {defn.subjects.map((s, i) => (
@@ -176,7 +178,7 @@ export default function DefinitionDetailPage() {
               <ol className="space-y-1 pl-1">
                 {s.units.map((u, j) => (
                   <li key={j} className="flex items-start gap-2 text-sm text-gray-700">
-                    <span className="mt-0.5 text-xs font-mono text-gray-400">
+                    <span className="mt-0.5 font-mono text-xs text-gray-400">
                       {String(j + 1).padStart(2, "0")}
                     </span>
                     {u.title}
@@ -192,7 +194,9 @@ export default function DefinitionDetailPage() {
       {isAdmin && defn.status === "pending_approval" && (
         <Card className="border border-amber-200 bg-amber-50">
           <CardHeader className="pb-2">
-            <CardTitle className="text-base text-amber-900">Review this definition</CardTitle>
+            <CardTitle className="text-base text-amber-900">
+              Review this definition
+            </CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
             {!showReject ? (
@@ -237,7 +241,8 @@ export default function DefinitionDetailPage() {
               </div>
             )}
             <p className="text-xs text-amber-700">
-              After approval, the school admin can trigger the pipeline to generate content.
+              After approval, the school admin can trigger the pipeline to generate
+              content.
             </p>
           </CardContent>
         </Card>

--- a/web/app/(school)/school/curriculum/definitions/new/page.tsx
+++ b/web/app/(school)/school/curriculum/definitions/new/page.tsx
@@ -13,7 +13,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Badge } from "@/components/ui/badge";
 import {
   FileText,
   ChevronRight,
@@ -64,10 +63,8 @@ function StepBasics({
         <select
           id="def_grade"
           value={grade}
-          onChange={(e) =>
-            setGrade(e.target.value === "" ? "" : Number(e.target.value))
-          }
-          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          onChange={(e) => setGrade(e.target.value === "" ? "" : Number(e.target.value))}
+          className="border-input focus-visible:ring-ring flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:ring-1 focus-visible:outline-none"
         >
           <option value="">Select grade</option>
           {ALL_GRADES.map((g) => (
@@ -211,7 +208,12 @@ function StepSubjects({
           onRemove={() => removeSubject(i)}
         />
       ))}
-      <Button type="button" variant="outline" onClick={addSubject} className="w-full gap-2">
+      <Button
+        type="button"
+        variant="outline"
+        onClick={addSubject}
+        className="w-full gap-2"
+      >
         <Plus className="h-4 w-4" />
         Add subject
       </Button>
@@ -240,8 +242,8 @@ function StepLanguages({
   return (
     <div className="space-y-3">
       <p className="text-sm text-gray-500">
-        Select the languages in which content should be generated. Each language is a separate
-        pipeline run.
+        Select the languages in which content should be generated. Each language is a
+        separate pipeline run.
       </p>
       <div className="flex flex-wrap gap-3">
         {SUPPORTED_LANGUAGES.map((lang) => {
@@ -264,7 +266,8 @@ function StepLanguages({
         })}
       </div>
       <p className="text-xs text-gray-400">
-        At least one language is required. Content cost scales with the number of languages.
+        At least one language is required. Content cost scales with the number of
+        languages.
       </p>
     </div>
   );
@@ -286,7 +289,7 @@ function StepReview({
   const totalUnits = subjects.reduce((acc, s) => acc + s.units.length, 0);
   return (
     <div className="space-y-4">
-      <div className="rounded-lg bg-gray-50 p-4 space-y-3 text-sm">
+      <div className="space-y-3 rounded-lg bg-gray-50 p-4 text-sm">
         <div className="flex justify-between">
           <span className="text-gray-500">Name</span>
           <span className="font-medium text-gray-900">{name}</span>
@@ -314,7 +317,9 @@ function StepReview({
       <div className="space-y-3">
         {subjects.map((s, i) => (
           <div key={i} className="rounded-lg border p-3">
-            <p className="text-sm font-medium text-gray-800">{s.subject_label || "(unnamed)"}</p>
+            <p className="text-sm font-medium text-gray-800">
+              {s.subject_label || "(unnamed)"}
+            </p>
             <ul className="mt-1.5 space-y-1">
               {s.units.map((u, j) => (
                 <li key={j} className="flex items-center gap-1.5 text-xs text-gray-500">
@@ -455,14 +460,17 @@ export default function NewDefinitionPage() {
           {step === 0 && (
             <StepBasics name={name} setName={setName} grade={grade} setGrade={setGrade} />
           )}
-          {step === 1 && (
-            <StepSubjects subjects={subjects} setSubjects={setSubjects} />
-          )}
+          {step === 1 && <StepSubjects subjects={subjects} setSubjects={setSubjects} />}
           {step === 2 && (
             <StepLanguages languages={languages} setLanguages={setLanguages} />
           )}
           {step === 3 && (
-            <StepReview name={name} grade={grade} languages={languages} subjects={subjects} />
+            <StepReview
+              name={name}
+              grade={grade}
+              languages={languages}
+              subjects={subjects}
+            />
           )}
 
           {validationError && (
@@ -480,7 +488,9 @@ export default function NewDefinitionPage() {
         <Button
           type="button"
           variant="ghost"
-          onClick={step === 0 ? () => router.push("/school/curriculum/definitions") : back}
+          onClick={
+            step === 0 ? () => router.push("/school/curriculum/definitions") : back
+          }
           className="gap-2"
         >
           <ChevronLeft className="h-4 w-4" />
@@ -493,7 +503,12 @@ export default function NewDefinitionPage() {
             <ChevronRight className="h-4 w-4" />
           </Button>
         ) : (
-          <Button type="button" onClick={() => mutate()} disabled={isPending} className="gap-2">
+          <Button
+            type="button"
+            onClick={() => mutate()}
+            disabled={isPending}
+            className="gap-2"
+          >
             {isPending ? "Submitting…" : "Submit for approval"}
           </Button>
         )}

--- a/web/app/(school)/school/curriculum/definitions/page.tsx
+++ b/web/app/(school)/school/curriculum/definitions/page.tsx
@@ -10,19 +10,12 @@ import {
   rejectDefinition,
   type CurriculumDefinition,
 } from "@/lib/api/school-admin";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  FileText,
-  Plus,
-  CheckCircle2,
-  XCircle,
-  Clock,
-  ChevronRight,
-} from "lucide-react";
+import { FileText, Plus, CheckCircle2, XCircle, Clock, ChevronRight } from "lucide-react";
 
 const STATUS_TABS = [
   { label: "Pending", value: "pending_approval" },
@@ -71,7 +64,8 @@ function DefinitionRow({
 
   const { mutate: approve, isPending: approving } = useMutation({
     mutationFn: () => approveDefinition(schoolId, defn.definition_id),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["definitions", schoolId] }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["definitions", schoolId] }),
   });
 
   const { mutate: reject, isPending: rejecting } = useMutation({
@@ -98,12 +92,14 @@ function DefinitionRow({
           </div>
 
           <div className="mt-1 flex flex-wrap gap-3 text-xs text-gray-500">
-            <span>{subjectCount} subject{subjectCount !== 1 ? "s" : ""}</span>
-            <span>{unitCount} unit{unitCount !== 1 ? "s" : ""}</span>
+            <span>
+              {subjectCount} subject{subjectCount !== 1 ? "s" : ""}
+            </span>
+            <span>
+              {unitCount} unit{unitCount !== 1 ? "s" : ""}
+            </span>
             <span>{defn.languages.join(", ").toUpperCase()}</span>
-            {defn.submitted_by_name && (
-              <span>by {defn.submitted_by_name}</span>
-            )}
+            {defn.submitted_by_name && <span>by {defn.submitted_by_name}</span>}
           </div>
 
           {defn.status === "rejected" && defn.rejection_reason && (
@@ -160,7 +156,7 @@ function DefinitionRow({
               <Button
                 size="sm"
                 variant="outline"
-                className="h-7 gap-1 text-xs text-red-600 border-red-200 hover:bg-red-50"
+                className="h-7 gap-1 border-red-200 text-xs text-red-600 hover:bg-red-50"
                 onClick={() => setShowReject(true)}
               >
                 <XCircle className="h-3 w-3" />
@@ -214,9 +210,9 @@ export default function DefinitionsPage() {
       </div>
 
       <p className="text-sm text-gray-500">
-        A Curriculum Definition specifies the grade, subjects, and units for a custom content
-        build. Submit one for school admin approval — after approval the pipeline can be
-        triggered to generate the full Curriculum Package.
+        A Curriculum Definition specifies the grade, subjects, and units for a custom
+        content build. Submit one for school admin approval — after approval the pipeline
+        can be triggered to generate the full Curriculum Package.
       </p>
 
       {/* Status tabs */}

--- a/web/app/(school)/school/curriculum/jobs/[job_id]/page.tsx
+++ b/web/app/(school)/school/curriculum/jobs/[job_id]/page.tsx
@@ -17,7 +17,8 @@ import { useRouter } from "next/navigation";
 function StatusIcon({ status }: { status: string }) {
   if (status === "done") return <CheckCircle className="h-5 w-5 text-green-500" />;
   if (status === "failed") return <XCircle className="h-5 w-5 text-red-500" />;
-  if (status === "running") return <Loader2 className="h-5 w-5 animate-spin text-blue-500" />;
+  if (status === "running")
+    return <Loader2 className="h-5 w-5 animate-spin text-blue-500" />;
   return <Clock className="h-5 w-5 text-gray-400" />;
 }
 
@@ -192,11 +193,13 @@ export default function JobDetailPage() {
                 </div>
                 <div>
                   <dt className="text-xs text-gray-400">Languages</dt>
-                  <dd className="font-mono text-xs text-gray-700 uppercase">{data.langs}</dd>
+                  <dd className="font-mono text-xs text-gray-700 uppercase">
+                    {data.langs}
+                  </dd>
                 </div>
                 <div>
                   <dt className="text-xs text-gray-400">Curriculum ID</dt>
-                  <dd className="font-mono text-xs text-gray-500 break-all">
+                  <dd className="font-mono text-xs break-all text-gray-500">
                     {data.curriculum_id}
                   </dd>
                 </div>
@@ -236,7 +239,12 @@ export default function JobDetailPage() {
           {isFinished && (
             <div className="flex gap-2">
               {isFailed && (
-                <Button onClick={handleRetry} disabled={retrying} variant="outline" className="gap-2">
+                <Button
+                  onClick={handleRetry}
+                  disabled={retrying}
+                  variant="outline"
+                  className="gap-2"
+                >
                   {retrying ? (
                     <Loader2 className="h-4 w-4 animate-spin" />
                   ) : (

--- a/web/app/(school)/school/curriculum/jobs/page.tsx
+++ b/web/app/(school)/school/curriculum/jobs/page.tsx
@@ -161,10 +161,7 @@ export default function JobsListPage() {
                   {jobs.map((job) => {
                     const pct =
                       job.total && job.total > 0
-                        ? Math.min(
-                            ((job.built ?? 0) / job.total) * 100,
-                            100,
-                          )
+                        ? Math.min(((job.built ?? 0) / job.total) * 100, 100)
                         : 0;
                     return (
                       <tr key={job.job_id} className="hover:bg-gray-50">
@@ -236,7 +233,7 @@ export default function JobsListPage() {
           <button
             onClick={() => setPage((p) => Math.max(1, p - 1))}
             disabled={page === 1}
-            className="rounded-md border border-gray-200 px-3 py-1.5 text-xs disabled:opacity-40 hover:bg-gray-50"
+            className="rounded-md border border-gray-200 px-3 py-1.5 text-xs hover:bg-gray-50 disabled:opacity-40"
           >
             ← Prev
           </button>
@@ -246,7 +243,7 @@ export default function JobsListPage() {
           <button
             onClick={() => setPage((p) => Math.min(pageCount, p + 1))}
             disabled={page === pageCount}
-            className="rounded-md border border-gray-200 px-3 py-1.5 text-xs disabled:opacity-40 hover:bg-gray-50"
+            className="rounded-md border border-gray-200 px-3 py-1.5 text-xs hover:bg-gray-50 disabled:opacity-40"
           >
             Next →
           </button>

--- a/web/app/(school)/school/curriculum/page.tsx
+++ b/web/app/(school)/school/curriculum/page.tsx
@@ -161,7 +161,7 @@ function JsonPipelineSection({ schoolId }: { schoolId: string }) {
     setState("uploading");
     setError(null);
     try {
-      const uploaded = await uploadCurriculumJSON(schoolId, file, year);
+      await uploadCurriculumJSON(schoolId, file, year);
       const triggered = await triggerSchoolPipeline(schoolId, {
         langs: Array.from(langs).join(","),
         force,
@@ -212,8 +212,8 @@ function JsonPipelineSection({ schoolId }: { schoolId: string }) {
       {parsed && (
         <div className="flex items-center gap-2 rounded-lg border border-blue-100 bg-blue-50 px-3 py-2 text-xs text-blue-700">
           <CheckCircle className="h-3.5 w-3.5 shrink-0" />
-          Grade {parsed.grade} — {parsed.unitCount} unit{parsed.unitCount !== 1 ? "s" : ""}{" "}
-          detected
+          Grade {parsed.grade} — {parsed.unitCount} unit
+          {parsed.unitCount !== 1 ? "s" : ""} detected
         </div>
       )}
 
@@ -533,14 +533,15 @@ export default function CurriculumPage() {
       {/* Definitions panel */}
       <Link
         href="/school/curriculum/definitions"
-        className="flex items-center justify-between rounded-lg border border-indigo-100 bg-indigo-50 px-4 py-3 text-sm hover:bg-indigo-100 transition-colors"
+        className="flex items-center justify-between rounded-lg border border-indigo-100 bg-indigo-50 px-4 py-3 text-sm transition-colors hover:bg-indigo-100"
       >
         <div className="flex items-center gap-3">
           <FileText className="h-5 w-5 text-indigo-600" />
           <div>
             <p className="font-medium text-indigo-900">Curriculum Definitions</p>
             <p className="text-xs text-indigo-600">
-              Build a form-based definition and submit for approval before generating content.
+              Build a form-based definition and submit for approval before generating
+              content.
             </p>
           </div>
         </div>
@@ -581,7 +582,9 @@ export default function CurriculumPage() {
       {tab === "json" ? (
         <Card className="border shadow-sm">
           <CardHeader className="pb-2">
-            <CardTitle className="text-base">Upload grade JSON &amp; trigger pipeline</CardTitle>
+            <CardTitle className="text-base">
+              Upload grade JSON &amp; trigger pipeline
+            </CardTitle>
             <p className="text-sm text-gray-500">
               Upload a pipeline-schema JSON file. Content will be generated for the
               selected languages.

--- a/web/app/(school)/school/dashboard/page.tsx
+++ b/web/app/(school)/school/dashboard/page.tsx
@@ -88,7 +88,7 @@ export default function SchoolDashboard() {
 
   const assignedGrades = useMemo(() => {
     if (isAdmin || !teachers || !teacher?.teacher_id) return null;
-    const me = teachers.find(t => t.teacher_id === teacher.teacher_id);
+    const me = teachers.find((t) => t.teacher_id === teacher.teacher_id);
     return me?.assigned_grades ?? [];
   }, [teachers, teacher, isAdmin]);
 
@@ -136,13 +136,14 @@ export default function SchoolDashboard() {
         {/* My Classes — shown for non-admin teachers with assigned grades */}
         {!isAdmin && assignedGrades && assignedGrades.length > 0 && (
           <section>
-            <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-gray-500">
+            <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold tracking-wide text-gray-500 uppercase">
               <GraduationCap className="h-4 w-4" />
               My Classes
             </h2>
             <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-              {assignedGrades.map(grade => {
-                const studentCount = classMetrics?.students.filter(s => s.grade === grade).length ?? 0;
+              {assignedGrades.map((grade) => {
+                const studentCount =
+                  classMetrics?.students.filter((s) => s.grade === grade).length ?? 0;
                 return (
                   <div key={grade} className="rounded-lg border bg-white p-4 shadow-sm">
                     <p className="text-3xl font-bold text-indigo-600">{grade}</p>
@@ -187,7 +188,9 @@ export default function SchoolDashboard() {
             />
             <KpiCard
               title="Active this week"
-              value={overview.active_pct != null ? `${overview.active_pct.toFixed(0)}%` : "—"}
+              value={
+                overview.active_pct != null ? `${overview.active_pct.toFixed(0)}%` : "—"
+              }
               subtitle={`${overview.active_students_period ?? 0} of ${overview.enrolled_students ?? 0}`}
               icon={<TrendingUp className="h-5 w-5" />}
               accent="green"
@@ -229,36 +232,38 @@ export default function SchoolDashboard() {
           </div>
         ) : null}
 
-        {overview && overview.units_with_struggles && overview.units_with_struggles.length > 0 && (
-          <Card className="border shadow-sm">
-            <CardHeader className="pb-2">
-              <CardTitle className="flex items-center gap-2 text-base">
-                <AlertTriangle className="h-4 w-4 text-orange-500" />
-                Units needing attention
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="flex flex-wrap gap-2">
-                {overview.units_with_struggles.map((uid) => (
-                  <Badge
-                    key={uid}
-                    className="border-orange-200 bg-orange-50 text-orange-700"
-                  >
-                    {uid}
-                  </Badge>
-                ))}
-              </div>
-              <LinkButton
-                href="/school/reports/at-risk"
-                variant="outline"
-                size="sm"
-                className="mt-3"
-              >
-                View at-risk report
-              </LinkButton>
-            </CardContent>
-          </Card>
-        )}
+        {overview &&
+          overview.units_with_struggles &&
+          overview.units_with_struggles.length > 0 && (
+            <Card className="border shadow-sm">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <AlertTriangle className="h-4 w-4 text-orange-500" />
+                  Units needing attention
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-wrap gap-2">
+                  {overview.units_with_struggles.map((uid) => (
+                    <Badge
+                      key={uid}
+                      className="border-orange-200 bg-orange-50 text-orange-700"
+                    >
+                      {uid}
+                    </Badge>
+                  ))}
+                </div>
+                <LinkButton
+                  href="/school/reports/at-risk"
+                  variant="outline"
+                  size="sm"
+                  className="mt-3"
+                >
+                  View at-risk report
+                </LinkButton>
+              </CardContent>
+            </Card>
+          )}
 
         <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
           {[

--- a/web/app/(school)/school/help/page.tsx
+++ b/web/app/(school)/school/help/page.tsx
@@ -11,7 +11,7 @@ const GETTING_STARTED_TEACHER = [
   {
     step: "1",
     title: "Log in",
-    body: 'Go to /school/login and sign in with your teacher credentials. The portal loads your assigned grades automatically.',
+    body: "Go to /school/login and sign in with your teacher credentials. The portal loads your assigned grades automatically.",
   },
   {
     step: "2",
@@ -63,9 +63,7 @@ export default function SchoolHelpPage() {
   const teacher = useTeacher();
   const isAdmin = teacher?.role === "school_admin";
 
-  const personaIds = isAdmin
-    ? ["school-admin", "school-teacher"]
-    : ["school-teacher"];
+  const personaIds = isAdmin ? ["school-admin", "school-teacher"] : ["school-teacher"];
   const maps = HELP_MINDMAPS.filter((m) => personaIds.includes(m.id));
   const steps = isAdmin ? GETTING_STARTED_ADMIN : GETTING_STARTED_TEACHER;
 
@@ -88,12 +86,15 @@ export default function SchoolHelpPage() {
 
       {/* Getting started */}
       <section>
-        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">
+        <h2 className="mb-4 text-sm font-semibold tracking-wide text-gray-500 uppercase">
           Getting Started
         </h2>
         <ol className="space-y-3">
           {steps.map((s) => (
-            <li key={s.step} className="flex gap-4 rounded-lg border border-gray-100 bg-white p-4 shadow-sm">
+            <li
+              key={s.step}
+              className="flex gap-4 rounded-lg border border-gray-100 bg-white p-4 shadow-sm"
+            >
               <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-blue-600 text-xs font-bold text-white">
                 {s.step}
               </span>
@@ -108,7 +109,7 @@ export default function SchoolHelpPage() {
 
       {/* Mind maps — one per persona, collapsible */}
       <section>
-        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">
+        <h2 className="mb-4 text-sm font-semibold tracking-wide text-gray-500 uppercase">
           {isAdmin ? "Persona Mind Maps" : "Your Role — Mind Map"}
         </h2>
         <div className="space-y-4">
@@ -148,7 +149,7 @@ export default function SchoolHelpPage() {
 
       {/* Quick reference */}
       <section>
-        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">
+        <h2 className="mb-4 text-sm font-semibold tracking-wide text-gray-500 uppercase">
           Quick Reference
         </h2>
         <div className="overflow-hidden rounded-xl border border-gray-200 shadow-sm">
@@ -162,13 +163,25 @@ export default function SchoolHelpPage() {
             <tbody className="divide-y divide-gray-100">
               {[
                 isAdmin && ["Invite a new teacher", "/school/teachers → Invite"],
-                isAdmin && ["Assign grades to a teacher", "/school/teachers → teacher row → Edit grades"],
+                isAdmin && [
+                  "Assign grades to a teacher",
+                  "/school/teachers → teacher row → Edit grades",
+                ],
                 isAdmin && ["Upload curriculum JSON", "/school/curriculum → Upload"],
-                isAdmin && ["Trigger pipeline build", "/school/curriculum/jobs → Trigger"],
+                isAdmin && [
+                  "Trigger pipeline build",
+                  "/school/curriculum/jobs → Trigger",
+                ],
                 isAdmin && ["View subscription plan", "/school/subscription"],
                 isAdmin && ["View / renew curriculum versions", "/school/retention"],
-                isAdmin && ["Purchase storage add-on", "/school/retention → Storage strip"],
-                isAdmin && ["Assign curriculum version to a grade", "/school/retention → row → Details → Assign"],
+                isAdmin && [
+                  "Purchase storage add-on",
+                  "/school/retention → Storage strip",
+                ],
+                isAdmin && [
+                  "Assign curriculum version to a grade",
+                  "/school/retention → row → Details → Assign",
+                ],
                 ["View AI-generated content", "/school/curriculum/content"],
                 ["Browse a unit's lesson", "/school/curriculum/content → subject → unit"],
                 ["See class performance", "/school/reports/overview"],

--- a/web/app/(school)/school/reports/at-risk/page.tsx
+++ b/web/app/(school)/school/reports/at-risk/page.tsx
@@ -45,12 +45,31 @@ function RiskBadge({ reasons }: { reasons: AtRiskStudent["risk_reasons"] }) {
   );
 }
 
-function LastActiveCell({ lastActive, inactiveDays }: { lastActive: string | null; inactiveDays: number | null }) {
+function LastActiveCell({
+  lastActive,
+  inactiveDays,
+}: {
+  lastActive: string | null;
+  inactiveDays: number | null;
+}) {
   if (!lastActive) {
     return <span className="text-gray-400">Never active</span>;
   }
-  const label = inactiveDays != null ? `${inactiveDays}d ago` : new Date(lastActive).toLocaleDateString();
-  return <span className={cn(inactiveDays != null && inactiveDays > 21 ? "font-semibold text-red-600" : "text-gray-600")}>{label}</span>;
+  const label =
+    inactiveDays != null
+      ? `${inactiveDays}d ago`
+      : new Date(lastActive).toLocaleDateString();
+  return (
+    <span
+      className={cn(
+        inactiveDays != null && inactiveDays > 21
+          ? "font-semibold text-red-600"
+          : "text-gray-600",
+      )}
+    >
+      {label}
+    </span>
+  );
 }
 
 export default function AtRiskPage() {
@@ -68,7 +87,8 @@ export default function AtRiskPage() {
   const seenMutation = useMutation({
     mutationFn: ({ studentId, seen }: { studentId: string; seen: boolean }) =>
       markAtRiskSeen(schoolId, studentId, seen),
-    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ["at-risk", schoolId] }),
+    onSuccess: () =>
+      void queryClient.invalidateQueries({ queryKey: ["at-risk", schoolId] }),
   });
 
   const reminderMutation = useMutation({
@@ -83,13 +103,13 @@ export default function AtRiskPage() {
       <div>
         <h1 className="text-2xl font-bold text-gray-900">At-Risk Students</h1>
         <p className="mt-1 text-sm text-gray-500">
-          Students who are inactive or have a low pass rate. Mark as seen once
-          you&apos;ve followed up, or send a push reminder.
+          Students who are inactive or have a low pass rate. Mark as seen once you&apos;ve
+          followed up, or send a push reminder.
         </p>
         {data && (
           <p className="mt-0.5 text-xs text-gray-400">
-            Thresholds: inactive &gt; {data.inactive_days_threshold} days ·
-            pass rate &lt; {data.pass_rate_threshold}%
+            Thresholds: inactive &gt; {data.inactive_days_threshold} days · pass rate &lt;{" "}
+            {data.pass_rate_threshold}%
           </p>
         )}
       </div>
@@ -107,8 +127,8 @@ export default function AtRiskPage() {
           <CheckCircle className="mx-auto mb-3 h-10 w-10 text-green-400" />
           <p className="text-sm font-medium text-green-700">No at-risk students</p>
           <p className="mt-1 text-xs text-gray-500">
-            All enrolled students are active and passing. Check back later or
-            adjust thresholds in{" "}
+            All enrolled students are active and passing. Check back later or adjust
+            thresholds in{" "}
             <Link href="/school/reports/alerts" className="underline hover:text-gray-700">
               Alert Settings
             </Link>
@@ -130,16 +150,21 @@ export default function AtRiskPage() {
                 <table className="w-full text-sm">
                   <thead className="border-b border-gray-100 bg-gray-50">
                     <tr>
-                      {["Student", "Grade", "Last active", "Pass rate", "Risk", "Actions"].map(
-                        (h) => (
-                          <th
-                            key={h}
-                            className="px-4 py-3 text-left text-xs font-medium text-gray-500"
-                          >
-                            {h}
-                          </th>
-                        ),
-                      )}
+                      {[
+                        "Student",
+                        "Grade",
+                        "Last active",
+                        "Pass rate",
+                        "Risk",
+                        "Actions",
+                      ].map((h) => (
+                        <th
+                          key={h}
+                          className="px-4 py-3 text-left text-xs font-medium text-gray-500"
+                        >
+                          {h}
+                        </th>
+                      ))}
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-gray-50">
@@ -182,9 +207,7 @@ export default function AtRiskPage() {
                         <td className="px-4 py-3">
                           <div className="flex items-center gap-2">
                             <button
-                              onClick={() =>
-                                reminderMutation.mutate(s.student_id)
-                              }
+                              onClick={() => reminderMutation.mutate(s.student_id)}
                               disabled={reminderMutation.isPending}
                               title="Send push reminder"
                               className="inline-flex items-center gap-1 rounded bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-600 hover:bg-indigo-100 disabled:opacity-50"
@@ -227,14 +250,16 @@ export default function AtRiskPage() {
                 <table className="w-full text-sm">
                   <thead className="border-b border-gray-100 bg-gray-50">
                     <tr>
-                      {["Student", "Grade", "Last active", "Pass rate", "Risk", ""].map((h) => (
-                        <th
-                          key={h}
-                          className="px-4 py-3 text-left text-xs font-medium text-gray-400"
-                        >
-                          {h}
-                        </th>
-                      ))}
+                      {["Student", "Grade", "Last active", "Pass rate", "Risk", ""].map(
+                        (h) => (
+                          <th
+                            key={h}
+                            className="px-4 py-3 text-left text-xs font-medium text-gray-400"
+                          >
+                            {h}
+                          </th>
+                        ),
+                      )}
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-gray-50">
@@ -256,7 +281,9 @@ export default function AtRiskPage() {
                           />
                         </td>
                         <td className="px-4 py-3 text-gray-400">
-                          {s.pass_rate_pct != null ? `${s.pass_rate_pct.toFixed(0)}%` : "—"}
+                          {s.pass_rate_pct != null
+                            ? `${s.pass_rate_pct.toFixed(0)}%`
+                            : "—"}
                         </td>
                         <td className="px-4 py-3">
                           <RiskBadge reasons={s.risk_reasons} />

--- a/web/app/(school)/school/reports/overview/page.tsx
+++ b/web/app/(school)/school/reports/overview/page.tsx
@@ -56,10 +56,7 @@ export default function OverviewReportPage() {
               { label: "Enrolled", value: data.enrolled_students ?? 0 },
               {
                 label: "Active",
-                value:
-                  data.active_pct != null
-                    ? `${data.active_pct.toFixed(0)}%`
-                    : "—",
+                value: data.active_pct != null ? `${data.active_pct.toFixed(0)}%` : "—",
                 sub: `${data.active_students_period ?? 0} students`,
               },
               { label: "Lessons viewed", value: data.lessons_viewed ?? 0 },
@@ -71,7 +68,8 @@ export default function OverviewReportPage() {
                     ? `${data.first_attempt_pass_rate_pct.toFixed(0)}%`
                     : "—",
                 highlight:
-                  data.first_attempt_pass_rate_pct != null && data.first_attempt_pass_rate_pct < 60
+                  data.first_attempt_pass_rate_pct != null &&
+                  data.first_attempt_pass_rate_pct < 60
                     ? "red"
                     : "green",
               },

--- a/web/app/(school)/school/retention/page.tsx
+++ b/web/app/(school)/school/retention/page.tsx
@@ -55,9 +55,17 @@ function StatusBadge({ status }: { status: RetentionVersion["retention_status"] 
     unavailable: { label: "Unavailable", cls: "bg-amber-100 text-amber-700" },
     purged: { label: "Purged", cls: "bg-red-100 text-red-600" },
   } as const;
-  const { label, cls } = map[status] ?? { label: status, cls: "bg-gray-100 text-gray-500" };
+  const { label, cls } = map[status] ?? {
+    label: status,
+    cls: "bg-gray-100 text-gray-500",
+  };
   return (
-    <span className={cn("inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium", cls)}>
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+        cls,
+      )}
+    >
       {label}
     </span>
   );
@@ -65,13 +73,7 @@ function StatusBadge({ status }: { status: RetentionVersion["retention_status"] 
 
 // ── Storage strip ─────────────────────────────────────────────────────────────
 
-function StorageStrip({
-  schoolId,
-  origin,
-}: {
-  schoolId: string;
-  origin: string;
-}) {
+function StorageStrip({ schoolId, origin }: { schoolId: string; origin: string }) {
   // The backend doesn't yet expose storage_used_gb / storage_purchased_gb in the
   // retention dashboard (it's in school_storage_quotas), but we include this
   // component for the UI skeleton and the add-on checkout flow.
@@ -120,7 +122,7 @@ function StorageStrip({
           {([5, 10, 25] as const).map((gb) => (
             <div
               key={gb}
-              className="flex flex-col items-center gap-1.5 rounded-xl border border-gray-200 p-4 min-w-[110px]"
+              className="flex min-w-[110px] flex-col items-center gap-1.5 rounded-xl border border-gray-200 p-4"
             >
               <span className="text-lg font-bold text-gray-900">{gb} GB</span>
               <span className="text-xs text-gray-400">add-on</span>
@@ -152,14 +154,12 @@ function VersionDrawer({
   version,
   schoolId,
   origin,
-  gradesForThisVersion,
   onClose,
   onRenewed,
 }: {
   version: RetentionVersion;
   schoolId: string;
   origin: string;
-  gradesForThisVersion: RetentionVersion[];
   onClose: () => void;
   onRenewed: () => void;
 }) {
@@ -269,11 +269,18 @@ function VersionDrawer({
           <div className="grid grid-cols-2 gap-3">
             <div className="rounded-lg border bg-gray-50 p-3">
               <p className="text-xs text-gray-400">Expires</p>
-              <p className={cn("mt-0.5 text-sm", urgencyClass(version.days_until_expiry))}>
+              <p
+                className={cn("mt-0.5 text-sm", urgencyClass(version.days_until_expiry))}
+              >
                 {fmtDate(version.expires_at)}
               </p>
               {version.days_until_expiry !== null && (
-                <p className={cn("text-xs mt-0.5", urgencyClass(version.days_until_expiry))}>
+                <p
+                  className={cn(
+                    "mt-0.5 text-xs",
+                    urgencyClass(version.days_until_expiry),
+                  )}
+                >
                   {version.days_until_expiry === 0
                     ? "Expires today"
                     : `${version.days_until_expiry}d left`}
@@ -286,7 +293,9 @@ function VersionDrawer({
                 {fmtDate(version.grace_until)}
               </p>
               {version.days_until_purge !== null && (
-                <p className={cn("text-xs mt-0.5", urgencyClass(version.days_until_purge))}>
+                <p
+                  className={cn("mt-0.5 text-xs", urgencyClass(version.days_until_purge))}
+                >
                   {version.days_until_purge === 0
                     ? "Purge pending"
                     : `${version.days_until_purge}d until purge`}
@@ -296,7 +305,9 @@ function VersionDrawer({
             {version.renewed_at && (
               <div className="col-span-2 rounded-lg border bg-gray-50 p-3">
                 <p className="text-xs text-gray-400">Last renewed</p>
-                <p className="mt-0.5 text-sm text-gray-700">{fmtDate(version.renewed_at)}</p>
+                <p className="mt-0.5 text-sm text-gray-700">
+                  {fmtDate(version.renewed_at)}
+                </p>
               </div>
             )}
           </div>
@@ -304,7 +315,7 @@ function VersionDrawer({
           {/* Curriculum ID */}
           <div>
             <p className="mb-1 text-xs font-medium text-gray-500">Curriculum ID</p>
-            <p className="rounded border bg-gray-50 px-2 py-1.5 font-mono text-xs text-gray-600 break-all">
+            <p className="rounded border bg-gray-50 px-2 py-1.5 font-mono text-xs break-all text-gray-600">
               {version.curriculum_id}
             </p>
           </div>
@@ -350,9 +361,7 @@ function VersionDrawer({
                   </Button>
                 </div>
               )}
-              {checkoutError && (
-                <p className="text-xs text-red-600">{checkoutError}</p>
-              )}
+              {checkoutError && <p className="text-xs text-red-600">{checkoutError}</p>}
               {renewMutation.isError && (
                 <p className="text-xs text-red-600">Renewal failed. Please try again.</p>
               )}
@@ -377,7 +386,8 @@ function VersionDrawer({
             ) : (
               <>
                 <p className="text-xs text-gray-500">
-                  Select this version as the live content source for Grade {version.grade}.
+                  Select this version as the live content source for Grade {version.grade}
+                  .
                 </p>
                 {assignSuccess && (
                   <div className="flex items-center gap-2 text-sm text-green-600">
@@ -385,9 +395,7 @@ function VersionDrawer({
                     {assignSuccess}
                   </div>
                 )}
-                {assignError && (
-                  <p className="text-xs text-red-600">{assignError}</p>
-                )}
+                {assignError && <p className="text-xs text-red-600">{assignError}</p>}
                 <Button
                   size="sm"
                   className="gap-2"
@@ -404,7 +412,9 @@ function VersionDrawer({
                   ) : (
                     <CheckCircle className="h-3.5 w-3.5" />
                   )}
-                  {version.is_assigned ? "Already assigned" : `Assign to Grade ${version.grade}`}
+                  {version.is_assigned
+                    ? "Already assigned"
+                    : `Assign to Grade ${version.grade}`}
                 </Button>
               </>
             )}
@@ -480,7 +490,8 @@ function CurriculumTable({
           </thead>
           <tbody className="divide-y">
             {curricula.map((v) => {
-              const urgentExpiry = v.days_until_expiry !== null && v.days_until_expiry <= 30;
+              const urgentExpiry =
+                v.days_until_expiry !== null && v.days_until_expiry <= 30;
               const urgentPurge = v.days_until_purge !== null && v.days_until_purge <= 30;
 
               return (
@@ -605,9 +616,9 @@ export default function RetentionPage() {
 
   const [selectedVersion, setSelectedVersion] = useState<RetentionVersion | null>(null);
   const [gradeFilter, setGradeFilter] = useState<number | null>(null);
-  const [statusFilter, setStatusFilter] = useState<"all" | "active" | "unavailable" | "purged">(
-    "all",
-  );
+  const [statusFilter, setStatusFilter] = useState<
+    "all" | "active" | "unavailable" | "purged"
+  >("all");
   const [renewedAlert, setRenewedAlert] = useState(false);
 
   const { data, isLoading, error, refetch } = useQuery({
@@ -624,9 +635,9 @@ export default function RetentionPage() {
     setTimeout(() => setRenewedAlert(false), 5000);
   }
 
-  const allGrades = Array.from(
-    new Set((data?.curricula ?? []).map((c) => c.grade)),
-  ).sort((a, b) => a - b);
+  const allGrades = Array.from(new Set((data?.curricula ?? []).map((c) => c.grade))).sort(
+    (a, b) => a - b,
+  );
 
   const filtered = (data?.curricula ?? []).filter(
     (c) =>
@@ -671,8 +682,8 @@ export default function RetentionPage() {
       {!isLoading && urgentCount > 0 && (
         <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
           <Clock className="h-4 w-4 shrink-0" />
-          <strong>{urgentCount}</strong> curriculum version{urgentCount > 1 ? "s" : ""} expire or
-          enter purge within 30 days. Review and renew them below.
+          <strong>{urgentCount}</strong> curriculum version{urgentCount > 1 ? "s" : ""}{" "}
+          expire or enter purge within 30 days. Review and renew them below.
         </div>
       )}
 
@@ -689,10 +700,7 @@ export default function RetentionPage() {
         <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
           <AlertTriangle className="h-4 w-4 shrink-0" />
           Failed to load retention data.{" "}
-          <button
-            onClick={() => void refetch()}
-            className="underline hover:no-underline"
-          >
+          <button onClick={() => void refetch()} className="underline hover:no-underline">
             Retry
           </button>
         </div>
@@ -739,10 +747,7 @@ export default function RetentionPage() {
           </div>
 
           {/* Curriculum table */}
-          <CurriculumTable
-            curricula={filtered}
-            onSelect={setSelectedVersion}
-          />
+          <CurriculumTable curricula={filtered} onSelect={setSelectedVersion} />
 
           {filtered.length > 0 && (
             <p className="text-xs text-gray-400">
@@ -759,9 +764,6 @@ export default function RetentionPage() {
           version={selectedVersion}
           schoolId={schoolId}
           origin={origin}
-          gradesForThisVersion={(data?.curricula ?? []).filter(
-            (c) => c.grade === selectedVersion.grade,
-          )}
           onClose={() => setSelectedVersion(null)}
           onRenewed={handleRenewed}
         />

--- a/web/app/(school)/school/storage/page.tsx
+++ b/web/app/(school)/school/storage/page.tsx
@@ -3,20 +3,31 @@
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTeacher } from "@/lib/hooks/useTeacher";
-import {
-  getSchoolStorage,
-  createStorageCheckout,
-  type StorageBreakdownItem,
-} from "@/lib/api/school-admin";
+import { getSchoolStorage, createStorageCheckout } from "@/lib/api/school-admin";
 import { STORAGE_PACKAGES } from "@/lib/pricing";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Loader2, HardDrive, AlertTriangle, CheckCircle, BookOpen, CreditCard } from "lucide-react";
+import {
+  Loader2,
+  HardDrive,
+  AlertTriangle,
+  CheckCircle,
+  BookOpen,
+  CreditCard,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // ── Quota bar ─────────────────────────────────────────────────────────────────
 
-function QuotaBar({ usedGb, totalGb, usedPct }: { usedGb: number; totalGb: number; usedPct: number }) {
+function QuotaBar({
+  usedGb,
+  totalGb,
+  usedPct,
+}: {
+  usedGb: number;
+  totalGb: number;
+  usedPct: number;
+}) {
   const isWarning = usedPct >= 80;
   const isFull = usedPct >= 100;
 
@@ -31,7 +42,9 @@ function QuotaBar({ usedGb, totalGb, usedPct }: { usedGb: number; totalGb: numbe
           )}
         >
           {usedGb.toFixed(2)} GB / {totalGb} GB
-          <span className="ml-1.5 text-xs font-normal text-gray-400">({usedPct.toFixed(1)}%)</span>
+          <span className="ml-1.5 text-xs font-normal text-gray-400">
+            ({usedPct.toFixed(1)}%)
+          </span>
         </span>
       </div>
       <div className="h-3 overflow-hidden rounded-full bg-gray-100">
@@ -52,43 +65,11 @@ function QuotaBar({ usedGb, totalGb, usedPct }: { usedGb: number; totalGb: numbe
       {isFull && (
         <p className="flex items-center gap-1.5 text-xs text-red-600">
           <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-          Storage quota exceeded — new pipeline builds will fail until you add more storage.
+          Storage quota exceeded — new pipeline builds will fail until you add more
+          storage.
         </p>
       )}
     </div>
-  );
-}
-
-// ── Breakdown row ─────────────────────────────────────────────────────────────
-
-function BreakdownRow({ item, totalGb }: { item: StorageBreakdownItem; totalGb: number }) {
-  const pct = totalGb > 0 ? (item.gb_used / totalGb) * 100 : 0;
-
-  return (
-    <tr className="border-b last:border-0">
-      <td className="py-3 pr-4">
-        <div className="flex items-center gap-2">
-          <BookOpen className="h-3.5 w-3.5 shrink-0 text-gray-400" />
-          <span className="text-sm text-gray-800">{item.name}</span>
-        </div>
-      </td>
-      <td className="py-3 pr-4 text-center">
-        <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
-          Grade {item.grade}
-        </span>
-      </td>
-      <td className="py-3 pr-4 text-right font-mono text-sm tabular-nums text-gray-700">
-        {item.gb_used.toFixed(2)} GB
-      </td>
-      <td className="py-3 pr-4 text-right text-xs text-gray-400 tabular-nums">
-        {item.job_count} build{item.job_count !== 1 ? "s" : ""}
-      </td>
-      <td className="py-3 w-32">
-        <div className="h-1.5 overflow-hidden rounded-full bg-gray-100">
-          <div className="h-full rounded-full bg-blue-400" style={{ width: `${Math.min(pct, 100)}%` }} />
-        </div>
-      </td>
-    </tr>
   );
 }
 
@@ -97,13 +78,11 @@ function BreakdownRow({ item, totalGb }: { item: StorageBreakdownItem; totalGb: 
 function AddOnCard({
   gb,
   priceUsd,
-  label,
   onBuy,
   isLoading,
 }: {
   gb: number;
   priceUsd: string;
-  label: string;
   onBuy: () => void;
   isLoading: boolean;
 }) {
@@ -117,8 +96,18 @@ function AddOnCard({
         <span className="font-mono text-sm font-semibold text-gray-800">
           ${parseFloat(priceUsd).toFixed(0)}
         </span>
-        <Button size="sm" variant="outline" onClick={onBuy} disabled={isLoading} className="gap-1.5">
-          {isLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <CreditCard className="h-3.5 w-3.5" />}
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onBuy}
+          disabled={isLoading}
+          className="gap-1.5"
+        >
+          {isLoading ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <CreditCard className="h-3.5 w-3.5" />
+          )}
           Buy
         </Button>
       </div>
@@ -134,7 +123,9 @@ export default function StoragePage() {
   const isAdmin = teacher?.role === "school_admin";
 
   const [origin, setOrigin] = useState("");
-  useEffect(() => { setOrigin(window.location.origin); }, []);
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
 
   const [buyingGb, setBuyingGb] = useState<number | null>(null);
   const [checkoutError, setCheckoutError] = useState<string | null>(null);
@@ -158,7 +149,7 @@ export default function StoragePage() {
         `${origin}/school/storage?success=1`,
         `${origin}/school/storage?cancelled=1`,
       );
-      window.location.href = checkout_url;
+      window.location.assign(checkout_url);
     } catch {
       setCheckoutError("Could not start checkout. Please try again.");
       setBuyingGb(null);
@@ -199,15 +190,20 @@ export default function StoragePage() {
               {/* Quota breakdown: base + purchased */}
               <div className="flex gap-6 text-xs text-gray-500">
                 <span>
-                  <span className="font-medium text-gray-700">{storage.base_gb} GB</span> base (plan)
+                  <span className="font-medium text-gray-700">{storage.base_gb} GB</span>{" "}
+                  base (plan)
                 </span>
                 {storage.purchased_gb > 0 && (
                   <span>
-                    <span className="font-medium text-gray-700">+{storage.purchased_gb} GB</span> purchased
+                    <span className="font-medium text-gray-700">
+                      +{storage.purchased_gb} GB
+                    </span>{" "}
+                    purchased
                   </span>
                 )}
                 <span>
-                  <span className="font-medium text-gray-700">{storage.total_gb} GB</span> total
+                  <span className="font-medium text-gray-700">{storage.total_gb} GB</span>{" "}
+                  total
                 </span>
               </div>
 
@@ -263,17 +259,19 @@ export default function StoragePage() {
                         Grade {item.grade}
                       </span>
                     </td>
-                    <td className="px-4 py-3 text-right font-mono text-sm tabular-nums text-gray-700">
+                    <td className="px-4 py-3 text-right font-mono text-sm text-gray-700 tabular-nums">
                       {item.gb_used.toFixed(2)} GB
                     </td>
                     <td className="px-4 py-3 text-right text-xs text-gray-400 tabular-nums">
                       {item.job_count} build{item.job_count !== 1 ? "s" : ""}
                     </td>
-                    <td className="px-4 py-3 w-32">
+                    <td className="w-32 px-4 py-3">
                       <div className="h-1.5 overflow-hidden rounded-full bg-gray-100">
                         <div
                           className="h-full rounded-full bg-blue-400"
-                          style={{ width: `${Math.min((item.gb_used / storage.total_gb) * 100, 100)}%` }}
+                          style={{
+                            width: `${Math.min((item.gb_used / storage.total_gb) * 100, 100)}%`,
+                          }}
                         />
                       </div>
                     </td>
@@ -299,7 +297,9 @@ export default function StoragePage() {
       {/* Add-on purchase — admins only */}
       {isAdmin && (
         <div className="space-y-3">
-          <h2 className="text-base font-semibold text-gray-900">Purchase additional storage</h2>
+          <h2 className="text-base font-semibold text-gray-900">
+            Purchase additional storage
+          </h2>
           <p className="text-sm text-gray-500">
             One-time purchases. Storage never expires and carries over on plan changes.
           </p>
@@ -317,7 +317,6 @@ export default function StoragePage() {
                 key={pkg.gb}
                 gb={pkg.gb}
                 priceUsd={pkg.priceUsd}
-                label={pkg.label}
                 onBuy={() => handleBuy(pkg.gb)}
                 isLoading={buyingGb === pkg.gb}
               />

--- a/web/app/(school)/school/students/page.tsx
+++ b/web/app/(school)/school/students/page.tsx
@@ -44,14 +44,20 @@ function ProgressBar({ pct }: { pct: number }) {
           style={{ width: `${clamped}%` }}
         />
       </div>
-      <span className="text-xs tabular-nums text-gray-500">{Math.round(clamped)}%</span>
+      <span className="text-xs text-gray-500 tabular-nums">{Math.round(clamped)}%</span>
     </div>
   );
 }
 
 // ── Teacher view (non-admin) ──────────────────────────────────────────────────
 
-function TeacherStudentView({ schoolId, teacherId }: { schoolId: string; teacherId: string }) {
+function TeacherStudentView({
+  schoolId,
+  teacherId,
+}: {
+  schoolId: string;
+  teacherId: string;
+}) {
   // Get this teacher's assigned grades
   const { data: teachers, isLoading: loadingTeachers } = useQuery({
     queryKey: ["teachers", schoolId],
@@ -127,12 +133,16 @@ function TeacherStudentView({ schoolId, teacherId }: { schoolId: string; teacher
               <tbody className="divide-y divide-gray-50">
                 {students.map((s) => (
                   <tr key={s.student_id} className="hover:bg-gray-50">
-                    <td className="px-4 py-3 font-medium text-gray-800">{s.student_name}</td>
+                    <td className="px-4 py-3 font-medium text-gray-800">
+                      {s.student_name}
+                    </td>
                     <td className="px-4 py-3 text-gray-600">Grade {s.grade}</td>
                     <td className="px-4 py-3">
-                      <ProgressBar pct={(s.units_completed / Math.max(s.total_units, 1)) * 100} />
+                      <ProgressBar
+                        pct={(s.units_completed / Math.max(s.total_units, 1)) * 100}
+                      />
                     </td>
-                    <td className="px-4 py-3 tabular-nums text-gray-600">
+                    <td className="px-4 py-3 text-gray-600 tabular-nums">
                       {s.avg_score_pct != null ? `${Math.round(s.avg_score_pct)}%` : "—"}
                     </td>
                     <td className="px-4 py-3 text-xs text-gray-400">
@@ -142,7 +152,10 @@ function TeacherStudentView({ schoolId, teacherId }: { schoolId: string; teacher
                 ))}
                 {students.length === 0 && (
                   <tr>
-                    <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-400">
+                    <td
+                      colSpan={5}
+                      className="px-4 py-8 text-center text-sm text-gray-400"
+                    >
                       {assignedGrades && assignedGrades.length === 0
                         ? "No grades assigned yet. Ask your school admin to assign grades to your account."
                         : "No students found for your assigned grades."}
@@ -194,7 +207,10 @@ function RosterRow({ item, schoolId }: { item: RosterItem; schoolId: string }) {
           {item.student_id && item.status === "active" && (
             <button
               type="button"
-              onClick={() => { setConfirmReset(true); setMsg(null); }}
+              onClick={() => {
+                setConfirmReset(true);
+                setMsg(null);
+              }}
               className="rounded-md p-1 text-gray-400 hover:bg-amber-50 hover:text-amber-600"
               aria-label="Reset password"
               title="Reset password"
@@ -208,8 +224,8 @@ function RosterRow({ item, schoolId }: { item: RosterItem; schoolId: string }) {
         <tr>
           <td colSpan={4} className="bg-amber-50 px-4 py-3">
             <p className="mb-2 text-xs text-amber-800">
-              Reset password for <strong>{item.student_email}</strong>? A new
-              temporary password will be emailed to them.
+              Reset password for <strong>{item.student_email}</strong>? A new temporary
+              password will be emailed to them.
             </p>
             <div className="flex gap-2">
               <Button
@@ -282,7 +298,11 @@ function AdminStudentView({ schoolId }: { schoolId: string }) {
 
   const { mutate: doProvision, isPending: provisioning } = useMutation({
     mutationFn: () =>
-      provisionStudent(schoolId, { name: addName, email: addEmail, grade: Number(addGrade) }),
+      provisionStudent(schoolId, {
+        name: addName,
+        email: addEmail,
+        grade: Number(addGrade),
+      }),
     onSuccess: (res) => {
       setAddSuccess(res.email);
       setAddName("");
@@ -447,7 +467,10 @@ function AdminStudentView({ schoolId }: { schoolId: string }) {
                 id="student_email"
                 type="email"
                 value={addEmail}
-                onChange={(e) => { setAddEmail(e.target.value); setAddError(null); }}
+                onChange={(e) => {
+                  setAddEmail(e.target.value);
+                  setAddError(null);
+                }}
                 placeholder="alex@school.edu"
               />
             </div>
@@ -460,7 +483,9 @@ function AdminStudentView({ schoolId }: { schoolId: string }) {
                 className="h-9 w-full rounded-md border border-gray-200 bg-white px-3 text-sm focus:ring-2 focus:ring-indigo-500 focus:outline-none"
               >
                 {[5, 6, 7, 8, 9, 10, 11, 12].map((g) => (
-                  <option key={g} value={g}>Grade {g}</option>
+                  <option key={g} value={g}>
+                    Grade {g}
+                  </option>
                 ))}
               </select>
             </div>
@@ -471,13 +496,17 @@ function AdminStudentView({ schoolId }: { schoolId: string }) {
             <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-green-700">
               <Check className="h-4 w-4 shrink-0" />
               Student added. A temporary password has been sent to{" "}
-              <span className="font-medium">{addSuccess}</span>. They must set a
-              new password on first login.
+              <span className="font-medium">{addSuccess}</span>. They must set a new
+              password on first login.
             </div>
           )}
 
           <Button
-            onClick={() => { setAddError(null); setAddSuccess(null); doProvision(); }}
+            onClick={() => {
+              setAddError(null);
+              setAddSuccess(null);
+              doProvision();
+            }}
             disabled={provisioning || !addName || !addEmail}
             className="gap-2"
           >

--- a/web/app/(school)/school/subscription/page.tsx
+++ b/web/app/(school)/school/subscription/page.tsx
@@ -13,7 +13,17 @@ import {
 import { SCHOOL_PLANS_LIST, formatPlanPrice } from "@/lib/pricing";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Loader2, CheckCircle, XCircle, CreditCard, Users, GraduationCap, AlertTriangle, Hammer, PackagePlus } from "lucide-react";
+import {
+  Loader2,
+  CheckCircle,
+  XCircle,
+  CreditCard,
+  Users,
+  GraduationCap,
+  AlertTriangle,
+  Hammer,
+  PackagePlus,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // ── Seat usage bar ────────────────────────────────────────────────────────────
@@ -117,13 +127,13 @@ function CancelDialog({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
       <div className="w-full max-w-md rounded-xl border bg-white p-6 shadow-xl">
         <div className="mb-4 flex items-center gap-3">
-          <AlertTriangle className="h-5 w-5 text-amber-500 shrink-0" />
+          <AlertTriangle className="h-5 w-5 shrink-0 text-amber-500" />
           <h2 className="text-base font-semibold text-gray-900">Cancel subscription?</h2>
         </div>
         <p className="mb-1 text-sm text-gray-600">
           Your school will retain access until{" "}
-          <strong>{endDate ?? "the end of the billing period"}</strong>. After that, limits
-          revert to the Starter plan.
+          <strong>{endDate ?? "the end of the billing period"}</strong>. After that,
+          limits revert to the Starter plan.
         </p>
         <p className="mb-5 text-sm text-gray-500">
           You can resubscribe at any time before the period ends.
@@ -194,7 +204,7 @@ export default function SubscriptionPage() {
         `${origin}/school/subscription?success=1`,
         `${origin}/school/subscription?cancelled=1`,
       );
-      window.location.href = checkout_url;
+      window.location.assign(checkout_url);
     } catch (err: unknown) {
       const msg =
         err != null &&
@@ -284,7 +294,7 @@ export default function SubscriptionPage() {
           ) : (
             <div className="space-y-4">
               <div className="flex items-center gap-3">
-                <span className="text-xl font-bold capitalize text-gray-900">
+                <span className="text-xl font-bold text-gray-900 capitalize">
                   {activePlan === "none" ? "No subscription" : activePlan}
                 </span>
                 {sub?.status && <StatusBadge status={sub.status} />}
@@ -326,12 +336,16 @@ export default function SubscriptionPage() {
                         <>
                           <span className="font-medium text-amber-600">Cancels</span> —
                           access continues until{" "}
-                          <span className="font-medium text-gray-700">{periodEndDate}</span>
+                          <span className="font-medium text-gray-700">
+                            {periodEndDate}
+                          </span>
                         </>
                       ) : (
                         <>
                           Renews on{" "}
-                          <span className="font-medium text-gray-700">{periodEndDate}</span>
+                          <span className="font-medium text-gray-700">
+                            {periodEndDate}
+                          </span>
                         </>
                       )}
                     </p>
@@ -360,8 +374,8 @@ export default function SubscriptionPage() {
 
               {!hasSub && (
                 <p className="text-sm text-gray-500">
-                  Your school is on the free Starter plan. Upgrade to unlock more students,
-                  teachers, and pipeline runs.
+                  Your school is on the free Starter plan. Upgrade to unlock more
+                  students, teachers, and pipeline runs.
                 </p>
               )}
             </div>
@@ -382,10 +396,13 @@ export default function SubscriptionPage() {
             <span className="font-medium text-gray-700">{sub.builds_used}</span>.
             {sub.builds_credits_balance > 0 && (
               <>
-                {" "}Rollover credit balance:{" "}
+                {" "}
+                Rollover credit balance:{" "}
                 <span className="font-medium text-blue-700">
-                  {sub.builds_credits_balance} credit{sub.builds_credits_balance !== 1 ? "s" : ""}
-                </span>.
+                  {sub.builds_credits_balance} credit
+                  {sub.builds_credits_balance !== 1 ? "s" : ""}
+                </span>
+                .
               </>
             )}
           </p>
@@ -403,7 +420,7 @@ export default function SubscriptionPage() {
               {sub.builds_credits_balance === 0 && (
                 <Button
                   size="sm"
-                  className="gap-2 shrink-0"
+                  className="shrink-0 gap-2"
                   disabled={buyingExtraBuild}
                   onClick={handleExtraBuild}
                 >
@@ -422,7 +439,7 @@ export default function SubscriptionPage() {
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
             {(
               [
-                { size: 3,  price: "$39",  saving: null },
+                { size: 3, price: "$39", saving: null },
                 { size: 10, price: "$119", saving: "Save 21%" },
                 { size: 25, price: "$269", saving: "Save 28%" },
               ] as { size: 3 | 10 | 25; price: string; saving: string | null }[]
@@ -506,12 +523,17 @@ export default function SubscriptionPage() {
 
                   <div className="mb-1">
                     <h3 className="text-base font-semibold text-gray-900">{plan.name}</h3>
-                    <p className="mt-0.5 text-sm text-gray-500">{formatPlanPrice(plan)}</p>
+                    <p className="mt-0.5 text-sm text-gray-500">
+                      {formatPlanPrice(plan)}
+                    </p>
                   </div>
 
                   <ul className="mt-3 flex-1 space-y-1.5">
                     {plan.features.map((f) => (
-                      <li key={f} className="flex items-start gap-1.5 text-xs text-gray-600">
+                      <li
+                        key={f}
+                        className="flex items-start gap-1.5 text-xs text-gray-600"
+                      >
                         <CheckCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-green-500" />
                         {f}
                       </li>
@@ -520,12 +542,7 @@ export default function SubscriptionPage() {
 
                   <div className="mt-4">
                     {isCurrent ? (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="w-full"
-                        disabled
-                      >
+                      <Button variant="outline" size="sm" className="w-full" disabled>
                         Current plan
                       </Button>
                     ) : isEnterprise ? (
@@ -534,7 +551,10 @@ export default function SubscriptionPage() {
                         size="sm"
                         className="w-full gap-2"
                         onClick={() =>
-                          window.open("mailto:sales@studybuddy.example.com?subject=Enterprise%20Plan", "_blank")
+                          window.open(
+                            "mailto:sales@studybuddy.example.com?subject=Enterprise%20Plan",
+                            "_blank",
+                          )
                         }
                       >
                         Contact sales

--- a/web/app/(school)/school/teachers/page.tsx
+++ b/web/app/(school)/school/teachers/page.tsx
@@ -69,7 +69,11 @@ function GradeEditor({
   function toggle(grade: number) {
     setSelected((prev) => {
       const next = new Set(prev);
-      next.has(grade) ? next.delete(grade) : next.add(grade);
+      if (next.has(grade)) {
+        next.delete(grade);
+      } else {
+        next.add(grade);
+      }
       return next;
     });
   }
@@ -186,7 +190,10 @@ function TeacherRow({
           {isAdmin && item.role !== "school_admin" && (
             <button
               type="button"
-              onClick={() => { setConfirmPromote(true); setActionMsg(null); }}
+              onClick={() => {
+                setConfirmPromote(true);
+                setActionMsg(null);
+              }}
               className="rounded-md p-1.5 text-gray-400 hover:bg-purple-50 hover:text-purple-600"
               aria-label="Promote to school admin"
               title="Promote to admin"
@@ -197,7 +204,10 @@ function TeacherRow({
           {isAdmin && (
             <button
               type="button"
-              onClick={() => { setConfirmReset(true); setActionMsg(null); }}
+              onClick={() => {
+                setConfirmReset(true);
+                setActionMsg(null);
+              }}
               className="rounded-md p-1.5 text-gray-400 hover:bg-amber-50 hover:text-amber-600"
               aria-label="Reset password"
               title="Reset password"
@@ -327,8 +337,8 @@ export default function TeachersPage() {
       if (status === 409) {
         setAddError("A teacher with that email already exists.");
       } else {
-        const detail = (err as { response?: { data?: { detail?: string } } })
-          ?.response?.data?.detail;
+        const detail = (err as { response?: { data?: { detail?: string } } })?.response
+          ?.data?.detail;
         setAddError(detail ?? "Could not add teacher. Please try again.");
       }
     },
@@ -343,7 +353,7 @@ export default function TeachersPage() {
 
       {/* ── Teacher roster ── */}
       <section>
-        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
+        <h2 className="mb-3 text-sm font-semibold tracking-wide text-gray-500 uppercase">
           Teachers at this school
         </h2>
         {isLoading ? (
@@ -409,8 +419,8 @@ export default function TeachersPage() {
                 <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-green-700">
                   <Check className="h-4 w-4 shrink-0" />
                   Teacher added. A temporary password has been sent to{" "}
-                  <span className="font-medium">{addSuccess}</span>. They must set
-                  a new password on first login.
+                  <span className="font-medium">{addSuccess}</span>. They must set a new
+                  password on first login.
                 </div>
               )}
 

--- a/web/app/(student)/curriculum/page.tsx
+++ b/web/app/(student)/curriculum/page.tsx
@@ -6,7 +6,14 @@ import { LinkButton } from "@/components/ui/link-button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { OfflineBanner } from "@/components/student/OfflineBanner";
 import { useTranslations } from "next-intl";
-import { FlaskConical, CheckCircle2, Circle, AlertCircle, Clock, BookOpen } from "lucide-react";
+import {
+  FlaskConical,
+  CheckCircle2,
+  Circle,
+  AlertCircle,
+  Clock,
+  BookOpen,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { UnitStatus } from "@/lib/types/api";
 
@@ -56,9 +63,7 @@ export default function CurriculumMapPage() {
         ) : !tree?.subjects?.length ? (
           <div className="rounded-xl border border-gray-200 bg-white py-16 text-center">
             <BookOpen className="mx-auto mb-3 h-10 w-10 text-gray-300" />
-            <p className="mb-1 text-sm font-medium text-gray-600">
-              {t("no_units")}
-            </p>
+            <p className="mb-1 text-sm font-medium text-gray-600">{t("no_units")}</p>
             <p className="text-xs text-gray-400">
               Your curriculum hasn&apos;t been published yet. Check back soon.
             </p>

--- a/web/app/(student)/dashboard/page.tsx
+++ b/web/app/(student)/dashboard/page.tsx
@@ -73,7 +73,8 @@ export default function DashboardPage() {
                 Welcome to StudyBuddy!
               </p>
               <p className="mb-4 text-xs text-indigo-600">
-                Pick a subject below to start your first lesson. Your progress will appear here.
+                Pick a subject below to start your first lesson. Your progress will appear
+                here.
               </p>
               <LinkButton href="/subjects" className="mx-auto w-fit text-xs">
                 Browse Subjects

--- a/web/app/(student)/help/page.tsx
+++ b/web/app/(student)/help/page.tsx
@@ -94,7 +94,7 @@ export default function StudentHelpPage() {
 
       {/* Getting started */}
       <section>
-        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">
+        <h2 className="mb-4 text-sm font-semibold tracking-wide text-gray-500 uppercase">
           Getting Started
         </h2>
         <ol className="space-y-3">
@@ -118,7 +118,7 @@ export default function StudentHelpPage() {
       {/* Mind map */}
       {map && (
         <section>
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">
+          <h2 className="mb-4 text-sm font-semibold tracking-wide text-gray-500 uppercase">
             Your Role — Mind Map
           </h2>
           <div className="overflow-hidden rounded-xl border border-gray-200 shadow-sm">
@@ -152,7 +152,7 @@ export default function StudentHelpPage() {
 
       {/* Quick reference */}
       <section>
-        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">
+        <h2 className="mb-4 text-sm font-semibold tracking-wide text-gray-500 uppercase">
           Quick Reference
         </h2>
         <div className="overflow-hidden rounded-xl border border-gray-200 shadow-sm">
@@ -173,7 +173,10 @@ export default function StudentHelpPage() {
                 ["See subject totals", "/stats"],
                 !demo && ["Update language / notifications", "/account/settings"],
                 ["Toggle dyslexia font", "Eye icon in top-right header, or Alt+D"],
-                demo && ["Demo limitations", "Grade 8 only; audio download requires full account"],
+                demo && [
+                  "Demo limitations",
+                  "Grade 8 only; audio download requires full account",
+                ],
               ]
                 .filter((r): r is string[] => Boolean(r))
                 .map(([task, where]) => (

--- a/web/app/(student)/stats/page.tsx
+++ b/web/app/(student)/stats/page.tsx
@@ -72,9 +72,7 @@ export default function StatsPage() {
         ) : !stats || stats.quizzes_completed === 0 ? (
           <div className="rounded-xl border border-gray-200 bg-white py-16 text-center">
             <BarChart2 className="mx-auto mb-3 h-10 w-10 text-gray-300" />
-            <p className="mb-1 text-sm font-medium text-gray-600">
-              No stats yet
-            </p>
+            <p className="mb-1 text-sm font-medium text-gray-600">No stats yet</p>
             <p className="mb-4 text-xs text-gray-400">
               Complete your first quiz to start tracking your progress here.
             </p>

--- a/web/app/(teacher)/layout.tsx
+++ b/web/app/(teacher)/layout.tsx
@@ -28,7 +28,9 @@ export default async function TeacherLayout({ children }: { children: React.Reac
     <QueryProvider>
       <div className="flex min-h-screen flex-col bg-gray-50">
         <PortalHeader portal="school" userName={userName} />
-        <main id="main-content" className="flex-1">{children}</main>
+        <main id="main-content" className="flex-1">
+          {children}
+        </main>
         <PortalFooter />
       </div>
     </QueryProvider>

--- a/web/app/(teacher)/teacher/billing/connect/page.tsx
+++ b/web/app/(teacher)/teacher/billing/connect/page.tsx
@@ -1,17 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   getConnectEarnings,
   getConnectStatus,
   refreshConnectLink,
   startConnectOnboarding,
   type ConnectStatus,
-  type EarningsItem,
 } from "@/lib/api/teacher";
 import { useTeacherIdFromToken } from "@/lib/hooks/useIndependentTeacher";
-import { cn } from "@/lib/utils";
 import {
   AlertTriangle,
   ArrowRight,
@@ -51,7 +48,9 @@ function OnboardingBanner({
             Stripe is sending {TEACHER_PCT}% of each student payment to your account.
           </p>
           {status.stripe_account_id && (
-            <p className="mt-1 font-mono text-xs text-green-600">{status.stripe_account_id}</p>
+            <p className="mt-1 font-mono text-xs text-green-600">
+              {status.stripe_account_id}
+            </p>
           )}
         </div>
       </div>
@@ -65,8 +64,8 @@ function OnboardingBanner({
         <div className="flex-1">
           <p className="text-sm font-semibold text-amber-900">Onboarding incomplete</p>
           <p className="mt-0.5 text-xs text-amber-700">
-            Your Stripe Connect account exists but payout capability is not yet
-            enabled. Complete onboarding to start receiving student payments.
+            Your Stripe Connect account exists but payout capability is not yet enabled.
+            Complete onboarding to start receiving student payments.
           </p>
           <button
             onClick={onRefresh}
@@ -105,7 +104,8 @@ function OnboardingBanner({
             </li>
             <li className="flex items-center gap-2">
               <CheckCircle2 className="h-3.5 w-3.5 flex-shrink-0 text-indigo-500" />
-              {PLATFORM_PCT}% platform fee covers hosting, content generation &amp; support
+              {PLATFORM_PCT}% platform fee covers hosting, content generation &amp;
+              support
             </li>
             <li className="flex items-center gap-2">
               <CheckCircle2 className="h-3.5 w-3.5 flex-shrink-0 text-indigo-500" />
@@ -206,7 +206,9 @@ function EarningsTable({ teacherId }: { teacherId: string }) {
             {earnings.map((t) => (
               <tr key={t.transfer_id} className="hover:bg-gray-50">
                 <td className="px-4 py-3 text-xs text-gray-500">{fmtDate(t.created)}</td>
-                <td className="px-4 py-3 font-mono text-xs text-gray-400">{t.transfer_id}</td>
+                <td className="px-4 py-3 font-mono text-xs text-gray-400">
+                  {t.transfer_id}
+                </td>
                 <td className="px-4 py-3 text-right font-mono text-sm font-medium text-gray-900">
                   {fmt(t.amount_cents, t.currency)}
                 </td>
@@ -223,7 +225,6 @@ function EarningsTable({ teacherId }: { teacherId: string }) {
 
 export default function TeacherConnectBillingPage() {
   const teacherId = useTeacherIdFromToken();
-  const queryClient = useQueryClient();
 
   const { data: status, isLoading: statusLoading } = useQuery({
     queryKey: ["teacher-connect-status", teacherId],
@@ -265,8 +266,8 @@ export default function TeacherConnectBillingPage() {
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-gray-900">Revenue-share billing</h1>
         <p className="mt-1 text-sm text-gray-500">
-          Receive {TEACHER_PCT}% of each student&apos;s ${STUDENT_PRICE_MONTHLY}/month payment directly
-          via Stripe Connect.
+          Receive {TEACHER_PCT}% of each student&apos;s ${STUDENT_PRICE_MONTHLY}/month
+          payment directly via Stripe Connect.
         </p>
       </div>
 
@@ -302,13 +303,18 @@ export default function TeacherConnectBillingPage() {
         <ol className="mt-2 list-decimal space-y-1.5 pl-4">
           <li>Complete Stripe Express onboarding (takes ~5 minutes).</li>
           <li>
-            Share your enrollment link with students — they pay ${STUDENT_PRICE_MONTHLY}/month.
+            Share your enrollment link with students — they pay ${STUDENT_PRICE_MONTHLY}
+            /month.
           </li>
           <li>
-            Stripe automatically sends {TEACHER_PCT}% (${(parseFloat(STUDENT_PRICE_MONTHLY) * TEACHER_PCT / 100).toFixed(2)}/student/month)
-            to your bank. The platform keeps {PLATFORM_PCT}%.
+            Stripe automatically sends {TEACHER_PCT}% ($
+            {((parseFloat(STUDENT_PRICE_MONTHLY) * TEACHER_PCT) / 100).toFixed(2)}
+            /student/month) to your bank. The platform keeps {PLATFORM_PCT}%.
           </li>
-          <li>Payouts arrive on your normal Stripe payout schedule (usually 2 business days).</li>
+          <li>
+            Payouts arrive on your normal Stripe payout schedule (usually 2 business
+            days).
+          </li>
         </ol>
         <p className="mt-3">
           Questions about Stripe Express?{" "}

--- a/web/app/(teacher)/teacher/billing/connect/return/page.tsx
+++ b/web/app/(teacher)/teacher/billing/connect/return/page.tsx
@@ -41,8 +41,10 @@ export default function ConnectReturnPage() {
         }
       });
 
-    return () => { cancelled = true; };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [teacherId]);
 
   return (
@@ -59,7 +61,9 @@ export default function ConnectReturnPage() {
             <p className="text-base font-semibold text-gray-900">
               Connect account active!
             </p>
-            <p className="mt-1 text-sm text-gray-500">Redirecting to your billing page…</p>
+            <p className="mt-1 text-sm text-gray-500">
+              Redirecting to your billing page…
+            </p>
           </>
         ) : (
           <>

--- a/web/app/(teacher)/teacher/subscription/page.tsx
+++ b/web/app/(teacher)/teacher/subscription/page.tsx
@@ -10,24 +10,17 @@
  * - Cancel subscription link
  */
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   cancelTeacherSubscription,
   getTeacherSubscription,
   startTeacherCheckout,
   upgradeTeacherPlan,
-  type TeacherSubscriptionStatus,
 } from "@/lib/api/teacher-subscription";
 import { useTeacherIdFromToken } from "@/lib/hooks/useIndependentTeacher";
 import { cn } from "@/lib/utils";
-import {
-  AlertTriangle,
-  CheckCircle2,
-  ChevronRight,
-  Loader2,
-  Users,
-} from "lucide-react";
+import { AlertTriangle, CheckCircle2, ChevronRight, Loader2, Users } from "lucide-react";
 
 // ── Plan definitions (mirrors pricing.py TEACHER_PLANS) ──────────────────────
 
@@ -131,9 +124,9 @@ function OverQuotaBanner({ since }: { since: string | null }) {
         <p className="text-sm font-semibold text-red-900">Student limit exceeded</p>
         <p className="mt-0.5 text-xs text-red-700">
           You have more enrolled students than your plan allows.
-          {sinceStr && ` This has been the case since ${sinceStr}.`}
-          {" "}Upgrade your plan to restore full access, or remove students to get back within your limit.
-          After 7 days over-limit, new content access may be restricted.
+          {sinceStr && ` This has been the case since ${sinceStr}.`} Upgrade your plan to
+          restore full access, or remove students to get back within your limit. After 7
+          days over-limit, new content access may be restricted.
         </p>
       </div>
     </div>
@@ -208,11 +201,13 @@ function PlanCard({
         </div>
       ) : (
         <button
-          onClick={() =>
-            hasSubscription ? onUpgrade(plan.id) : onCheckout(plan.id)
-          }
+          onClick={() => (hasSubscription ? onUpgrade(plan.id) : onCheckout(plan.id))}
           disabled={isPending || (tooSmall && hasSubscription)}
-          title={tooSmall && hasSubscription ? `You already have ${seatsUsed} students — this plan only allows ${plan.max_students}` : undefined}
+          title={
+            tooSmall && hasSubscription
+              ? `You already have ${seatsUsed} students — this plan only allows ${plan.max_students}`
+              : undefined
+          }
           className={cn(
             "inline-flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors",
             tooSmall && hasSubscription
@@ -286,14 +281,11 @@ export default function TeacherSubscriptionPage() {
   });
 
   const isPending =
-    upgradeMutation.isPending ||
-    checkoutMutation.isPending ||
-    cancelMutation.isPending;
+    upgradeMutation.isPending || checkoutMutation.isPending || cancelMutation.isPending;
   const mutationError =
     upgradeMutation.error ?? checkoutMutation.error ?? cancelMutation.error;
 
-  const hasSubscription =
-    !!sub && sub.plan !== "none" && sub.status !== "cancelled";
+  const hasSubscription = !!sub && sub.plan !== "none" && sub.status !== "cancelled";
 
   const handleUpgrade = (planId: PlanId) => {
     setPendingPlanId(planId);
@@ -338,8 +330,7 @@ export default function TeacherSubscriptionPage() {
           <div className="mb-3 flex items-center gap-2">
             <Users className="h-5 w-5 text-gray-400" />
             <h2 className="text-base font-semibold text-gray-900">
-              Student seats —{" "}
-              <span className="capitalize">{sub.plan}</span> plan
+              Student seats — <span className="capitalize">{sub.plan}</span> plan
             </h2>
           </div>
           <SeatUsageBar
@@ -395,9 +386,7 @@ export default function TeacherSubscriptionPage() {
             </button>
           ) : (
             <div className="flex items-center gap-3">
-              <p className="text-sm text-gray-600">
-                Cancel at end of billing period?
-              </p>
+              <p className="text-sm text-gray-600">Cancel at end of billing period?</p>
               <button
                 onClick={() => cancelMutation.mutate()}
                 disabled={cancelMutation.isPending}

--- a/web/app/api/auth/logout/route.ts
+++ b/web/app/api/auth/logout/route.ts
@@ -4,9 +4,7 @@ export async function GET(request: NextRequest) {
   const isLocalAuth = request.cookies.has("sb_local_teacher_session");
 
   // Local-auth users go back to the school login page; everyone else to home.
-  const destination = isLocalAuth
-    ? "/school/login"
-    : "/";
+  const destination = isLocalAuth ? "/school/login" : "/";
 
   const response = NextResponse.redirect(
     new URL(destination, process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000"),

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -30,7 +30,8 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   title: {
-    default: "StudyBuddy \u2014 Your bridge from lessons to a world that's always current",
+    default:
+      "StudyBuddy \u2014 Your bridge from lessons to a world that's always current",
     template: "%s | StudyBuddy",
   },
   description:

--- a/web/components/content/Markdown.tsx
+++ b/web/components/content/Markdown.tsx
@@ -93,7 +93,7 @@ export function SBMarkdown({
             );
           },
           blockquote: ({ children }) => (
-            <blockquote className="my-3 border-l-4 border-indigo-200 bg-indigo-50/50 px-4 py-2 text-sm italic text-gray-700">
+            <blockquote className="my-3 border-l-4 border-indigo-200 bg-indigo-50/50 px-4 py-2 text-sm text-gray-700 italic">
               {children}
             </blockquote>
           ),

--- a/web/components/demo/DemoTeacherRequestModal.tsx
+++ b/web/components/demo/DemoTeacherRequestModal.tsx
@@ -173,7 +173,9 @@ export function DemoTeacherRequestModal() {
                             onClick={handleResend}
                             className="text-cyan-600 underline underline-offset-2 hover:text-cyan-800 disabled:opacity-50"
                           >
-                            {resendState === "sending" ? t("resend_sending") : t("resend_link")}
+                            {resendState === "sending"
+                              ? t("resend_sending")
+                              : t("resend_link")}
                           </button>
                         </p>
                       )}

--- a/web/components/help/HelpWidget.tsx
+++ b/web/components/help/HelpWidget.tsx
@@ -115,7 +115,7 @@ function StepList({ steps }: { steps: string[] }) {
           <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-violet-100 text-xs font-semibold text-violet-700">
             {i + 1}
           </span>
-          <span className="text-sm text-gray-700 leading-snug">{step}</span>
+          <span className="text-sm leading-snug text-gray-700">{step}</span>
         </li>
       ))}
     </ol>
@@ -165,14 +165,14 @@ function FeedbackBar({ interactionId }: { interactionId: string | null }) {
       <button
         onClick={() => handleFeedback(true)}
         aria-label="Thumbs up — this answer was helpful"
-        className="rounded p-1 text-gray-400 hover:bg-green-50 hover:text-green-600 focus:outline-none focus:ring-1 focus:ring-green-400"
+        className="rounded p-1 text-gray-400 hover:bg-green-50 hover:text-green-600 focus:ring-1 focus:ring-green-400 focus:outline-none"
       >
         <ThumbsUp className="h-3.5 w-3.5" />
       </button>
       <button
         onClick={() => handleFeedback(false)}
         aria-label="Thumbs down — this answer was not helpful"
-        className="rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-500 focus:outline-none focus:ring-1 focus:ring-red-400"
+        className="rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-500 focus:ring-1 focus:ring-red-400 focus:outline-none"
       >
         <ThumbsDown className="h-3.5 w-3.5" />
       </button>
@@ -191,7 +191,7 @@ function ResponseCard({ response }: { response: HelpAskResponse }) {
 
       {/* Result */}
       {response.result && (
-        <p className="rounded-md bg-green-50 px-3 py-2 text-xs text-green-800 leading-snug">
+        <p className="rounded-md bg-green-50 px-3 py-2 text-xs leading-snug text-green-800">
           {response.result}
         </p>
       )}
@@ -201,9 +201,7 @@ function ResponseCard({ response }: { response: HelpAskResponse }) {
 
       {/* Sources (small attribution) */}
       {response.sources.length > 0 && (
-        <p className="text-xs text-gray-400">
-          Sources: {response.sources.join(" · ")}
-        </p>
+        <p className="text-xs text-gray-400">Sources: {response.sources.join(" · ")}</p>
       )}
 
       {/* Thumbs feedback (Deliver-4) */}
@@ -214,7 +212,7 @@ function ResponseCard({ response }: { response: HelpAskResponse }) {
 
 function LoadingSkeleton() {
   return (
-    <div className="space-y-3 animate-pulse">
+    <div className="animate-pulse space-y-3">
       <div className="h-4 w-3/4 rounded bg-gray-200" />
       <div className="space-y-2">
         {[1, 2, 3].map((i) => (
@@ -279,9 +277,7 @@ export function HelpWidget() {
       setResponse(data);
     } catch (err) {
       setError(
-        err instanceof Error
-          ? err.message
-          : "Something went wrong. Please try again.",
+        err instanceof Error ? err.message : "Something went wrong. Please try again.",
       );
     } finally {
       setIsLoading(false);
@@ -305,7 +301,7 @@ export function HelpWidget() {
         <button
           onClick={handleOpen}
           aria-label="Open help"
-          className="fixed bottom-6 right-6 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-violet-600 text-white shadow-lg transition-transform hover:scale-105 hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2"
+          className="fixed right-6 bottom-6 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-violet-600 text-white shadow-lg transition-transform hover:scale-105 hover:bg-violet-700 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 focus:outline-none"
         >
           <HelpCircle className="h-6 w-6" />
         </button>
@@ -314,7 +310,7 @@ export function HelpWidget() {
       {/* ── Slide-up panel ──────────────────────────────────────────────── */}
       {isOpen && (
         <div
-          className="fixed bottom-6 right-6 z-50 flex w-[360px] flex-col rounded-2xl bg-white shadow-2xl ring-1 ring-gray-200"
+          className="fixed right-6 bottom-6 z-50 flex w-[360px] flex-col rounded-2xl bg-white shadow-2xl ring-1 ring-gray-200"
           style={{ maxHeight: "calc(100vh - 80px)" }}
           role="dialog"
           aria-label="StudyBuddy Help"
@@ -324,9 +320,7 @@ export function HelpWidget() {
           <div className="flex items-center justify-between rounded-t-2xl bg-violet-600 px-4 py-3">
             <div className="flex items-center gap-2">
               <HelpCircle className="h-4 w-4 text-violet-200" />
-              <span className="text-sm font-semibold text-white">
-                StudyBuddy Help
-              </span>
+              <span className="text-sm font-semibold text-white">StudyBuddy Help</span>
             </div>
             <button
               onClick={handleClose}
@@ -355,11 +349,9 @@ export function HelpWidget() {
                 onKeyDown={handleKeyDown}
                 placeholder="e.g. How do I add a teacher?"
                 rows={2}
-                className="w-full resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                className="w-full resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-violet-500 focus:ring-1 focus:ring-violet-500 focus:outline-none"
               />
-              <p className="mt-1 text-right text-xs text-gray-400">
-                Ctrl+Enter to send
-              </p>
+              <p className="mt-1 text-right text-xs text-gray-400">Ctrl+Enter to send</p>
             </div>
 
             {/* Submit / Reset buttons */}

--- a/web/components/layout/PortalHeader.tsx
+++ b/web/components/layout/PortalHeader.tsx
@@ -87,7 +87,7 @@ export function PortalHeader({
             </span>
           )}
           {now && (
-            <span className="whitespace-nowrap tabular-nums text-gray-500">
+            <span className="whitespace-nowrap text-gray-500 tabular-nums">
               {now.toLocaleDateString()}{" "}
               {now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
             </span>

--- a/web/components/school/LocalAuthGuard.tsx
+++ b/web/components/school/LocalAuthGuard.tsx
@@ -37,8 +37,7 @@ function decodeJwtPayload(token: string): Record<string, unknown> | null {
 }
 
 function clearLocalSession() {
-  document.cookie =
-    "sb_local_teacher_session=; path=/; SameSite=Strict; Max-Age=0";
+  document.cookie = "sb_local_teacher_session=; path=/; SameSite=Strict; Max-Age=0";
 }
 
 export function LocalAuthGuard({

--- a/web/components/school/SetupChecklist.tsx
+++ b/web/components/school/SetupChecklist.tsx
@@ -42,7 +42,8 @@ const STEPS: ChecklistItem[] = [
   },
   {
     label: "Assign a curriculum",
-    description: "Browse the catalog or build a custom curriculum, then assign it to a classroom.",
+    description:
+      "Browse the catalog or build a custom curriculum, then assign it to a classroom.",
     href: "/school/catalog",
     done: (s) => s.curriculum_assigned,
   },
@@ -68,9 +69,7 @@ export function SetupChecklist({ schoolId }: { schoolId: string }) {
       {/* Header */}
       <div className="mb-4 flex items-start justify-between gap-4">
         <div>
-          <h2 className="text-base font-semibold text-violet-900">
-            Set up your school
-          </h2>
+          <h2 className="text-base font-semibold text-violet-900">Set up your school</h2>
           <p className="mt-0.5 text-sm text-violet-700">
             Complete these steps to get your school ready for students.{" "}
             <span className="font-medium">
@@ -117,9 +116,7 @@ export function SetupChecklist({ schoolId }: { schoolId: string }) {
                 >
                   <Circle className="mt-0.5 h-5 w-5 shrink-0 text-violet-300 group-hover:text-violet-500" />
                   <div className="flex-1">
-                    <p className="text-sm font-medium text-violet-900">
-                      {step.label}
-                    </p>
+                    <p className="text-sm font-medium text-violet-900">{step.label}</p>
                     <p className="text-xs text-violet-600">{step.description}</p>
                   </div>
                   <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-violet-300 group-hover:text-violet-500" />

--- a/web/lib/api/admin.ts
+++ b/web/lib/api/admin.ts
@@ -210,10 +210,10 @@ export async function mergeStream(
   code: string,
   targetCode: string,
 ): Promise<{ affected_curricula: number; source_archived: boolean }> {
-  const res = await adminApi.post<{ affected_curricula: number; source_archived: boolean }>(
-    `/admin/streams/${code}/merge`,
-    { target_code: targetCode },
-  );
+  const res = await adminApi.post<{
+    affected_curricula: number;
+    source_archived: boolean;
+  }>(`/admin/streams/${code}/merge`, { target_code: targetCode });
   return res.data;
 }
 
@@ -1003,9 +1003,7 @@ export async function rejectDemoLead(
 }
 
 export async function listDemoGeoBlocks(): Promise<{ blocks: GeoBlockItem[] }> {
-  const res = await adminApi.get<{ blocks: GeoBlockItem[] }>(
-    "/admin/demo-geo-blocks",
-  );
+  const res = await adminApi.get<{ blocks: GeoBlockItem[] }>("/admin/demo-geo-blocks");
   return res.data;
 }
 

--- a/web/lib/api/help.ts
+++ b/web/lib/api/help.ts
@@ -49,9 +49,7 @@ export async function askHelp(body: HelpAskRequest): Promise<HelpAskResponse> {
 
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
-    throw new Error(
-      err?.detail ?? err?.error ?? `Help request failed (${res.status})`,
-    );
+    throw new Error(err?.detail ?? err?.error ?? `Help request failed (${res.status})`);
   }
 
   return res.json() as Promise<HelpAskResponse>;

--- a/web/lib/api/reports.ts
+++ b/web/lib/api/reports.ts
@@ -329,7 +329,9 @@ export interface SendReminderResponse {
 }
 
 export async function getAtRiskStudents(schoolId: string): Promise<AtRiskListResponse> {
-  const res = await schoolApi.get<AtRiskListResponse>(`/reports/school/${schoolId}/at-risk`);
+  const res = await schoolApi.get<AtRiskListResponse>(
+    `/reports/school/${schoolId}/at-risk`,
+  );
   return res.data;
 }
 

--- a/web/lib/api/school-admin.ts
+++ b/web/lib/api/school-admin.ts
@@ -154,9 +154,7 @@ export async function getSchoolPipelineJob(
   schoolId: string,
   jobId: string,
 ): Promise<PipelineJob> {
-  const res = await schoolApi.get<PipelineJob>(
-    `/schools/${schoolId}/pipeline/${jobId}`,
-  );
+  const res = await schoolApi.get<PipelineJob>(`/schools/${schoolId}/pipeline/${jobId}`);
   return res.data;
 }
 
@@ -190,16 +188,20 @@ export interface SchoolSubscription {
   seats_used_teachers: number;
   current_period_end: string | null;
   // Curriculum build allowance (Option A — absorbed into plan)
-  builds_included: number;        // -1 = unlimited (Enterprise)
+  builds_included: number; // -1 = unlimited (Enterprise)
   builds_used: number;
-  builds_remaining: number;       // -1 = unlimited
+  builds_remaining: number; // -1 = unlimited
   builds_period_end: string | null;
   // Rollover credit balance (Option C, #107 — never expires)
   builds_credits_balance: number;
 }
 
-export async function getSchoolSubscription(schoolId: string): Promise<SchoolSubscription> {
-  const res = await schoolApi.get<SchoolSubscription>(`/schools/${schoolId}/subscription`);
+export async function getSchoolSubscription(
+  schoolId: string,
+): Promise<SchoolSubscription> {
+  const res = await schoolApi.get<SchoolSubscription>(
+    `/schools/${schoolId}/subscription`,
+  );
   return res.data;
 }
 
@@ -219,9 +221,10 @@ export async function createSchoolCheckout(
 export async function cancelSchoolSubscription(
   schoolId: string,
 ): Promise<{ status: string; current_period_end: string | null }> {
-  const res = await schoolApi.delete<{ status: string; current_period_end: string | null }>(
-    `/schools/${schoolId}/subscription`,
-  );
+  const res = await schoolApi.delete<{
+    status: string;
+    current_period_end: string | null;
+  }>(`/schools/${schoolId}/subscription`);
   return res.data;
 }
 
@@ -387,10 +390,9 @@ export async function assignTeacherGrades(
   teacherId: string,
   grades: number[],
 ): Promise<{ teacher_id: string; school_id: string; assigned_grades: number[] }> {
-  const res = await schoolApi.put(
-    `/schools/${schoolId}/teachers/${teacherId}/grades`,
-    { grades },
-  );
+  const res = await schoolApi.put(`/schools/${schoolId}/teachers/${teacherId}/grades`, {
+    grades,
+  });
   return res.data;
 }
 
@@ -541,7 +543,9 @@ export interface AssignCurriculumResponse {
   previous_curriculum_id: string | null;
 }
 
-export async function getRetentionDashboard(schoolId: string): Promise<RetentionDashboard> {
+export async function getRetentionDashboard(
+  schoolId: string,
+): Promise<RetentionDashboard> {
   const res = await schoolApi.get<RetentionDashboard>(`/schools/${schoolId}/retention`);
   return res.data;
 }
@@ -662,7 +666,10 @@ export async function listClassrooms(schoolId: string): Promise<ClassroomItem[]>
   return res.data;
 }
 
-export async function getClassroom(schoolId: string, classroomId: string): Promise<ClassroomDetail> {
+export async function getClassroom(
+  schoolId: string,
+  classroomId: string,
+): Promise<ClassroomDetail> {
   const res = await schoolApi.get<ClassroomDetail>(
     `/schools/${schoolId}/classrooms/${classroomId}`,
   );
@@ -673,14 +680,22 @@ export async function createClassroom(
   schoolId: string,
   body: { name: string; grade?: number | null; teacher_id?: string | null },
 ): Promise<ClassroomItem> {
-  const res = await schoolApi.post<ClassroomItem>(`/schools/${schoolId}/classrooms`, body);
+  const res = await schoolApi.post<ClassroomItem>(
+    `/schools/${schoolId}/classrooms`,
+    body,
+  );
   return res.data;
 }
 
 export async function updateClassroom(
   schoolId: string,
   classroomId: string,
-  body: { name?: string; grade?: number | null; teacher_id?: string | null; status?: string },
+  body: {
+    name?: string;
+    grade?: number | null;
+    teacher_id?: string | null;
+    status?: string;
+  },
 ): Promise<ClassroomItem> {
   const res = await schoolApi.patch<ClassroomItem>(
     `/schools/${schoolId}/classrooms/${classroomId}`,
@@ -695,10 +710,10 @@ export async function assignPackageToClassroom(
   curriculumId: string,
   sortOrder = 0,
 ): Promise<void> {
-  await schoolApi.post(
-    `/schools/${schoolId}/classrooms/${classroomId}/packages`,
-    { curriculum_id: curriculumId, sort_order: sortOrder },
-  );
+  await schoolApi.post(`/schools/${schoolId}/classrooms/${classroomId}/packages`, {
+    curriculum_id: curriculumId,
+    sort_order: sortOrder,
+  });
 }
 
 export async function reorderPackageInClassroom(
@@ -728,10 +743,9 @@ export async function assignStudentToClassroom(
   classroomId: string,
   studentId: string,
 ): Promise<void> {
-  await schoolApi.post(
-    `/schools/${schoolId}/classrooms/${classroomId}/students`,
-    { student_id: studentId },
-  );
+  await schoolApi.post(`/schools/${schoolId}/classrooms/${classroomId}/students`, {
+    student_id: studentId,
+  });
 }
 
 export async function removeStudentFromClassroom(

--- a/web/lib/api/school-client.ts
+++ b/web/lib/api/school-client.ts
@@ -64,12 +64,16 @@ schoolApi.interceptors.response.use(
     ) {
       try {
         if (!refreshing) {
-          refreshing = attemptRefresh().finally(() => { refreshing = null; });
+          refreshing = attemptRefresh().finally(() => {
+            refreshing = null;
+          });
         }
         const newToken = await refreshing;
 
         // Retry the original request with the fresh token.
-        const retryConfig = { ...error.config, _retried: true } as typeof error.config & { _retried: boolean };
+        const retryConfig = { ...error.config, _retried: true } as typeof error.config & {
+          _retried: boolean;
+        };
         if (retryConfig.headers) {
           retryConfig.headers.Authorization = `Bearer ${newToken}`;
         }

--- a/web/lib/api/teacher-subscription.ts
+++ b/web/lib/api/teacher-subscription.ts
@@ -67,8 +67,6 @@ export async function upgradeTeacherPlan(
 export async function cancelTeacherSubscription(
   teacherId: string,
 ): Promise<{ status: string; current_period_end: string | null }> {
-  const res = await schoolApi.delete(
-    `/teachers/${teacherId}/subscription`,
-  );
+  const res = await schoolApi.delete(`/teachers/${teacherId}/subscription`);
   return res.data;
 }

--- a/web/lib/api/teacher.ts
+++ b/web/lib/api/teacher.ts
@@ -33,9 +33,7 @@ export interface EarningsItem {
 // ── API calls ─────────────────────────────────────────────────────────────────
 
 export async function getConnectStatus(teacherId: string): Promise<ConnectStatus> {
-  const res = await schoolApi.get<ConnectStatus>(
-    `/teachers/${teacherId}/connect/status`,
-  );
+  const res = await schoolApi.get<ConnectStatus>(`/teachers/${teacherId}/connect/status`);
   return res.data;
 }
 

--- a/web/lib/pricing.ts
+++ b/web/lib/pricing.ts
@@ -88,8 +88,8 @@ export const SCHOOL_PLANS: Record<string, SchoolPlan> = {
     priceMonthly: "custom",
     maxStudents: null,
     maxTeachers: null,
-    buildsPerYear: -1,          // unlimited
-    storageBaseGb: 5,           // base; typically negotiated higher
+    buildsPerYear: -1, // unlimited
+    storageBaseGb: 5, // base; typically negotiated higher
     features: [
       "Unlimited students & teachers",
       "Unlimited curriculum builds",
@@ -115,7 +115,6 @@ export function formatPlanPrice(plan: SchoolPlan): string {
   return `$${parseFloat(plan.priceMonthly).toFixed(0)} / month`;
 }
 
-
 // ─────────────────────────────────────────────────────────────────────────────
 // 2. Storage add-on packages
 // ─────────────────────────────────────────────────────────────────────────────
@@ -130,13 +129,12 @@ export interface StoragePackage {
 }
 
 export const STORAGE_PACKAGES: StoragePackage[] = [
-  { gb: 5,  priceUsd: "19.00", label: "+5 GB — $19" },
+  { gb: 5, priceUsd: "19.00", label: "+5 GB — $19" },
   { gb: 10, priceUsd: "35.00", label: "+10 GB — $35" },
   { gb: 25, priceUsd: "79.00", label: "+25 GB — $79" },
 ];
 
 export const VALID_STORAGE_GB = new Set([5, 10, 25] as const);
-
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 3. AI generation cost model  (for internal dashboards / cost projection)
@@ -147,13 +145,13 @@ export const AI_COST_MODEL = {
   model: "claude-sonnet-4-6" as const,
 
   /** USD per 1 million input tokens */
-  inputPerMillionUsd: 3.00,
+  inputPerMillionUsd: 3.0,
 
   /** USD per 1 million output tokens */
-  outputPerMillionUsd: 15.00,
+  outputPerMillionUsd: 15.0,
 
   /** Pipeline abort threshold — never exceed this per run */
-  maxRunUsd: 50.00,
+  maxRunUsd: 50.0,
 
   /** Estimated average input tokens per curriculum unit */
   avgInputTokensPerUnit: 1_800,
@@ -166,8 +164,9 @@ export const AI_COST_MODEL = {
 
   /** Estimated Anthropic API cost to build one grade in English */
   get costPerGradeEnUsd(): number {
-    const inputCost  = (this.avgInputTokensPerUnit  / 1_000_000) * this.inputPerMillionUsd;
-    const outputCost = (this.avgOutputTokensPerUnit / 1_000_000) * this.outputPerMillionUsd;
+    const inputCost = (this.avgInputTokensPerUnit / 1_000_000) * this.inputPerMillionUsd;
+    const outputCost =
+      (this.avgOutputTokensPerUnit / 1_000_000) * this.outputPerMillionUsd;
     return Math.round((inputCost + outputCost) * this.avgUnitsPerGrade * 100) / 100;
   },
 
@@ -176,7 +175,6 @@ export const AI_COST_MODEL = {
     return Math.round(this.costPerGradeEnUsd * 3 * 100) / 100;
   },
 } as const;
-
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 4. Independent teacher plans  (future — teacher tier rebuild, #57)
@@ -190,7 +188,7 @@ export interface TeacherPlan {
 }
 
 export const TEACHER_PLANS: TeacherPlan[] = [
-  { id: "solo",   name: "Solo",   priceMonthly: "29.00", maxStudents: 25  },
-  { id: "growth", name: "Growth", priceMonthly: "59.00", maxStudents: 75  },
-  { id: "pro",    name: "Pro",    priceMonthly: "99.00", maxStudents: 200 },
+  { id: "solo", name: "Solo", priceMonthly: "29.00", maxStudents: 25 },
+  { id: "growth", name: "Growth", priceMonthly: "59.00", maxStudents: 75 },
+  { id: "pro", name: "Pro", priceMonthly: "99.00", maxStudents: 200 },
 ];

--- a/web/tests/e2e/README.md
+++ b/web/tests/e2e/README.md
@@ -60,12 +60,12 @@ npx playwright test
 
 Runs all **four** Playwright projects in parallel:
 
-| Project | Files | What it covers |
-|---|---|---|
-| `chromium` | `landing-page.spec.ts`, `login-pages.spec.ts`, `auth-redirects.spec.ts`, `admin-portal.spec.ts`, `public.spec.ts`, `pricing-page.spec.ts`, `static-pages.spec.ts`, `student_flow.spec.ts` | Public pages, login flows, auth-redirect rules, admin portal smoke |
-| `persona-student` | `personas/student-accessibility.spec.ts` | Student-role pages with mocked APIs + axe WCAG 2.1 AA checks |
-| `persona-teacher` | `personas/teacher-accessibility.spec.ts`, `personas/school-admin-curriculum-flow.spec.ts` | Teacher / school-admin pages with mocked APIs + axe; new school-admin curriculum-submission flow (#188) |
-| `persona-admin` | `personas/admin-accessibility.spec.ts` | Super-admin / product-admin / developer / tester pages; role-based nav differences |
+| Project           | Files                                                                                                                                                                                     | What it covers                                                                                          |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `chromium`        | `landing-page.spec.ts`, `login-pages.spec.ts`, `auth-redirects.spec.ts`, `admin-portal.spec.ts`, `public.spec.ts`, `pricing-page.spec.ts`, `static-pages.spec.ts`, `student_flow.spec.ts` | Public pages, login flows, auth-redirect rules, admin portal smoke                                      |
+| `persona-student` | `personas/student-accessibility.spec.ts`                                                                                                                                                  | Student-role pages with mocked APIs + axe WCAG 2.1 AA checks                                            |
+| `persona-teacher` | `personas/teacher-accessibility.spec.ts`, `personas/school-admin-curriculum-flow.spec.ts`                                                                                                 | Teacher / school-admin pages with mocked APIs + axe; new school-admin curriculum-submission flow (#188) |
+| `persona-admin`   | `personas/admin-accessibility.spec.ts`                                                                                                                                                    | Super-admin / product-admin / developer / tester pages; role-based nav differences                      |
 
 Expected outcome: **120 passing, ~8 `fixme`'d, 0 failing**. Run time: ~2 min.
 
@@ -98,6 +98,7 @@ npx playwright test --ui
 ```
 
 Opens a Chromium-based test runner with:
+
 - Time-travel: hover any step to see the DOM snapshot at that moment.
 - Pick-locator: click an element in the snapshot to auto-generate a
   Playwright locator expression.
@@ -138,14 +139,14 @@ Playwright fails loudly — the terminal output shows:
 
 ### 3.1 Common failure patterns
 
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| `Error: element(s) not found` with a selector that worked yesterday | UI copy changed | Update the selector in the spec (prefer roles + accessible names over raw text) |
-| `Error: strict mode violation: getByRole(...) resolved to N elements` | Multiple elements match (e.g. duplicate sidebar + footer links) | Add `.first()` or narrow with a parent locator |
-| `Error: browserType.launch: Executable doesn't exist` | Browser binary missing | `npx playwright install chromium` |
-| `Error: spawn ... ENOENT` + `__memset_chk: symbol not found` | Running Playwright inside the Alpine container | Run on host instead — see §6 |
-| `Timeout: 5000ms` waiting for a network request | Mock route doesn't match the real URL pattern | Run with `--trace=on` and inspect the network panel; tighten the route glob |
-| Color-contrast axe failures | Known debt tracked in issue #189 | Do NOT add more rules to `KNOWN_A11Y_EXCLUSIONS` — fix the app |
+| Symptom                                                               | Likely cause                                                    | Fix                                                                             |
+| --------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `Error: element(s) not found` with a selector that worked yesterday   | UI copy changed                                                 | Update the selector in the spec (prefer roles + accessible names over raw text) |
+| `Error: strict mode violation: getByRole(...) resolved to N elements` | Multiple elements match (e.g. duplicate sidebar + footer links) | Add `.first()` or narrow with a parent locator                                  |
+| `Error: browserType.launch: Executable doesn't exist`                 | Browser binary missing                                          | `npx playwright install chromium`                                               |
+| `Error: spawn ... ENOENT` + `__memset_chk: symbol not found`          | Running Playwright inside the Alpine container                  | Run on host instead — see §6                                                    |
+| `Timeout: 5000ms` waiting for a network request                       | Mock route doesn't match the real URL pattern                   | Run with `--trace=on` and inspect the network panel; tighten the route glob     |
+| Color-contrast axe failures                                           | Known debt tracked in issue #189                                | Do NOT add more rules to `KNOWN_A11Y_EXCLUSIONS` — fix the app                  |
 
 ### 3.2 Debugging with trace
 
@@ -182,11 +183,11 @@ web/tests/e2e/
 
 ### 4.2 Pick the right project
 
-| If your test needs... | Put it here |
-|---|---|
-| A logged-out public page | New `*.spec.ts` under `tests/e2e/`; extend the `chromium` `testMatch` glob in `playwright.config.ts` |
-| A logged-in student | `personas/*.spec.ts`; use the `persona-student` project; reuse `setupStudentAuth()` from `student-accessibility.spec.ts` |
-| A logged-in teacher / school_admin | `personas/*.spec.ts`; use the `persona-teacher` project; reuse `setupTeacherAuth()` |
+| If your test needs...                               | Put it here                                                                                                                     |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| A logged-out public page                            | New `*.spec.ts` under `tests/e2e/`; extend the `chromium` `testMatch` glob in `playwright.config.ts`                            |
+| A logged-in student                                 | `personas/*.spec.ts`; use the `persona-student` project; reuse `setupStudentAuth()` from `student-accessibility.spec.ts`        |
+| A logged-in teacher / school_admin                  | `personas/*.spec.ts`; use the `persona-teacher` project; reuse `setupTeacherAuth()`                                             |
 | A logged-in super-admin / product-admin / developer | `personas/*.spec.ts`; use the `persona-admin` project; reuse `setupAdminAuth()` + `SUPER_TOKEN` / `PRODUCT_TOKEN` / `DEV_TOKEN` |
 
 ### 4.3 Auth setup for persona tests
@@ -209,6 +210,7 @@ async function setupAuth(page: Page) {
 ```
 
 `helpers/tokens.ts` exports:
+
 - `makeStudentToken()` → stored as `sb_token`
 - `makeTeacherToken(teacherId, schoolId, role)` → stored as `sb_teacher_token`
 - `makeAdminToken(role)` → stored as `sb_admin_token`
@@ -233,9 +235,7 @@ Always include a **catch-all** at the end so unexpected calls don't
 hang the test on a timeout:
 
 ```typescript
-await page.route("**/api/v1/**", (route) =>
-  route.fulfill({ status: 200, json: {} }),
-);
+await page.route("**/api/v1/**", (route) => route.fulfill({ status: 200, json: {} }));
 ```
 
 ### 4.5 Prefer role-based locators
@@ -276,9 +276,7 @@ specs without filing a GitHub issue first (currently tracked in #189).
 The three persona specs disable one axe rule:
 
 ```typescript
-const KNOWN_A11Y_EXCLUSIONS = [
-  "color-contrast",
-] as const;
+const KNOWN_A11Y_EXCLUSIONS = ["color-contrast"] as const;
 ```
 
 Each is tracked in GitHub issue **#189** with root-cause hypothesis +
@@ -308,6 +306,7 @@ Error relocating chrome-headless-shell: __memset_chk: symbol not found
 ```
 
 Options we rejected:
+
 - Switching the container base to Debian / Ubuntu — larger image, no
   other benefit given the host has Node installed already.
 - Using Playwright's official `mcr.microsoft.com/playwright` Docker image
@@ -325,11 +324,11 @@ install chromium` after cloning.
 Some tests are marked `test.fixme(...)` — they don't run, but the spec
 skeleton stays visible as a to-do list.
 
-| Spec | Test | Reason |
-|---|---|---|
-| `landing-page.spec.ts` | PUB-03 — primary CTA | Hero CTAs changed to `<DemoRequestModal />`; needs rewrite to assert modal behaviour |
-| `landing-page.spec.ts` | PUB-04 — secondary CTA | Same UX change; "See how it works" became a text link to `/tour` |
-| `school-admin-curriculum-flow.spec.ts` | (6 tests) | Wizard happy-path skeleton; each fixme carries notes on what the per-step field fills need |
+| Spec                                   | Test                   | Reason                                                                                     |
+| -------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------ |
+| `landing-page.spec.ts`                 | PUB-03 — primary CTA   | Hero CTAs changed to `<DemoRequestModal />`; needs rewrite to assert modal behaviour       |
+| `landing-page.spec.ts`                 | PUB-04 — secondary CTA | Same UX change; "See how it works" became a text link to `/tour`                           |
+| `school-admin-curriculum-flow.spec.ts` | (6 tests)              | Wizard happy-path skeleton; each fixme carries notes on what the per-step field fills need |
 
 To unfixme a test, change `test.fixme(...)` back to `test(...)` and make
 it pass.

--- a/web/tests/e2e/data/landing-page.ts
+++ b/web/tests/e2e/data/landing-page.ts
@@ -23,8 +23,7 @@ export const BANNER = {
 export const HERO = {
   // Matches en.json "hero_heading". Update here if the i18n value changes.
   heading: "Study Buddy",
-  subheading:
-    "Instant lessons, quizzes, and audio where available. Just learning.",
+  subheading: "Instant lessons, quizzes, and audio where available. Just learning.",
   ctaPrimary: { text: "Start free trial", href: "/signup" },
   ctaSecondary: { text: "See how it works", href: "/#features" },
 } as const;
@@ -73,8 +72,7 @@ export const FEATURES: ReadonlyArray<{ title: string; description: string }> = [
 
 export const TESTIMONIALS: ReadonlyArray<{ quote: string; author: string }> = [
   {
-    quote:
-      "My daughter went from a C to a B+ in her favourite subject in one semester.",
+    quote: "My daughter went from a C to a B+ in her favourite subject in one semester.",
     author: "Maria T., Parent",
   },
   {

--- a/web/tests/e2e/helpers/axe.ts
+++ b/web/tests/e2e/helpers/axe.ts
@@ -49,11 +49,7 @@ export async function checkA11y(
   label: string,
   excludeRules: readonly string[] = [],
 ): Promise<A11yReport> {
-  let builder = new AxeBuilder({ page }).withTags([
-    "wcag2a",
-    "wcag2aa",
-    "best-practice",
-  ]);
+  let builder = new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa", "best-practice"]);
   if (excludeRules.length > 0) {
     builder = builder.disableRules([...excludeRules]);
   }

--- a/web/tests/e2e/landing-page.spec.ts
+++ b/web/tests/e2e/landing-page.spec.ts
@@ -56,43 +56,41 @@ test("PUB-02 — hero H1 heading is visible above the fold", async ({ page }) =>
 // PUB-03 — Primary CTA navigates to /signup
 // ---------------------------------------------------------------------------
 
-test.fixme(
-  "PUB-03 — primary CTA 'Start free trial' navigates to /signup",
-  async ({ page }) => {
-    // Hero CTAs were replaced with <DemoRequestModal /> +
-    // <DemoTeacherRequestModal /> when the demo lead flow shipped
-    // (Epic 7). Rewrite this test to assert the modal opens and accepts
-    // an email, rather than a navigation to /signup. Tracked alongside
-    // PUB-04 below.
-    await page.goto("/");
-    const cta = page.getByRole("link", { name: HERO.ctaPrimary.text }).first();
-    await expect(cta).toBeVisible();
-    await cta.click();
-    await expect(page).toHaveURL(new RegExp(HERO.ctaPrimary.href));
-  },
-);
+test.fixme("PUB-03 — primary CTA 'Start free trial' navigates to /signup", async ({
+  page,
+}) => {
+  // Hero CTAs were replaced with <DemoRequestModal /> +
+  // <DemoTeacherRequestModal /> when the demo lead flow shipped
+  // (Epic 7). Rewrite this test to assert the modal opens and accepts
+  // an email, rather than a navigation to /signup. Tracked alongside
+  // PUB-04 below.
+  await page.goto("/");
+  const cta = page.getByRole("link", { name: HERO.ctaPrimary.text }).first();
+  await expect(cta).toBeVisible();
+  await cta.click();
+  await expect(page).toHaveURL(new RegExp(HERO.ctaPrimary.href));
+});
 
 // ---------------------------------------------------------------------------
 // PUB-04 — Secondary CTA links to /#features
 // ---------------------------------------------------------------------------
 
-test.fixme(
-  "PUB-04 — secondary CTA 'See how it works' points to /#features",
-  async ({ page }) => {
-    // The "See how it works" CTA was replaced with a smaller
-    // "Explore the platform first" text link pointing to /tour.
-    // Rewrite to assert on the new affordance, or remove if the
-    // landing-page tour is the canonical path going forward.
-    await page.goto("/");
-    const cta = page.getByRole("link", { name: HERO.ctaSecondary.text }).first();
-    await expect(cta).toBeVisible();
-    const href = await cta.getAttribute("href");
-    expect(href).toBe(HERO.ctaSecondary.href);
-    await cta.click();
-    await expect(page).toHaveURL(/\/#features$/);
-    await expect(page.locator("#features")).toBeAttached();
-  },
-);
+test.fixme("PUB-04 — secondary CTA 'See how it works' points to /#features", async ({
+  page,
+}) => {
+  // The "See how it works" CTA was replaced with a smaller
+  // "Explore the platform first" text link pointing to /tour.
+  // Rewrite to assert on the new affordance, or remove if the
+  // landing-page tour is the canonical path going forward.
+  await page.goto("/");
+  const cta = page.getByRole("link", { name: HERO.ctaSecondary.text }).first();
+  await expect(cta).toBeVisible();
+  const href = await cta.getAttribute("href");
+  expect(href).toBe(HERO.ctaSecondary.href);
+  await cta.click();
+  await expect(page).toHaveURL(/\/#features$/);
+  await expect(page.locator("#features")).toBeAttached();
+});
 
 // ---------------------------------------------------------------------------
 // PUB-05 — Features grid renders all 6 cards

--- a/web/tests/e2e/login-pages.spec.ts
+++ b/web/tests/e2e/login-pages.spec.ts
@@ -11,9 +11,7 @@ test.describe("School login page", () => {
     // Page was restructured from a redirect-link pattern to a form-with-submit
     // pattern; the primary affordance is now a submit <button>, matched by
     // role. Use .last() to pick the in-page form button over the nav link.
-    await expect(
-      page.getByRole("button", { name: /sign in/i }).last(),
-    ).toBeVisible();
+    await expect(page.getByRole("button", { name: /sign in/i }).last()).toBeVisible();
   });
 
   test("links to student login", async ({ page }) => {

--- a/web/tests/e2e/personas/school-admin-curriculum-flow.spec.ts
+++ b/web/tests/e2e/personas/school-admin-curriculum-flow.spec.ts
@@ -26,11 +26,7 @@ import type { Page } from "@playwright/test";
 import { makeTeacherToken, devSessionCookie } from "../helpers/tokens";
 
 const SCHOOL_ID = "test-school-001";
-const TEACHER_TOKEN = makeTeacherToken(
-  "test-teacher-001",
-  SCHOOL_ID,
-  "school_admin",
-);
+const TEACHER_TOKEN = makeTeacherToken("test-teacher-001", SCHOOL_ID, "school_admin");
 
 const DEFINITION_ID = "def-test-001";
 const SUBMITTED_DEFINITION = {
@@ -132,9 +128,7 @@ async function stubDefinitionApis(page: Page, opts: { overage?: boolean } = {}) 
   );
 
   // Catch-all
-  await page.route("**/api/v1/**", (route) =>
-    route.fulfill({ status: 200, json: {} }),
-  );
+  await page.route("**/api/v1/**", (route) => route.fulfill({ status: 200, json: {} }));
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -151,16 +145,12 @@ test.describe("School admin — curriculum submission flow (#188)", () => {
     await expect(page.getByLabel(/^grade$/i)).toBeVisible();
   });
 
-  test("wizard submits and posts to the definitions endpoint", async ({
-    page,
-  }) => {
+  test("wizard submits and posts to the definitions endpoint", async ({ page }) => {
     // Capture the POST before navigation so no request is missed.
     const postBodyPromise = page.waitForRequest(
       (req) =>
         req.method() === "POST" &&
-        req.url().endsWith(
-          `/api/v1/schools/${SCHOOL_ID}/curriculum/definitions`,
-        ),
+        req.url().endsWith(`/api/v1/schools/${SCHOOL_ID}/curriculum/definitions`),
     );
 
     await page.goto("/school/curriculum/definitions/new");
@@ -173,9 +163,7 @@ test.describe("School admin — curriculum submission flow (#188)", () => {
     // Step 1 — Subjects. A default subject row with one empty unit is already
     // rendered by the page; validateStep(1) requires subject_label + unit title
     // to be non-empty. Selectors match SubjectCard + UnitRow placeholders.
-    await page
-      .getByPlaceholder("Subject name (e.g. Mathematics)")
-      .fill("Accountancy");
+    await page.getByPlaceholder("Subject name (e.g. Mathematics)").fill("Accountancy");
     await page.getByPlaceholder("Unit title").fill("Introduction to Accounting");
     await page.getByRole("button", { name: /^Next$/i }).click();
 
@@ -183,9 +171,7 @@ test.describe("School admin — curriculum submission flow (#188)", () => {
     await page.getByRole("button", { name: /^Next$/i }).click();
 
     // Step 3 — Review. Fire the mutation.
-    await page
-      .getByRole("button", { name: /submit for approval/i })
-      .click();
+    await page.getByRole("button", { name: /submit for approval/i }).click();
 
     // Assert the wizard collected the right shape.
     const req = await postBodyPromise;
@@ -204,9 +190,7 @@ test.describe("School admin — curriculum submission flow (#188)", () => {
     expect(body.subjects[0].units[0].title).toBe("Introduction to Accounting");
   });
 
-  test.fixme("approval queue lists the submitted definition", async ({
-    page,
-  }) => {
+  test.fixme("approval queue lists the submitted definition", async ({ page }) => {
     // UNBLOCK: run `cd web && npx playwright test -g "approval queue" --trace=on`
     // then `npx playwright show-trace test-results/.../trace.zip` and inspect the
     // Network tab. The list fetch is initiated by a React Query hook on the
@@ -219,9 +203,7 @@ test.describe("School admin — curriculum submission flow (#188)", () => {
     await expect(page.getByText(/pending/i).first()).toBeVisible();
   });
 
-  test.fixme("definition detail view shows grade, status, subjects", async ({
-    page,
-  }) => {
+  test.fixme("definition detail view shows grade, status, subjects", async ({ page }) => {
     // UNBLOCK: run `cd web && npx playwright test -g "detail view" --trace=on`
     // and inspect the trace Network tab for the single-definition fetch from
     // `web/app/(school)/school/curriculum/definitions/[definitionId]/page.tsx`.
@@ -247,11 +229,7 @@ test.describe("School admin — curriculum submission flow (#188)", () => {
     await page.goto(`/school/curriculum/definitions/${DEFINITION_ID}`);
 
     const estimatePromise = page.waitForResponse((res) =>
-      res
-        .url()
-        .endsWith(
-          `/definitions/${DEFINITION_ID}/estimate`,
-        ),
+      res.url().endsWith(`/definitions/${DEFINITION_ID}/estimate`),
     );
 
     const estimateBtn = page.getByRole("button", { name: /estimate|cost/i }).first();
@@ -278,11 +256,7 @@ test.describe("School admin — curriculum submission flow (#188)", () => {
     await page.goto(`/school/curriculum/definitions/${DEFINITION_ID}`);
 
     const triggerPromise = page.waitForResponse((res) =>
-      res
-        .url()
-        .endsWith(
-          `/definitions/${DEFINITION_ID}/trigger`,
-        ),
+      res.url().endsWith(`/definitions/${DEFINITION_ID}/trigger`),
     );
 
     const triggerBtn = page
@@ -322,11 +296,7 @@ test.describe("School admin — curriculum build overage gate", () => {
     await page.goto(`/school/curriculum/definitions/${DEFINITION_ID}`);
 
     const estimatePromise = page.waitForResponse((res) =>
-      res
-        .url()
-        .endsWith(
-          `/definitions/${DEFINITION_ID}/estimate`,
-        ),
+      res.url().endsWith(`/definitions/${DEFINITION_ID}/estimate`),
     );
 
     const estimateBtn = page.getByRole("button", { name: /estimate|cost/i }).first();

--- a/web/tests/e2e/personas/student-accessibility.spec.ts
+++ b/web/tests/e2e/personas/student-accessibility.spec.ts
@@ -256,9 +256,7 @@ test.describe("Student persona — smoke & accessibility", () => {
     // first nav explicitly to avoid Playwright's strict-mode violation.
     const nav = page.getByRole("navigation").first();
     await expect(nav).toBeVisible();
-    await expect(
-      nav.getByRole("link", { name: /dashboard/i }).first(),
-    ).toBeVisible();
+    await expect(nav.getByRole("link", { name: /dashboard/i }).first()).toBeVisible();
   });
 
   // ── Paywall page ──────────────────────────────────────────────────────────

--- a/web/tests/e2e/personas/teacher-accessibility.spec.ts
+++ b/web/tests/e2e/personas/teacher-accessibility.spec.ts
@@ -238,9 +238,7 @@ test.describe("Teacher persona — smoke & accessibility", () => {
   test("students page loads and lists enrolled students", async ({ page }) => {
     await page.goto("/school/students");
     // Page h1 is "Student Roster".
-    await expect(
-      page.getByRole("heading", { name: /student roster/i }),
-    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: /student roster/i })).toBeVisible();
   });
 
   test("students — no critical WCAG violations", async ({ page }) => {
@@ -277,9 +275,7 @@ test.describe("Teacher persona — smoke & accessibility", () => {
   test("alerts page loads and shows alert", async ({ page }) => {
     await page.goto("/school/alerts");
     // Page h1 is "Alert Inbox".
-    await expect(
-      page.getByRole("heading", { name: /alert inbox/i }),
-    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: /alert inbox/i })).toBeVisible();
   });
 
   test("alerts — no critical WCAG violations", async ({ page }) => {
@@ -295,9 +291,7 @@ test.describe("Teacher persona — smoke & accessibility", () => {
     // Multiple nav elements (sidebar + footer) — disambiguate.
     const nav = page.getByRole("navigation").first();
     await expect(nav).toBeVisible();
-    await expect(
-      nav.getByRole("link", { name: /dashboard/i }).first(),
-    ).toBeVisible();
+    await expect(nav.getByRole("link", { name: /dashboard/i }).first()).toBeVisible();
   });
 
   // ── RBAC: teacher vs school_admin ─────────────────────────────────────────

--- a/web/tests/e2e/public.spec.ts
+++ b/web/tests/e2e/public.spec.ts
@@ -6,9 +6,7 @@ test.describe("Public pages", () => {
     await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
     // Header CTA label is now "Start free" (not "Start free trial");
     // bottom CTA section still reads "Start your free trial". Regex covers both.
-    await expect(
-      page.getByRole("link", { name: /start.*free/i }).first(),
-    ).toBeVisible();
+    await expect(page.getByRole("link", { name: /start.*free/i }).first()).toBeVisible();
   });
 
   test("pricing page shows three plan cards", async ({ page }) => {

--- a/web/tests/e2e/student_flow.spec.ts
+++ b/web/tests/e2e/student_flow.spec.ts
@@ -158,21 +158,15 @@ async function stubProgressApis(page: Page) {
 // Test 1 — Public landing page (no auth)
 // ---------------------------------------------------------------------------
 
-test("public landing page — hero heading and sign-in CTA visible", async ({
-  page,
-}) => {
+test("public landing page — hero heading and sign-in CTA visible", async ({ page }) => {
   await page.goto("/");
   await page.waitForLoadState("networkidle");
 
   // Hero heading
-  await expect(
-    page.getByRole("heading", { name: HERO.heading }),
-  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: HERO.heading })).toBeVisible();
 
   // Sign in link in nav
-  await expect(
-    page.getByRole("link", { name: NAV_LINKS[1].text }),
-  ).toBeVisible();
+  await expect(page.getByRole("link", { name: NAV_LINKS[1].text })).toBeVisible();
 });
 
 // ---------------------------------------------------------------------------
@@ -202,9 +196,7 @@ test("curriculum map → lesson navigation", async ({ page }) => {
   await expect(page.getByText(MOCK_LESSON_WITH_AUDIO.title)).toBeVisible();
 
   // First section heading
-  await expect(
-    page.getByText(MOCK_LESSON_WITH_AUDIO.sections[0].heading),
-  ).toBeVisible();
+  await expect(page.getByText(MOCK_LESSON_WITH_AUDIO.sections[0].heading)).toBeVisible();
 
   // Take Quiz CTA must be present
   await expect(
@@ -216,9 +208,7 @@ test("curriculum map → lesson navigation", async ({ page }) => {
 // Test 3 — Lesson → quiz → result screen → progress history
 // ---------------------------------------------------------------------------
 
-test("student learning loop: lesson → quiz → result → progress", async ({
-  page,
-}) => {
+test("student learning loop: lesson → quiz → result → progress", async ({ page }) => {
   await setupStudentAuth(page);
   await stubCommonApis(page);
   await stubLessonApis(page);
@@ -231,14 +221,10 @@ test("student learning loop: lesson → quiz → result → progress", async ({
   await expect(page.getByText(MOCK_LESSON_WITH_AUDIO.title)).toBeVisible();
 
   // Key Points section
-  await expect(
-    page.getByText(MOCK_LESSON_WITH_AUDIO.key_points[0]),
-  ).toBeVisible();
+  await expect(page.getByText(MOCK_LESSON_WITH_AUDIO.key_points[0])).toBeVisible();
 
   // ── Step 2: navigate to quiz ──────────────────────────────────────────────
-  await page
-    .getByRole("link", { name: LESSON_STRINGS.takeQuizBtn })
-    .click();
+  await page.getByRole("link", { name: LESSON_STRINGS.takeQuizBtn }).click();
   await page.waitForURL("**/quiz/G8-SCI-001**");
   await page.waitForLoadState("networkidle");
 
@@ -254,27 +240,19 @@ test("student learning loop: lesson → quiz → result → progress", async ({
     await expect(page.getByText(q.question)).toBeVisible();
 
     // Select the correct option
-    await page
-      .getByRole("button", { name: q.options[q.correct_index] })
-      .click();
+    await page.getByRole("button", { name: q.options[q.correct_index] }).click();
 
     // Submit
-    await page
-      .getByRole("button", { name: QUIZ_STRINGS.submitBtn })
-      .click();
+    await page.getByRole("button", { name: QUIZ_STRINGS.submitBtn }).click();
 
     // Explanation appears
     await expect(page.getByText(q.explanation)).toBeVisible();
 
     // Advance to next question or results
     if (isLast) {
-      await page
-        .getByRole("button", { name: QUIZ_STRINGS.seeResultsBtn })
-        .click();
+      await page.getByRole("button", { name: QUIZ_STRINGS.seeResultsBtn }).click();
     } else {
-      await page
-        .getByRole("button", { name: QUIZ_STRINGS.nextBtn })
-        .click();
+      await page.getByRole("button", { name: QUIZ_STRINGS.nextBtn }).click();
     }
   }
 


### PR DESCRIPTION
## Summary

Mirror of PR #253 for `web/`. The `Frontend Lint & Typecheck` CI job has been failing on `main` for weeks on 17 errors and 24 warnings (ESLint) plus 88 files with Prettier drift. This PR returns ESLint and Prettier to clean.

## ESLint — 17 errors fixed

| Rule | Count | Fix |
|---|---|---|
| `react/no-unescaped-entities` | 11 | `&apos;` / `&ldquo;` / `&rdquo;` across tour pages + admin/streams/new |
| `@next/next/no-html-link-for-pages` | 1 | `<a href=>` → `<Link href=>` in school/catalog |
| `react-hooks/immutability` | 2 | `window.location.href = …` → `window.location.assign(…)` |
| Cannot-create-component-during-render | 1 | Hoisted `StatusChip` out of `DefinitionDetailPage` |
| `no-unused-expressions` (ternary-as-statement) | 1 | `if/else` in school/teachers `GradeEditor.toggle()` |
| **Total** | **17** | |

## ESLint — 24 warnings cleared (required for `--max-warnings=0`)

- Unused imports — lucide icons, shadcn components, React hooks
- Unused destructured props — `gradesForThisVersion` on `VersionDrawer`, `label` on `AddOnCard`, `BreakdownRow` dead component entirely
- Unused local variables — `uploaded`, `router`, `queryClient` where no longer referenced

## Prettier

- Ran `prettier --write .` — closed the 88-file format gap.
- **New `.prettierignore`**: excludes `lib/api/types.gen.ts` and `openapi.json` so running prettier over regenerated output doesn't churn diffs on every `regen-openapi` run. Also excludes `node_modules/`, `.next/`, `test-results/`, `playwright-report/`, `coverage/`.

## Out of scope (tracked separately)

`tsc --noEmit` still fails on `tests/unit/*.test.tsx`:

```
error TS2305: Module '"@testing-library/react"' has no exported member 'screen'
error TS2305: Module '"@testing-library/react"' has no exported member 'fireEvent'
error TS2305: Module '"@testing-library/react"' has no exported member 'waitFor'
error TS7006: Parameter 'b' implicitly has an 'any' type
```

Package-version mismatch in the unit tests — orthogonal to lint/format. Will file as follow-up.

## Test plan

- [x] `docker compose exec -T web npm run lint -- --max-warnings=0` — clean locally (0 errors, 0 warnings)
- [x] `docker compose exec -T web npm run format:check` — clean locally
- [x] Revert of `lib/api/types.gen.ts` + `openapi.json` verified — original content restored
- [ ] CI `Frontend — Lint & Typecheck`: ESLint + Prettier pass; `tsc` still fails on pre-existing test-file issues (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)