### PR TITLE
feat(auth): CF-aware client IP + fail-open + env-driven rate limits

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -73,6 +73,14 @@ class Settings(BaseSettings):
     def allowed_origins_list(self) -> list[str]:
         return [o.strip() for o in self.ALLOWED_ORIGINS.split(",") if o.strip()]
 
+    # ── Rate limiting (credential-stuffing defence on /auth/* and /help/*) ───
+    # Env-driven so ops can tighten at the edge without a code change.
+    # Defaults preserve the pre-hardening behaviour: 10 requests / 60 s / IP.
+    AUTH_RATE_LIMIT: int = 10
+    AUTH_RATE_WINDOW: int = 60
+    HELP_RATE_LIMIT: int = 10
+    HELP_RATE_WINDOW: int = 60
+
     # ── Sentry (optional) ─────────────────────────────────────────────────────
     SENTRY_DSN: str | None = None
 

--- a/backend/src/core/rate_limit.py
+++ b/backend/src/core/rate_limit.py
@@ -9,27 +9,102 @@ body parameter introspection on async handlers.
 
 State lives in shared Redis so limits are enforced across all workers.
 
-Limits:
-  AUTH_LIMIT  — 10 requests per 60 s per IP on all auth token/login endpoints.
+Posture:
+  - Client IP is resolved via the standard reverse-proxy header chain
+    (CF-Connecting-IP → X-Real-IP → X-Forwarded-For → request.client.host).
+    Behind Cloudflare this keeps per-user throttling intact; without a
+    trusted proxy header the whole fleet would bucket under the edge IP.
+  - Redis errors fail *open* — the limiter is a safety net, not an auth
+    layer. A Redis hiccup must not take down /auth/*. The limiter logs
+    and lets the request through.
+  - Windows and limits are env-driven so ops can tighten credential-stuffing
+    defences at the edge without a code change.
 """
 
 from __future__ import annotations
 
+from config import settings
 from fastapi import HTTPException, Request
+from redis.exceptions import RedisError
 
 from src.core.redis_client import get_redis
+from src.utils.logger import get_logger
 
-_AUTH_LIMIT = 10
-_AUTH_WINDOW = 60  # seconds
+log = get_logger("rate_limit")
 
-_HELP_LIMIT = 10
-_HELP_WINDOW = 60  # seconds
+
+def _get_client_ip(request: Request) -> str:
+    """Resolve the client IP from proxy headers with direct-connection fallback.
+
+    Order matters: CF-Connecting-IP is overwritten by Cloudflare per request
+    and cannot be spoofed by the client; the other headers can be, so they're
+    only trusted as a best-effort fallback when CF isn't fronting.
+    """
+    cf = request.headers.get("cf-connecting-ip")
+    if cf:
+        return cf.strip()
+    xri = request.headers.get("x-real-ip")
+    if xri:
+        return xri.strip()
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        # XFF is "client, proxy1, proxy2" — first hop is the originating client.
+        first = xff.split(",", 1)[0].strip()
+        if first:
+            return first
+    if request.client and request.client.host:
+        return request.client.host
+    return ""
+
+
+async def _enforce_rate_limit(
+    request: Request,
+    *,
+    key_prefix: str,
+    limit: int,
+    window: int,
+) -> None:
+    """Shared Redis fixed-window counter enforcement.
+
+    Raises HTTP 429 (with Retry-After) once count exceeds `limit` within
+    `window` seconds. On Redis error: logs and returns (fail open).
+    """
+    ip = _get_client_ip(request)
+    if not ip:
+        # No usable IP — throttling would bucket every misconfigured request
+        # into one noisy key. Better to pass through than to take the site
+        # down for anyone behind a broken proxy.
+        return
+
+    redis = get_redis(request)
+    key = f"{key_prefix}:{ip}"
+
+    try:
+        count = await redis.incr(key)
+        if count == 1:
+            await redis.expire(key, window)
+    except RedisError as exc:
+        log.warning("rate_limit_redis_error", key=key, error=str(exc))
+        return
+
+    if count > limit:
+        try:
+            ttl = await redis.ttl(key)
+            retry_after = ttl if isinstance(ttl, int) and ttl > 0 else window
+        except RedisError:
+            retry_after = window
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "error": "rate_limited",
+                "detail": "Too many requests. Please try again later.",
+            },
+            headers={"Retry-After": str(retry_after)},
+        )
 
 
 async def ip_help_rate_limit(request: Request) -> None:
-    """
-    FastAPI dependency: raise HTTP 429 if this IP has exceeded 10 help-ask
-    requests within the past 60 seconds.
+    """FastAPI dependency: throttle help-ask endpoint by client IP.
 
     Usage::
 
@@ -40,31 +115,19 @@ async def ip_help_rate_limit(request: Request) -> None:
             _: None = Depends(ip_help_rate_limit),
         ): ...
     """
-    redis = get_redis(request)
-    ip = request.client.host if request.client else "unknown"
-    key = f"help_rate:{ip}"
-
-    count = await redis.incr(key)
-    if count == 1:
-        await redis.expire(key, _HELP_WINDOW)
-
-    if count > _HELP_LIMIT:
-        raise HTTPException(
-            status_code=429,
-            detail={
-                "error": "rate_limited",
-                "detail": "Too many requests. Please try again later.",
-            },
-        )
+    await _enforce_rate_limit(
+        request,
+        key_prefix="help_rate",
+        limit=settings.HELP_RATE_LIMIT,
+        window=settings.HELP_RATE_WINDOW,
+    )
 
 
 async def ip_auth_rate_limit(request: Request) -> None:
-    """
-    FastAPI dependency: raise HTTP 429 if this IP has exceeded 10 auth
-    requests within the past 60 seconds.
+    """FastAPI dependency: throttle auth endpoints by client IP.
 
-    Uses a Redis INCR + EXPIRE counter.  The counter is keyed by client IP so
-    it is shared across requests but scoped per-IP (not per-endpoint).
+    The counter is keyed by resolved client IP so it is shared across auth
+    endpoints and enforced per-IP (not per-endpoint).
 
     Usage::
 
@@ -75,20 +138,9 @@ async def ip_auth_rate_limit(request: Request) -> None:
             _: None = Depends(ip_auth_rate_limit),
         ): ...
     """
-    redis = get_redis(request)
-    ip = request.client.host if request.client else "unknown"
-    key = f"auth_rate:{ip}"
-
-    count = await redis.incr(key)
-    if count == 1:
-        # First request in this window — set the expiry.
-        await redis.expire(key, _AUTH_WINDOW)
-
-    if count > _AUTH_LIMIT:
-        raise HTTPException(
-            status_code=429,
-            detail={
-                "error": "rate_limited",
-                "detail": "Too many requests. Please try again later.",
-            },
-        )
+    await _enforce_rate_limit(
+        request,
+        key_prefix="auth_rate",
+        limit=settings.AUTH_RATE_LIMIT,
+        window=settings.AUTH_RATE_WINDOW,
+    )

--- a/backend/tests/test_rate_limit_hardening.py
+++ b/backend/tests/test_rate_limit_hardening.py
@@ -1,0 +1,168 @@
+"""
+tests/test_rate_limit_hardening.py
+
+Covers the hardening work on src/core/rate_limit.py:
+  - _get_client_ip header precedence (CF > X-Real-IP > XFF first-hop > client.host)
+  - Fail-open on Redis error (throttle must not take down /auth/*)
+  - Retry-After header shape on 429
+  - Env-driven limits (AUTH_RATE_LIMIT / AUTH_RATE_WINDOW)
+
+The existing tests in test_auth_rate_limit.py continue to cover end-to-end
+throttling via the real FastAPI routes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException, Request
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+from src.core.rate_limit import _enforce_rate_limit, _get_client_ip
+
+
+def _make_request(headers: dict[str, str] | None = None, client_host: str | None = "1.2.3.4") -> Request:
+    """Build a minimal ASGI Request for helper-level tests."""
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "headers": raw_headers,
+        "client": (client_host, 12345) if client_host else None,
+    }
+    return Request(scope)
+
+
+# ── _get_client_ip header precedence ──────────────────────────────────────────
+
+
+def test_client_ip_prefers_cf_connecting_ip() -> None:
+    req = _make_request(
+        headers={
+            "CF-Connecting-IP": "203.0.113.5",
+            "X-Real-IP": "198.51.100.9",
+            "X-Forwarded-For": "192.0.2.1, 10.0.0.1",
+        },
+        client_host="1.2.3.4",
+    )
+    assert _get_client_ip(req) == "203.0.113.5"
+
+
+def test_client_ip_falls_back_to_x_real_ip() -> None:
+    req = _make_request(
+        headers={
+            "X-Real-IP": "198.51.100.9",
+            "X-Forwarded-For": "192.0.2.1, 10.0.0.1",
+        },
+    )
+    assert _get_client_ip(req) == "198.51.100.9"
+
+
+def test_client_ip_uses_xff_first_hop() -> None:
+    req = _make_request(headers={"X-Forwarded-For": "192.0.2.1, 10.0.0.1, 172.16.0.1"})
+    assert _get_client_ip(req) == "192.0.2.1"
+
+
+def test_client_ip_xff_single_value() -> None:
+    req = _make_request(headers={"X-Forwarded-For": "192.0.2.7"})
+    assert _get_client_ip(req) == "192.0.2.7"
+
+
+def test_client_ip_falls_back_to_remote_addr() -> None:
+    req = _make_request(client_host="1.2.3.4")
+    assert _get_client_ip(req) == "1.2.3.4"
+
+
+def test_client_ip_empty_when_nothing_available() -> None:
+    req = _make_request(client_host=None)
+    assert _get_client_ip(req) == ""
+
+
+def test_client_ip_trims_whitespace() -> None:
+    req = _make_request(headers={"CF-Connecting-IP": "  203.0.113.5  "})
+    assert _get_client_ip(req) == "203.0.113.5"
+
+
+# ── Fail-open behaviour on Redis error ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enforce_fail_open_on_redis_error(monkeypatch) -> None:
+    """Redis INCR failure must not block the request."""
+    req = _make_request(client_host="10.0.0.1")
+    redis = AsyncMock()
+    redis.incr.side_effect = RedisConnectionError("redis down")
+    req.app = type("App", (), {"state": type("S", (), {"redis": redis})()})()
+
+    # Should NOT raise — fail open.
+    await _enforce_rate_limit(req, key_prefix="auth_rate", limit=10, window=60)
+    redis.incr.assert_awaited_once_with("auth_rate:10.0.0.1")
+
+
+@pytest.mark.asyncio
+async def test_enforce_no_ip_passes_through() -> None:
+    """No resolvable client IP → pass through rather than bucket everyone."""
+    req = _make_request(client_host=None)
+    redis = AsyncMock()
+    req.app = type("App", (), {"state": type("S", (), {"redis": redis})()})()
+
+    await _enforce_rate_limit(req, key_prefix="auth_rate", limit=10, window=60)
+    redis.incr.assert_not_called()
+
+
+# ── 429 response shape ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enforce_raises_429_with_retry_after() -> None:
+    req = _make_request(client_host="10.0.0.2")
+    redis = AsyncMock()
+    redis.incr.return_value = 11  # one past the limit
+    redis.ttl.return_value = 42
+    req.app = type("App", (), {"state": type("S", (), {"redis": redis})()})()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _enforce_rate_limit(req, key_prefix="auth_rate", limit=10, window=60)
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers == {"Retry-After": "42"}
+    assert exc_info.value.detail["error"] == "rate_limited"
+
+
+@pytest.mark.asyncio
+async def test_enforce_retry_after_falls_back_to_window() -> None:
+    """TTL missing (-1 / -2 / None) → Retry-After uses the full window."""
+    req = _make_request(client_host="10.0.0.3")
+    redis = AsyncMock()
+    redis.incr.return_value = 11
+    redis.ttl.return_value = -1
+    req.app = type("App", (), {"state": type("S", (), {"redis": redis})()})()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _enforce_rate_limit(req, key_prefix="auth_rate", limit=10, window=60)
+
+    assert exc_info.value.headers == {"Retry-After": "60"}
+
+
+@pytest.mark.asyncio
+async def test_enforce_below_limit_passes_and_sets_ttl_on_first_hit() -> None:
+    req = _make_request(client_host="10.0.0.4")
+    redis = AsyncMock()
+    redis.incr.return_value = 1  # first hit
+    req.app = type("App", (), {"state": type("S", (), {"redis": redis})()})()
+
+    await _enforce_rate_limit(req, key_prefix="auth_rate", limit=10, window=60)
+    redis.expire.assert_awaited_once_with("auth_rate:10.0.0.4", 60)
+
+
+@pytest.mark.asyncio
+async def test_enforce_subsequent_hits_do_not_re_set_ttl() -> None:
+    req = _make_request(client_host="10.0.0.5")
+    redis = AsyncMock()
+    redis.incr.return_value = 5  # mid-window
+    req.app = type("App", (), {"state": type("S", (), {"redis": redis})()})()
+
+    await _enforce_rate_limit(req, key_prefix="auth_rate", limit=10, window=60)
+    redis.expire.assert_not_called()


### PR DESCRIPTION
## Summary

Hardens the existing auth rate limiter (`backend/src/core/rate_limit.py`) against the failure modes that show up when sketching the Cloudflare edge rollout.

1. **CF-aware client IP.** Resolves through `CF-Connecting-IP` → `X-Real-IP` → `X-Forwarded-For` first hop → `request.client.host`. Behind Cloudflare the old `request.client.host` would bucket every user under the CF edge IP and throttle the whole fleet together.
2. **Fail open on Redis error.** The limiter is a safety net, not an auth layer. An `INCR`/`EXPIRE` failure logs and lets the request through rather than 500-ing auth for the duration of a Redis hiccup.
3. **Env-driven limits.** `AUTH_RATE_LIMIT`, `AUTH_RATE_WINDOW`, `HELP_RATE_LIMIT`, `HELP_RATE_WINDOW`. Defaults preserve current behaviour (10 req / 60 s).
4. **`Retry-After` header.** 429 responses carry the remaining TTL (or the full window if TTL is unset) so clients can back off intelligently.

## Posture

The existing `ip_auth_rate_limit` and `ip_help_rate_limit` dependency shape is unchanged — all call sites in `auth/router.py`, `auth/admin_router.py`, and `help/router.py` continue to work.

Pairs with the [Cloudflare edge-setup runbook](https://github.com/wegofwd2020-hub/studybuddy-docs/pull/10) in `studybuddy-docs` (PR to follow in the linked repo).

## Test plan

- [x] New unit tests in `tests/test_rate_limit_hardening.py`: IP resolution precedence (CF/XRI/XFF/RemoteAddr/empty), Redis fail-open, 429 body + `Retry-After` header, TTL fallback when key TTL is `-1`.
- [x] Existing `tests/test_auth_rate_limit.py` (end-to-end) untouched and continues to exercise throttling via real FastAPI routes.
- [x] Live smoke: 11 POSTs to `/auth/exchange` with same `CF-Connecting-IP` yield 429 + `Retry-After: 53`; 12 POSTs with distinct `CF-Connecting-IP` values all pass through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)