### PR TITLE
fix(content): route demo students to stream-specific curricula

### DIFF
--- a/backend/scripts/seed_demo_milfordwaterford.py
+++ b/backend/scripts/seed_demo_milfordwaterford.py
@@ -121,23 +121,28 @@ STUDENTS: list[dict] = [
     },
     # Grade 11 Commerce students — pair with Warren Buffett / Indra Nooyi
     # teachers so the Commerce content pipeline can be tested end-to-end.
+    # stream='commerce' routes them to default-2026-g11-commerce via
+    # src/content/service.py::resolve_curriculum_id.
     {
         "name": "Anya Iyer",
         "email": "anya.iyer@milfordwaterford.edu",
         "password": "MWStudent-Anya-2026!",
         "grade": 11,
+        "stream": "commerce",
     },
     {
         "name": "Raj Kapoor",
         "email": "raj.kapoor@milfordwaterford.edu",
         "password": "MWStudent-Raj-2026!",
         "grade": 11,
+        "stream": "commerce",
     },
     {
         "name": "Mei Chen",
         "email": "mei.chen@milfordwaterford.edu",
         "password": "MWStudent-Mei-2026!",
         "grade": 11,
+        "stream": "commerce",
     },
 ]
 
@@ -328,6 +333,7 @@ async def _upsert_student(
     email = student["email"]
     name = student["name"]
     grade = student["grade"]
+    stream = student.get("stream")  # None for students without a stream assignment
     password = student["password"]
     password_hash = _hash(password)
 
@@ -353,17 +359,19 @@ async def _upsert_student(
             NEVER_EXPIRES,
             email,
         )
-        # Ensure student is linked to the correct school
+        # Ensure student is linked to the correct school + stream.
         await conn.execute(
             """
             UPDATE students
                SET school_id = $1,
                    grade     = $2,
+                   stream    = $3,
                    enrolled_at = COALESCE(enrolled_at, NOW())
-             WHERE student_id = $3
+             WHERE student_id = $4
             """,
             school_id,
             grade,
+            stream,
             existing_account["student_id"],
         )
         # Upsert enrolment
@@ -406,12 +414,13 @@ async def _upsert_student(
     student_id = await conn.fetchval(
         """
         INSERT INTO students
-            (external_auth_id, auth_provider, name, email, grade, locale,
+            (external_auth_id, auth_provider, name, email, grade, stream, locale,
              account_status, school_id, enrolled_at)
-        VALUES ($1, 'demo', $2, $3, $4, 'en', 'active', $5, NOW())
+        VALUES ($1, 'demo', $2, $3, $4, $5, 'en', 'active', $6, NOW())
         ON CONFLICT (email) DO UPDATE
             SET school_id   = EXCLUDED.school_id,
                 grade       = EXCLUDED.grade,
+                stream      = EXCLUDED.stream,
                 name        = EXCLUDED.name,
                 enrolled_at = COALESCE(students.enrolled_at, EXCLUDED.enrolled_at)
         RETURNING student_id
@@ -420,6 +429,7 @@ async def _upsert_student(
         name,
         email,
         grade,
+        stream,
         school_id,
     )
 

--- a/backend/src/content/service.py
+++ b/backend/src/content/service.py
@@ -267,7 +267,14 @@ async def resolve_curriculum_id(
     Return the curriculum_id for a student.
 
     L2 cache: school:{school_id}:cur:{student_id} (or cur:{student_id} if unaffiliated).
-    On miss: queries school enrollment or falls back to default-{year}-g{grade}.
+
+    Resolution order:
+      1. School-custom curriculum matching the student's grade (via
+         ``curricula.school_id`` + ``c.grade``).
+      2. Stream-specific default when the student has ``students.stream`` set
+         and ``default-{year}-g{grade}-{stream}`` exists as an active platform
+         curriculum (e.g. ``default-2026-g11-commerce``).
+      3. Plain default ``default-{year}-g{grade}``.
     """
     key = cur_key(student_id, school_id)
     cached = await redis.get(key)
@@ -277,12 +284,12 @@ async def resolve_curriculum_id(
         except Exception:
             pass
 
-    # Check school enrollment for a custom curriculum
     curriculum_id: str | None = None
     async with pool.acquire() as conn:
+        # 1. School-custom curriculum match.
         row = await conn.fetchrow(
             """
-            SELECT c.curriculum_id
+            SELECT c.curriculum_id, s.stream
             FROM students s
             JOIN schools sc ON s.school_id = sc.school_id
             JOIN curricula c ON c.school_id = sc.school_id AND c.grade = s.grade
@@ -294,6 +301,31 @@ async def resolve_curriculum_id(
         if row:
             curriculum_id = row["curriculum_id"]
 
+        # 2. Stream-specific default. Only consulted when the school had no
+        #    custom curriculum for this grade. Requires the student to have a
+        #    non-null ``stream`` value and a matching platform curriculum in
+        #    the ``curricula`` table.
+        if not curriculum_id:
+            student_row = await conn.fetchrow(
+                "SELECT stream FROM students WHERE student_id = $1",
+                student_id,
+            )
+            stream = student_row["stream"] if student_row else None
+            if stream:
+                candidate = f"default-{year}-g{grade}-{stream}"
+                hit = await conn.fetchval(
+                    """
+                    SELECT curriculum_id FROM curricula
+                    WHERE curriculum_id = $1
+                      AND owner_type = 'platform'
+                      AND status = 'active'
+                    """,
+                    candidate,
+                )
+                if hit:
+                    curriculum_id = hit
+
+    # 3. Plain default.
     if not curriculum_id:
         curriculum_id = f"default-{year}-g{grade}"
 

--- a/backend/src/demo/router.py
+++ b/backend/src/demo/router.py
@@ -308,6 +308,20 @@ async def demo_login(body: DemoLoginInput, request: Request):
         await update_last_login(conn, account["id"])
         expires_at = account["expires_at"]
 
+        # Pull the student's actual grade/locale/school_id so the JWT reflects
+        # per-student state. Older versions of this router hard-coded
+        # grade=8/locale=en, which broke for MilfordWaterford demo students at
+        # grade 11 and 12 (and for any content endpoint that resolves per-grade
+        # curricula). The resolver also reads ``students.stream`` server-side
+        # for stream-aware routing (Commerce / Science / Humanities / etc.).
+        student_row = await conn.fetchrow(
+            "SELECT grade, locale, school_id FROM students WHERE student_id = $1",
+            account["student_id"],
+        )
+        student_grade = (student_row["grade"] if student_row else None) or 8
+        student_locale = (student_row["locale"] if student_row else None) or "en"
+        student_school_id = student_row["school_id"] if student_row else None
+
     # JWT TTL: lesser of 15 min or remaining demo lifetime
     expires_at_aware = expires_at if expires_at.tzinfo else expires_at.replace(tzinfo=UTC)
     remaining_minutes = int((expires_at_aware - datetime.now(UTC)).total_seconds() / 60)
@@ -322,16 +336,20 @@ async def demo_login(body: DemoLoginInput, request: Request):
             },
         )
 
+    payload: dict = {
+        "student_id": str(account["student_id"]),
+        "grade": student_grade,
+        "locale": student_locale,
+        "role": "demo_student",
+        "account_status": "active",
+        "demo_account_id": str(account["id"]),
+        "demo_expires_at": expires_at_aware.isoformat(),
+    }
+    if student_school_id is not None:
+        payload["school_id"] = str(student_school_id)
+
     token = create_internal_jwt(
-        payload={
-            "student_id": str(account["student_id"]),
-            "grade": 8,
-            "locale": "en",
-            "role": "demo_student",
-            "account_status": "active",
-            "demo_account_id": str(account["id"]),
-            "demo_expires_at": expires_at_aware.isoformat(),
-        },
+        payload=payload,
         secret=settings.JWT_SECRET,
         expire_minutes=token_ttl,
     )


### PR DESCRIPTION
## Summary

Three coordinated fixes for the "Anya (G11 Commerce) lands on default g11 STEM content" bug hit during today's end-to-end demo.

| # | File | What changed |
|---|---|---|
| 1 | \`backend/src/content/service.py\` | \`resolve_curriculum_id\` now has a step-2 lookup: after the school-custom match misses, consult \`students.stream\` and try \`default-{year}-g{grade}-{stream}\` against the \`curricula\` table. Falls back to the plain default when the student has no stream or no matching stream-specific curriculum exists. |
| 2 | \`backend/src/demo/router.py\` | \`demo_login\` was hard-coding \`grade=8\`, \`locale=en\`, and never included \`school_id\` in the JWT. Fine when the demo track was just one G8 account; broken for MilfordWaterford demo students at grades 11 and 12. Now reads grade / locale / school_id from the \`students\` row at login time. |
| 3 | \`backend/scripts/seed_demo_milfordwaterford.py\` | Stamps \`stream='commerce'\` on Anya / Raj / Mei and threads the column through \`_upsert_student\`'s INSERT + existing-row UPDATE paths. |

## Verified for Anya

- JWT payload: \`grade=11\`, \`locale='en'\`, \`school_id=<milfordwaterford>\`
- \`resolve_curriculum_id\` → \`default-2026-g11-commerce\` (was \`default-2026-g11\`)
- \`get_unit_subject('G11-ACC-001', 'default-2026-g11-commerce')\` → \`G11-ACC\`
- \`check_content_published\` → \`true\` after publishing the previously-pending \`content_subject_versions\` rows (data-only, not in this commit)

## Known remaining blocker (separate issue)

Pipeline output shape mismatches \`LessonResponse\` schema:

| Pipeline emits | \`LessonResponse\` expects |
|---|---|
| \`topic\`, \`synopsis\`, \`key_concepts\`, \`learning_objectives\`, \`reading_level\`, \`estimated_duration_minutes\` | \`title\`, \`grade\`, \`lang\`, \`sections\`, \`key_points\` |

After this PR, Anya's content fetch 200s past \`check_content_published\` but then fails with pydantic validation 500. That's pre-existing and in Epic 11/12 territory — will file a separate tracking issue.

Pre-existing Frontend Lint typecheck debt will fail CI. Admin-merge past it as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)