### PR TITLE
feat(cors): env-driven allowlist for loopback + RFC-1918 + extras

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -67,11 +67,20 @@ class Settings(BaseSettings):
     AUTH0_MGMT_API_URL: str
 
     # ── CORS ──────────────────────────────────────────────────────────────────
+    # Exact-match origin allowlist (cloud hostnames, explicit dev URLs).
     ALLOWED_ORIGINS: str = "http://localhost:3000,http://localhost:8080"
+    # Additional exact-match origins (comma-separated) layered on top of
+    # ALLOWED_ORIGINS. Populated at deploy time for demo/preview hostnames
+    # before the edge layer is in place.
+    CORS_EXTRA_ORIGINS: str = ""
 
     @property
     def allowed_origins_list(self) -> list[str]:
         return [o.strip() for o in self.ALLOWED_ORIGINS.split(",") if o.strip()]
+
+    @property
+    def cors_extra_origins_list(self) -> list[str]:
+        return [o.strip() for o in self.CORS_EXTRA_ORIGINS.split(",") if o.strip()]
 
     # ── Sentry (optional) ─────────────────────────────────────────────────────
     SENTRY_DSN: str | None = None

--- a/backend/src/core/app_factory.py
+++ b/backend/src/core/app_factory.py
@@ -26,6 +26,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from slowapi.errors import RateLimitExceeded
 
+from src.core.cors import build_lan_origin_regex
 from src.core.limiter import limiter
 from src.core.middleware import AppVersionMiddleware
 from src.core.observability import CorrelationIdMiddleware
@@ -198,7 +199,8 @@ def _register_middleware(app: FastAPI) -> None:
     app.add_middleware(AppVersionMiddleware)
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=settings.allowed_origins_list,
+        allow_origins=settings.allowed_origins_list + settings.cors_extra_origins_list,
+        allow_origin_regex=build_lan_origin_regex(),
         allow_credentials=True,
         allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
         allow_headers=[

--- a/backend/src/core/cors.py
+++ b/backend/src/core/cors.py
@@ -1,0 +1,59 @@
+"""
+backend/src/core/cors.py
+
+CORS helpers for local-dev and pre-edge deploys.
+
+Production CORS is expected to be handled at the edge (Cloudflare + future
+API gateway). This module exists for two interim states where that edge is
+not yet in front of the service:
+
+1. Local dev — `uvicorn` loaded from localhost or a LAN peer (e.g.
+   192.168.x.x) during a customer demo, with the Next.js dev server on
+   port 3000/3010.
+2. Pre-edge cloud deploys — service on a public VM under a real hostname
+   before the edge layer lands. Cloud origins are exact-match entries in
+   ALLOWED_ORIGINS / CORS_EXTRA_ORIGINS.
+
+With Option B's same-origin rewrites() proxy the browser talks to the
+Next.js origin only, so the LAN regex is mostly defense in depth —
+direct browser-to-backend hits still need a sane allowlist.
+"""
+
+from __future__ import annotations
+
+# Allowed LAN web ports — mirrors docker-compose (3000 primary, 3010 admin).
+_WEB_PORTS: tuple[int, ...] = (3000, 3010)
+
+# RFC-1918 + loopback host patterns. Matches localhost, IPv4/IPv6 loopback,
+# and all three RFC-1918 private ranges.
+_HOST_PATTERNS: tuple[str, ...] = (
+    r"localhost",
+    r"\[::1\]",  # IPv6 loopback, bracketed in URLs
+    r"127(?:\.\d{1,3}){3}",  # 127.0.0.0/8
+    r"10(?:\.\d{1,3}){3}",  # 10.0.0.0/8
+    r"172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2}",  # 172.16.0.0/12
+    r"192\.168(?:\.\d{1,3}){2}",  # 192.168.0.0/16
+)
+
+
+def build_lan_origin_regex() -> str:
+    """Regex for CORSMiddleware(allow_origin_regex=...).
+
+    Admits http://<loopback-or-RFC1918>:<web-port>. HTTPS is excluded —
+    LAN demos run plain HTTP; cloud origins go through the exact-match
+    allowlist (ALLOWED_ORIGINS / CORS_EXTRA_ORIGINS).
+    """
+    hosts = "|".join(_HOST_PATTERNS)
+    ports = "|".join(str(p) for p in _WEB_PORTS)
+    return rf"^http://(?:{hosts}):(?:{ports})$"
+
+
+def parse_extra_origins(env_value: str | None) -> list[str]:
+    """Parse comma-separated CORS_EXTRA_ORIGINS → list of exact origins.
+
+    Empty entries and surrounding whitespace are stripped. Empty input
+    returns an empty list.
+    """
+    if not env_value:
+        return []
+    return [o.strip() for o in env_value.split(",") if o.strip()]

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,75 @@
+"""
+backend/tests/test_cors.py
+
+Parity with Thittam's pkg/corsutil tests — same inputs, same expected
+outputs. FastAPI's CORSMiddleware consumes the regex directly, so these
+tests exercise the regex via re.fullmatch() rather than a callable wrapper.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from src.core.cors import build_lan_origin_regex, parse_extra_origins
+
+
+@pytest.fixture(scope="module")
+def lan_regex() -> re.Pattern[str]:
+    return re.compile(build_lan_origin_regex())
+
+
+def _allows(regex: re.Pattern[str], origin: str) -> bool:
+    return regex.fullmatch(origin) is not None
+
+
+@pytest.mark.parametrize(
+    ("origin", "expected"),
+    [
+        # Accepted — loopback + RFC-1918 on allowed web ports.
+        ("http://localhost:3000", True),
+        ("http://localhost:3010", True),
+        ("http://127.0.0.1:3000", True),
+        ("http://192.168.68.55:3000", True),
+        ("http://10.0.0.5:3010", True),
+        ("http://172.16.4.2:3000", True),
+        ("http://172.31.255.1:3000", True),
+        ("http://[::1]:3000", True),
+        # Wrong port.
+        ("http://localhost:3200", False),
+        ("http://192.168.1.1:8080", False),
+        # Wrong scheme — https intentionally out of scope for LAN.
+        ("https://localhost:3000", False),
+        # Public IPs and just-outside-RFC-1918 ranges.
+        ("http://8.8.8.8:3000", False),
+        ("http://172.32.0.1:3000", False),
+        ("http://example.com:3000", False),
+        # Garbage.
+        ("", False),
+        ("not-a-url", False),
+        ("http://:3000", False),
+    ],
+)
+def test_lan_origin_regex(lan_regex: re.Pattern[str], origin: str, expected: bool) -> None:
+    assert _allows(lan_regex, origin) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, []),
+        ("", []),
+        ("https://a.example.com", ["https://a.example.com"]),
+        (
+            "https://a.example.com,https://b.example.com",
+            ["https://a.example.com", "https://b.example.com"],
+        ),
+        (
+            " https://a.example.com , ,https://b.example.com  ",
+            ["https://a.example.com", "https://b.example.com"],
+        ),
+    ],
+)
+def test_parse_extra_origins(value: str | None, expected: list[str]) -> None:
+    assert parse_extra_origins(value) == expected


### PR DESCRIPTION
## Summary

Adds a regex-driven CORS allowance for local-dev and pre-edge deploys so demos from a LAN peer (`http://192.168.x.x:3000`) no longer hit a CORS wall, without opening the door to arbitrary public origins. Mirrors the Thittam `pkg/corsutil` pattern.

- `src/core/cors.py` — `build_lan_origin_regex()` emits `^http://(localhost|[::1]|127.*|10.*|172.16-31.*|192.168.*):(3000|3010)$`
- `config.py` — `CORS_EXTRA_ORIGINS` env var for comma-separated exact-match cloud origins (preview/demo hostnames), layered on top of `ALLOWED_ORIGINS`
- `app_factory.py` — `CORSMiddleware` now consumes `allow_origin_regex` alongside the combined `allow_origins` list
- `tests/test_cors.py` — 22 cases ported from `thittam/pkg/corsutil` tests

## Posture

HTTPS is deliberately excluded from the regex — LAN demos are plain HTTP, and cloud origins (HTTPS) must be explicit entries in `ALLOWED_ORIGINS` / `CORS_EXTRA_ORIGINS` so misconfiguration fails closed.

With Option B (#264) landed, the browser talks same-origin to Next.js anyway, so this CORS allowance is defense-in-depth for direct backend hits (mobile app, debugging, future SPAs).

## Test plan

- [x] Unit tests: 22 cases (17 regex + 5 parse) pass inside the running api container.
- [x] End-to-end: preflight from `Origin: http://192.168.1.50:3000` echoes the origin in `Access-Control-Allow-Origin`; preflight from `Origin: https://evil.example.com` returns no allow-origin header.
- [x] App boots: `create_app()` returns non-None with the new middleware wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)