### PR TITLE
test(auth): PR #2 of #261 — cover identity/audit cluster of tasks.py

### DIFF
--- a/backend/tests/test_auth_tasks_identity.py
+++ b/backend/tests/test_auth_tasks_identity.py
@@ -1,0 +1,285 @@
+"""
+tests/test_auth_tasks_identity.py
+
+Identity / audit-cluster Celery tasks from src/auth/tasks.py.
+
+Covers four zero-coverage tasks that sit on the auth critical path:
+  - sync_auth0_suspension       — Auth0 block/unblock
+  - cascade_school_suspension   — suspend all members of a school
+  - gdpr_delete_account         — anonymise + delete from Auth0
+  - write_audit_log_task        — append a row to audit_log
+
+Part of Issue #261 floor-raise for src/auth. Each task is invoked directly
+via the Celery .run() entry point with its async dependencies mocked at
+their external module seams (no live Redis / Postgres / Auth0).
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _async_pool_ctx(pool: MagicMock) -> MagicMock:
+    """Wrap a pool mock so `await asyncpg.create_pool(...)` returns it."""
+    ctx = AsyncMock()
+    ctx.return_value = pool
+    return ctx
+
+
+# ── sync_auth0_suspension ─────────────────────────────────────────────────────
+
+
+def test_sync_auth0_suspension_block_calls_auth0_with_blocked_true():
+    from src.auth.tasks import sync_auth0_suspension
+
+    mock_redis = AsyncMock()
+    with (
+        patch("redis.asyncio.from_url", new=AsyncMock(return_value=mock_redis)),
+        patch(
+            "src.auth.auth0_client.block_auth0_user", new_callable=AsyncMock
+        ) as mock_block,
+    ):
+        sync_auth0_suspension.run("auth0|user-123", "block")
+
+    mock_block.assert_awaited_once_with(
+        "auth0|user-123", blocked=True, redis=mock_redis
+    )
+    mock_redis.aclose.assert_awaited_once()
+
+
+def test_sync_auth0_suspension_unblock_calls_auth0_with_blocked_false():
+    from src.auth.tasks import sync_auth0_suspension
+
+    mock_redis = AsyncMock()
+    with (
+        patch("redis.asyncio.from_url", new=AsyncMock(return_value=mock_redis)),
+        patch(
+            "src.auth.auth0_client.block_auth0_user", new_callable=AsyncMock
+        ) as mock_block,
+    ):
+        sync_auth0_suspension.run("auth0|user-456", "unblock")
+
+    mock_block.assert_awaited_once_with(
+        "auth0|user-456", blocked=False, redis=mock_redis
+    )
+
+
+def test_sync_auth0_suspension_retries_on_auth0_error():
+    from src.auth.tasks import sync_auth0_suspension
+
+    mock_redis = AsyncMock()
+    with (
+        patch("redis.asyncio.from_url", new=AsyncMock(return_value=mock_redis)),
+        patch(
+            "src.auth.auth0_client.block_auth0_user",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("auth0 api down"),
+        ),
+    ):
+        # `self.retry(...)` outside a worker raises; just assert it bubbles.
+        with pytest.raises(Exception):
+            sync_auth0_suspension.run("auth0|user-789", "block")
+
+
+# ── cascade_school_suspension (retry path below) ──────────────────────────────
+
+
+def test_cascade_school_suspension_noops_on_non_suspended_status():
+    """Reactivating a school does not cascade to members — task returns early."""
+    from src.auth.tasks import cascade_school_suspension
+
+    mock_create_pool = AsyncMock()
+    with patch("asyncpg.create_pool", mock_create_pool):
+        cascade_school_suspension.run(str(uuid.uuid4()), "active")
+
+    mock_create_pool.assert_not_called()
+
+
+def test_cascade_school_suspension_suspends_teachers_and_students():
+    from src.auth.tasks import cascade_school_suspension
+
+    school_id = str(uuid.uuid4())
+    teacher_id = uuid.uuid4()
+    student_id = uuid.uuid4()
+
+    pool = MagicMock()
+    pool.fetch = AsyncMock(
+        side_effect=[
+            [{"teacher_id": teacher_id}],
+            [{"student_id": student_id}],
+        ]
+    )
+    pool.execute = AsyncMock()
+    pool.close = AsyncMock()
+
+    redis_pipeline = MagicMock()
+    redis_pipeline.execute = AsyncMock()
+    redis_client = AsyncMock()
+    redis_client.pipeline = MagicMock(return_value=redis_pipeline)
+
+    with (
+        patch("asyncpg.create_pool", new=AsyncMock(return_value=pool)),
+        patch("redis.asyncio.from_url", new=AsyncMock(return_value=redis_client)),
+    ):
+        cascade_school_suspension.run(school_id, "suspended")
+
+    # Two SELECTs (teachers + students) + two UPDATEs (teachers + students).
+    assert pool.fetch.await_count == 2
+    assert pool.execute.await_count == 2
+
+    # Redis pipeline set the suspension flag for each member.
+    redis_pipeline.set.assert_any_call(f"suspended:{teacher_id}", "1")
+    redis_pipeline.set.assert_any_call(f"suspended:{student_id}", "1")
+    redis_pipeline.execute.assert_awaited_once()
+
+    redis_client.aclose.assert_awaited_once()
+    pool.close.assert_awaited_once()
+
+
+# ── gdpr_delete_account ───────────────────────────────────────────────────────
+
+
+def test_gdpr_delete_account_anonymises_student_and_deletes_auth0():
+    from src.auth.tasks import gdpr_delete_account
+
+    student_id = str(uuid.uuid4())
+    auth0_sub = "auth0|to-delete-42"
+
+    pool = MagicMock()
+    pool.execute = AsyncMock()
+    pool.close = AsyncMock()
+    redis_client = AsyncMock()
+
+    with (
+        patch("asyncpg.create_pool", new=AsyncMock(return_value=pool)),
+        patch("redis.asyncio.from_url", new=AsyncMock(return_value=redis_client)),
+        patch(
+            "src.auth.auth0_client.delete_auth0_user", new_callable=AsyncMock
+        ) as mock_delete,
+    ):
+        gdpr_delete_account.run(student_id, auth0_sub)
+
+    # DB anonymisation query fired with redacted placeholder values.
+    pool.execute.assert_awaited_once()
+    call_args = pool.execute.call_args.args
+    assert "UPDATE students" in call_args[0]
+    assert call_args[1] == f"deleted-{student_id[:8]}"  # anon_name
+    assert call_args[2] == f"deleted-{student_id}@deleted.invalid"  # anon_email
+    assert call_args[3] == uuid.UUID(student_id)
+
+    mock_delete.assert_awaited_once_with(auth0_sub, redis=redis_client)
+    redis_client.aclose.assert_awaited_once()
+    pool.close.assert_awaited_once()
+
+
+# ── write_audit_log_task ──────────────────────────────────────────────────────
+
+
+def test_write_audit_log_task_inserts_row_with_all_fields():
+    from src.auth.tasks import write_audit_log_task
+
+    pool = MagicMock()
+    pool.execute = AsyncMock()
+    pool.close = AsyncMock()
+
+    actor_id = str(uuid.uuid4())
+    target_id = str(uuid.uuid4())
+
+    with patch("asyncpg.create_pool", new=AsyncMock(return_value=pool)):
+        write_audit_log_task.run(
+            event_type="auth.suspend",
+            actor_type="admin",
+            actor_id=actor_id,
+            target_type="student",
+            target_id=target_id,
+            metadata={"reason": "policy"},
+            ip_address="10.0.0.1",
+            correlation_id="corr-xyz",
+        )
+
+    pool.execute.assert_awaited_once()
+    call_args = pool.execute.call_args.args
+    assert "INSERT INTO audit_log" in call_args[0]
+    assert call_args[1] == "auth.suspend"
+    assert call_args[2] == "admin"
+    assert call_args[3] == uuid.UUID(actor_id)
+    assert call_args[4] == "student"
+    assert call_args[5] == uuid.UUID(target_id)
+    assert call_args[6] == '{"reason": "policy"}'  # json-encoded
+    assert call_args[7] == "10.0.0.1"
+    assert call_args[8] == "corr-xyz"
+    pool.close.assert_awaited_once()
+
+
+def test_write_audit_log_task_handles_null_optional_fields():
+    """actor_id / target_id / metadata = None — no uuid.UUID() call, no JSON encode."""
+    from src.auth.tasks import write_audit_log_task
+
+    pool = MagicMock()
+    pool.execute = AsyncMock()
+    pool.close = AsyncMock()
+
+    with patch("asyncpg.create_pool", new=AsyncMock(return_value=pool)):
+        write_audit_log_task.run(
+            event_type="system.startup",
+            actor_type="system",
+            actor_id=None,
+            target_type=None,
+            target_id=None,
+            metadata=None,
+            ip_address=None,
+            correlation_id=None,
+        )
+
+    call_args = pool.execute.call_args.args
+    assert call_args[3] is None  # actor_id
+    assert call_args[5] is None  # target_id
+    assert call_args[6] is None  # metadata
+
+
+# ── Retry paths ───────────────────────────────────────────────────────────────
+
+
+def test_cascade_school_suspension_retries_on_db_error():
+    from src.auth.tasks import cascade_school_suspension
+
+    with patch(
+        "asyncpg.create_pool",
+        new=AsyncMock(side_effect=RuntimeError("db down")),
+    ):
+        with pytest.raises(Exception):
+            cascade_school_suspension.run(str(uuid.uuid4()), "suspended")
+
+
+def test_gdpr_delete_account_retries_on_db_error():
+    from src.auth.tasks import gdpr_delete_account
+
+    with patch(
+        "asyncpg.create_pool",
+        new=AsyncMock(side_effect=RuntimeError("db down")),
+    ):
+        with pytest.raises(Exception):
+            gdpr_delete_account.run(str(uuid.uuid4()), "auth0|user-x")
+
+
+def test_write_audit_log_task_retries_on_db_error():
+    from src.auth.tasks import write_audit_log_task
+
+    with patch(
+        "asyncpg.create_pool",
+        new=AsyncMock(side_effect=RuntimeError("db down")),
+    ):
+        with pytest.raises(Exception):
+            write_audit_log_task.run(
+                event_type="test",
+                actor_type="system",
+                actor_id=None,
+                target_type=None,
+                target_id=None,
+                metadata=None,
+                ip_address=None,
+                correlation_id=None,
+            )

--- a/backend/tests/test_rate_limit_hardening.py
+++ b/backend/tests/test_rate_limit_hardening.py
@@ -23,7 +23,12 @@ from src.core.rate_limit import _enforce_rate_limit, _get_client_ip
 
 
 def _make_request(headers: dict[str, str] | None = None, client_host: str | None = "1.2.3.4") -> Request:
-    """Build a minimal ASGI Request for helper-level tests."""
+    """Build a minimal ASGI Request for helper-level tests.
+
+    Note: Starlette exposes request.app via a read-only property backed by
+    scope["app"], so direct attribute assignment (req.app = ...) fails with
+    AttributeError. Tests that need an app install it via req.scope["app"].
+    """
     raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
     scope = {
         "type": "http",
@@ -94,7 +99,7 @@ async def test_enforce_fail_open_on_redis_error(monkeypatch) -> None:
     req = _make_request(client_host="10.0.0.1")
     redis = AsyncMock()
     redis.incr.side_effect = RedisConnectionError("redis down")
-    req.app = type("App", (), {"state": type("S", (), {"redis": redis})()})()
+    req.scope["app"] = type("App", (), {"state": type("S", (), {"redis": redis})()})()
 
     # Should NOT raise — fail open.
     await _enforce_rate_limit(req, key_prefix="auth_rate", limit=10, window=60)
@@ -106,7 +111,7 @@ async def test_enforce_no_ip_passes_through() -> None:
     """No resolvable client IP → pass through rather than bucket everyone."""
     req = _make_request(client_host=None)
     redis = AsyncMock()
-    req.app = type("App", (), {"state": type("S", (), {"redis": redis})()})()
+    req.scope["app"] = type("App", (), {"state": type("S", (), {"redis": redis})()})()
 
     await _enforce_rate_limit(req, key_prefix="auth_rate", limit=10, window=60)
     redis.incr.assert_not_called()
@@ -121,7 +126,7 @@ async def test_enforce_raises_429_with_retry_after() -> None:
     redis = AsyncMock()
     redis.incr.return_value = 11  # one past the limit
     redis.ttl.return_value = 42
-    req.app = type("App", (), {"state": type("S", (), {"redis": redis})()})()
+    req.scope["app"] = type("App", (), {"state": type("S", (), {"redis": redis})()})()
 
     with pytest.raises(HTTPException) as exc_info:
         await _enforce_rate_limit(req, key_prefix="auth_rate", limit=10, window=60)
@@ -138,7 +143,7 @@ async def test_enforce_retry_after_falls_back_to_window() -> None:
     redis = AsyncMock()
     redis.incr.return_value = 11
     redis.ttl.return_value = -1
-    req.app = type("App", (), {"state": type("S", (), {"redis": redis})()})()
+    req.scope["app"] = type("App", (), {"state": type("S", (), {"redis": redis})()})()
 
     with pytest.raises(HTTPException) as exc_info:
         await _enforce_rate_limit(req, key_prefix="auth_rate", limit=10, window=60)
@@ -151,7 +156,7 @@ async def test_enforce_below_limit_passes_and_sets_ttl_on_first_hit() -> None:
     req = _make_request(client_host="10.0.0.4")
     redis = AsyncMock()
     redis.incr.return_value = 1  # first hit
-    req.app = type("App", (), {"state": type("S", (), {"redis": redis})()})()
+    req.scope["app"] = type("App", (), {"state": type("S", (), {"redis": redis})()})()
 
     await _enforce_rate_limit(req, key_prefix="auth_rate", limit=10, window=60)
     redis.expire.assert_awaited_once_with("auth_rate:10.0.0.4", 60)
@@ -162,7 +167,7 @@ async def test_enforce_subsequent_hits_do_not_re_set_ttl() -> None:
     req = _make_request(client_host="10.0.0.5")
     redis = AsyncMock()
     redis.incr.return_value = 5  # mid-window
-    req.app = type("App", (), {"state": type("S", (), {"redis": redis})()})()
+    req.scope["app"] = type("App", (), {"state": type("S", (), {"redis": redis})()})()
 
     await _enforce_rate_limit(req, key_prefix="auth_rate", limit=10, window=60)
     redis.expire.assert_not_called()


### PR DESCRIPTION
## Summary

Second slice of Issue #261 coverage raise. `tasks.py` was at **12.8%**; the four tasks on the auth / identity / audit critical path were at **0%**. This PR covers them.

| Task | Tests | Lines | Why it matters |
|---|---|---|---|
| \`sync_auth0_suspension\` | 3 (block / unblock / retry) | 22 | Blocks Auth0 users on suspension — security-critical |
| \`cascade_school_suspension\` | 3 (noop / full cascade / retry) | 54 | Suspends all teachers + students when a school is suspended |
| \`gdpr_delete_account\` | 2 (happy / retry) | 39 | Anonymises PII + deletes from Auth0 — compliance-critical |
| \`write_audit_log_task\` | 3 (all fields / null optionals / retry) | 41 | Used everywhere; append-only audit trail |

**11 new tests.** \`src/auth/tasks.py\` coverage: 12.8% → **20.0%** (+7.2 pp).

## Pattern

Each task is invoked via its Celery \`.run()\` entry point with async dependencies mocked at module seams (\`asyncpg.create_pool\`, \`redis.asyncio.from_url\`, \`src.auth.auth0_client.{block,delete}_auth0_user\`) — no live DB / Redis / Auth0 required. Same pattern as \`test_cdn_invalidation.py\` (already-shipped tests for \`invalidate_cdn_task\`).

## Test plan

- [x] 11 tests pass in the api container.
- [x] Coverage confirmed via \`pytest --cov=src.auth.tasks\` — 4 target tasks at ~100%, untouched tasks stay at 0% (next PRs).

## What's still uncovered in tasks.py

Remaining 0%-coverage blocks for PR #3+: \`write_progress_answer_task\`, \`update_streak_task\`, \`refresh_progress_view_task\`, \`poll_infra_metrics\`, \`write_lesson_end_task\`, \`send_push_notification_task\`, the pipeline tasks (\`run_curriculum_pipeline_task\`, \`run_grade_pipeline_task\`, \`regenerate_subject_task\`), scheduled tasks (\`promote_student_grades\`, \`refresh_report_views_task\`, \`evaluate_report_alerts_task\`, \`send_weekly_digest_task\`), and the demo sweep/email tasks.

Part of #261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)