### PR TITLE
feat(web): same-origin API via Next.js rewrites proxy

### DIFF
--- a/web/lib/api/admin-client.ts
+++ b/web/lib/api/admin-client.ts
@@ -6,7 +6,7 @@
 import axios from "axios";
 
 const adminApi = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000/api/v1",
+  baseURL: "/api/v1",
   headers: { "Content-Type": "application/json" },
   timeout: 15_000,
 });

--- a/web/lib/api/auth.ts
+++ b/web/lib/api/auth.ts
@@ -3,7 +3,7 @@ import api from "./client";
 
 // Unauthenticated Axios instance for login endpoints (no Bearer token pre-injected)
 const publicApi = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000/api/v1",
+  baseURL: "/api/v1",
   headers: { "Content-Type": "application/json" },
   timeout: 15_000,
 });

--- a/web/lib/api/client.ts
+++ b/web/lib/api/client.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000/api/v1",
+  baseURL: "/api/v1",
   headers: { "Content-Type": "application/json" },
   timeout: 15_000,
 });

--- a/web/lib/api/help.ts
+++ b/web/lib/api/help.ts
@@ -11,8 +11,7 @@
  * (first_login, teacher_count, etc.) that the backend threads into the prompt.
  */
 
-export const HELP_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000/api/v1";
+export const HELP_BASE_URL = "/api/v1";
 
 /** Recognised account_state signal keys (mirrors backend schema). */
 export interface AccountState {

--- a/web/lib/api/school-client.ts
+++ b/web/lib/api/school-client.ts
@@ -10,7 +10,7 @@
  */
 import axios, { AxiosError } from "axios";
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000/api/v1";
+const BASE_URL = "/api/v1";
 
 const schoolApi = axios.create({
   baseURL: BASE_URL,

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -3,10 +3,12 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./lib/i18n/request.ts");
 
-// Derive the backend API origin so the CSP connect-src is scoped correctly.
-// NEXT_PUBLIC_API_URL is set in .env.local / CI / production deploy config.
-const apiOrigin = process.env.NEXT_PUBLIC_API_URL
-  ? new URL(process.env.NEXT_PUBLIC_API_URL).origin
+// Backend origin for the server-side rewrites() proxy. Browser code uses
+// same-origin relative paths (/api/v1/*); Next's server forwards them here.
+// INTERNAL_API_URL resolves to the Docker service name in compose and to a
+// reachable host in other deploys.
+const backendOrigin = process.env.INTERNAL_API_URL
+  ? new URL(process.env.INTERNAL_API_URL).origin
   : "http://localhost:8000";
 
 // Content-Security-Policy
@@ -15,7 +17,7 @@ const apiOrigin = process.env.NEXT_PUBLIC_API_URL
 //   nonce-based CSP is the correct long-term fix but is left for a dedicated hardening sprint.
 // - 'unsafe-eval' is added only in development: React dev builds use eval() for call-stack
 //   reconstruction and debugging features. React never uses eval() in production.
-// - connect-src: API origin + Stripe telemetry (JS.stripe.com requires it)
+// - connect-src 'self' covers the backend (proxied via rewrites) + Stripe telemetry
 // - img-src 'self' data: blob: *.cloudfront.net: lesson images served from CDN
 // - frame-src https://js.stripe.com: Stripe Checkout iframe
 // - frame-ancestors 'none': equivalent to X-Frame-Options DENY, but honoured by modern browsers
@@ -25,7 +27,8 @@ const csp = [
   isDev
     ? "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com"
     : "script-src 'self' 'unsafe-inline' https://js.stripe.com",
-  `connect-src 'self' ${apiOrigin} https://api.stripe.com`,
+  // Same-origin only — /api/v1/* is proxied by rewrites() to the backend.
+  `connect-src 'self' https://api.stripe.com`,
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob: https://*.cloudfront.net",
   "font-src 'self'",
@@ -63,6 +66,14 @@ const nextConfig: NextConfig = {
         hostname: "**.cloudfront.net",
       },
     ],
+  },
+  async rewrites() {
+    return [
+      {
+        source: "/api/v1/:path*",
+        destination: `${backendOrigin}/api/v1/:path*`,
+      },
+    ];
   },
   async headers() {
     return [


### PR DESCRIPTION
## Summary

- Browser code now uses relative `/api/v1/*` paths. Next.js `rewrites()` proxies them server-side to `INTERNAL_API_URL`, so the browser never sees the backend origin.
- Eliminates CORS preflight surface for the web app and unblocks LAN demos: the old module-scoped `NEXT_PUBLIC_API_URL` capture baked `localhost:8000` into every axios `baseURL`, which broke when visiting from a peer on the LAN.
- CSP `connect-src` drops the external backend origin — same-origin via rewrites().
- Server-side route handler (`app/api/dev-login`) keeps the `INTERNAL_API_URL` fallback chain: it's server-to-server and needs the absolute URL.

## Files

- `web/next.config.ts` — `rewrites()` + CSP update
- `web/lib/api/{client,admin-client,school-client,auth,help}.ts` — `baseURL: "/api/v1"`

## Test plan

- [x] Typecheck: no new errors in the 6 touched files (one pre-existing error in `school/subscription/page.tsx` untouched).
- [x] Lint: clean.
- [x] Proxy smoke test: `curl http://localhost:3000/api/v1/curricula/catalog` and `curl http://localhost:8000/api/v1/curricula/catalog` return identical responses (only correlation_id differs).
- [ ] Manual: visit the admin console from a LAN peer (e.g. `http://192.168.x.x:3000`) and confirm login + protected pages load without CORS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)