### PR TITLE
fix(content): normalise new pipeline lesson shape → LessonResponse (#295)

### DIFF
--- a/backend/src/content/router.py
+++ b/backend/src/content/router.py
@@ -64,6 +64,78 @@ _FREE_TIER_LESSON_LIMIT = 2
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
+def _normalize_lesson_dict(data: dict, *, unit_id: str) -> dict:
+    """Normalise two lesson-JSON shapes to the single ``LessonResponse`` shape.
+
+    **Legacy shape** (placeholder ``dev-placeholder`` seeds, e.g.
+    ``default-2026-g8``): already carries ``title``, ``grade``, ``lang``,
+    ``sections`` (list of {heading, body}), ``key_points``. Pass through
+    unchanged.
+
+    **New pipeline shape** (``claude-sonnet-4-6`` output from Epic 11 runs,
+    e.g. ``default-2026-g11-commerce``): carries ``topic``, ``synopsis``,
+    ``key_concepts``, ``learning_objectives``, ``reading_level``,
+    ``language``. Map onto the legacy-response fields so the existing
+    frontend renderer keeps working without a parallel schema.
+
+    This is the tactical normaliser for #295 — Option 2. Epic 12's
+    structured content blocks will eventually replace this layer; until
+    then the frontend contract is stable.
+    """
+    # Already legacy-shaped → short-circuit.
+    if "title" in data and "sections" in data:
+        return data
+
+    # Pull out the new-shape fields, tolerating missing ones so malformed
+    # pipeline output degrades into a readable-but-sparse lesson rather
+    # than a 500.
+    topic = data.get("topic") or data.get("title") or unit_id
+    synopsis = data.get("synopsis", "")
+    key_concepts = data.get("key_concepts") or []
+    learning_objectives = data.get("learning_objectives") or []
+    reading_level = data.get("reading_level", "")
+    language = data.get("language") or data.get("lang") or "en"
+
+    # Derive grade from unit_id prefix (e.g. "G11-ACC-001" → 11). The
+    # pipeline output doesn't carry grade; the resolver knows it but we
+    # don't have that context here. Fall back to 0 if unparseable so the
+    # response stays valid rather than 500-ing.
+    grade = 0
+    if unit_id.startswith("G") and "-" in unit_id:
+        head = unit_id.split("-", 1)[0].lstrip("G")
+        if head.isdigit():
+            grade = int(head)
+
+    sections: list[dict] = []
+    if synopsis:
+        sections.append({"heading": "Overview", "body": synopsis})
+    if learning_objectives:
+        bullets = "\n".join(f"- {obj}" for obj in learning_objectives)
+        sections.append({"heading": "Learning objectives", "body": bullets})
+    if key_concepts:
+        bullets = "\n".join(f"- {c}" for c in key_concepts)
+        sections.append({"heading": "Key concepts", "body": bullets})
+    if reading_level:
+        sections.append({"heading": "Reading level", "body": str(reading_level)})
+    if not sections:
+        # Last-resort: show something rather than fail validation.
+        sections.append({"heading": "Overview", "body": topic})
+
+    return {
+        "unit_id": data.get("unit_id", unit_id),
+        "title": topic,
+        "grade": grade,
+        "subject": data.get("subject", ""),
+        "lang": language,
+        "sections": sections,
+        "key_points": key_concepts,
+        "has_audio": bool(data.get("has_audio", False)),
+        "generated_at": data.get("generated_at"),
+        "model": data.get("model"),
+        "content_version": data.get("content_version"),
+    }
+
+
 async def _get_curriculum_and_check_published(
     request: Request,
     unit_id: str,
@@ -180,7 +252,7 @@ async def get_lesson(
         log.warning("increment_lessons_accessed_failed student_id=%s error=%s", student_id, exc)
 
     log.info("lesson_served unit_id=%s student_id=%s", unit_id, student_id)
-    return LessonResponse(**data)
+    return LessonResponse(**_normalize_lesson_dict(data, unit_id=unit_id))
 
 
 # ── GET /content/{unit_id}/lesson/audio ──────────────────────────────────────

--- a/backend/tests/test_content_lesson_normalizer.py
+++ b/backend/tests/test_content_lesson_normalizer.py
@@ -1,0 +1,160 @@
+"""
+tests/test_content_lesson_normalizer.py
+
+Unit tests for src/content/router.py::_normalize_lesson_dict — the
+tactical fix for issue #295 (lesson schema drift).
+
+Covers:
+  - Legacy shape (placeholder / dev-placeholder seeds) passes through unchanged
+  - New pipeline shape (topic/synopsis/key_concepts/learning_objectives)
+    maps to LessonResponse fields (title/sections/key_points)
+  - Grade parsed from unit_id prefix ("G11-ACC-001" → 11)
+  - Missing / partial pipeline fields degrade gracefully (no 500)
+  - Non-G unit_ids fall back to grade=0 without crashing
+  - Result always satisfies LessonResponse validation
+"""
+
+from __future__ import annotations
+
+from src.content.router import _normalize_lesson_dict
+from src.content.schemas import LessonResponse
+
+
+def test_legacy_shape_passes_through_unchanged():
+    """A lesson that already has title + sections must be a no-op."""
+    legacy = {
+        "unit_id": "G8-MATH-001",
+        "title": "Linear Equations",
+        "grade": 8,
+        "subject": "G8-MATH",
+        "lang": "en",
+        "sections": [{"heading": "Overview", "body": "Single-step equations."}],
+        "key_points": ["solve 2x + 3 = 7"],
+        "has_audio": False,
+        "generated_at": "2026-04-14T14:46:52.218701+00:00",
+        "model": "dev-placeholder",
+        "content_version": 1,
+    }
+    result = _normalize_lesson_dict(legacy, unit_id="G8-MATH-001")
+    # Same dict (short-circuit).
+    assert result is legacy
+    # And it's valid under LessonResponse.
+    LessonResponse(**result)
+
+
+def test_new_pipeline_shape_maps_to_lesson_response():
+    pipeline = {
+        "unit_id": "G11-ACC-001",
+        "subject": "G11-ACC",
+        "topic": "Theoretical Framework",
+        "synopsis": "This lesson introduces the conceptual framework…",
+        "key_concepts": [
+            "Conceptual Framework for Financial Reporting",
+            "Objectives of General Purpose Financial Reporting",
+        ],
+        "learning_objectives": [
+            "Explain the purpose and structure of the conceptual framework.",
+            "Identify the primary users of financial reports.",
+        ],
+        "reading_level": "Grade 11–12 (University Preparatory)",
+        "estimated_duration_minutes": 40,
+        "language": "en",
+        "generated_at": "2026-04-15T11:33:28.570725+00:00",
+        "model": "claude-sonnet-4-6",
+        "content_version": 1,
+    }
+    result = _normalize_lesson_dict(pipeline, unit_id="G11-ACC-001")
+
+    # Top-level mapping
+    assert result["unit_id"] == "G11-ACC-001"
+    assert result["title"] == "Theoretical Framework"
+    assert result["grade"] == 11  # parsed from unit_id
+    assert result["subject"] == "G11-ACC"
+    assert result["lang"] == "en"
+    assert result["model"] == "claude-sonnet-4-6"
+
+    # Sections built from synopsis + learning_objectives + key_concepts + reading_level
+    headings = [s["heading"] for s in result["sections"]]
+    assert "Overview" in headings
+    assert "Learning objectives" in headings
+    assert "Key concepts" in headings
+    assert "Reading level" in headings
+
+    # Synopsis body preserved
+    overview = next(s for s in result["sections"] if s["heading"] == "Overview")
+    assert "conceptual framework" in overview["body"]
+
+    # Bullets render from learning_objectives
+    learn = next(s for s in result["sections"] if s["heading"] == "Learning objectives")
+    assert "- Explain the purpose" in learn["body"]
+    assert "- Identify the primary users" in learn["body"]
+
+    # key_points carries through from key_concepts
+    assert result["key_points"] == pipeline["key_concepts"]
+
+    # Valid under LessonResponse.
+    LessonResponse(**result)
+
+
+def test_grade_parsed_from_various_unit_id_prefixes():
+    """G5 through G12 should all parse correctly; non-G should fall back to 0."""
+    for grade in (5, 8, 11, 12):
+        pipeline = {"topic": "x", "synopsis": "y"}
+        result = _normalize_lesson_dict(pipeline, unit_id=f"G{grade}-MATH-001")
+        assert result["grade"] == grade
+
+    # Fallback for odd unit_ids.
+    result = _normalize_lesson_dict({"topic": "x", "synopsis": "y"}, unit_id="custom-unit-1")
+    assert result["grade"] == 0
+    LessonResponse(**result)  # still validates
+
+
+def test_missing_synopsis_and_objectives_yield_overview_fallback():
+    """Sparse pipeline output → single Overview section, no validation error."""
+    pipeline = {
+        "unit_id": "G11-ACC-001",
+        "topic": "Theoretical Framework",
+        "language": "en",
+        "model": "claude-sonnet-4-6",
+    }
+    result = _normalize_lesson_dict(pipeline, unit_id="G11-ACC-001")
+    assert len(result["sections"]) == 1
+    assert result["sections"][0]["heading"] == "Overview"
+    assert result["sections"][0]["body"] == "Theoretical Framework"
+    assert result["key_points"] == []
+    LessonResponse(**result)
+
+
+def test_pipeline_shape_with_language_key_not_lang():
+    """Pipeline uses 'language'; legacy/response uses 'lang'. Mapping required."""
+    result = _normalize_lesson_dict(
+        {"topic": "x", "synopsis": "y", "language": "fr"}, unit_id="G8-MATH-001"
+    )
+    assert result["lang"] == "fr"
+
+
+def test_legacy_priority_when_both_shapes_collide():
+    """A dict with both 'title' and 'topic' → treat as legacy (title wins,
+    short-circuit)."""
+    mixed = {
+        "unit_id": "G8-MATH-001",
+        "title": "Legacy Title",
+        "topic": "New Pipeline Topic",  # ignored because legacy shape detected
+        "grade": 8,
+        "subject": "G8-MATH",
+        "lang": "en",
+        "sections": [{"heading": "Overview", "body": "ok"}],
+        "key_points": [],
+    }
+    result = _normalize_lesson_dict(mixed, unit_id="G8-MATH-001")
+    assert result is mixed  # short-circuit
+    assert result["title"] == "Legacy Title"
+
+
+def test_empty_dict_still_produces_valid_response():
+    """Degrade-gracefully: empty dict → Overview section with unit_id as title."""
+    result = _normalize_lesson_dict({}, unit_id="G11-ACC-001")
+    assert result["title"] == "G11-ACC-001"
+    assert result["grade"] == 11
+    assert len(result["sections"]) == 1
+    LessonResponse(**result)


### PR DESCRIPTION
## Summary

Tactical fix for [#295](https://github.com/wegofwd2020-hub/StudyBuddy_OnDemand/issues/295) — the lesson schema drift that was blocking the end-to-end Anya → G11 Commerce demo. Stacks on top of [#294](https://github.com/wegofwd2020-hub/StudyBuddy_OnDemand/pull/294) so the two fixes flow together to main.

## What changed

\`backend/src/content/router.py\`
- New \`_normalize_lesson_dict(data, *, unit_id)\` helper.
- \`get_lesson\` calls it before constructing \`LessonResponse\`.

### Normaliser behaviour

| Input shape | Detection | Output |
|---|---|---|
| Legacy (placeholder / dev-placeholder) with \`title\` + \`sections\` | short-circuit | pass-through (same dict) |
| New pipeline (\`claude-sonnet-4-6\`) with \`topic\` / \`synopsis\` / \`key_concepts\` / \`learning_objectives\` | \`title\` absent or no \`sections\` | map to \`title\` / \`sections\` / \`key_points\` / \`lang\` / \`grade\` |
| Sparse / malformed | any | graceful degrade — \`title=unit_id\`, single Overview section, no 500 |

- \`grade\` is parsed from the unit_id prefix (\`G11-ACC-001\` → 11). Pipeline output doesn't carry grade; the resolver knows it but that context isn't passed into the renderer.
- \`sections\` are built from: synopsis → Overview; learning_objectives → Learning objectives (bullets); key_concepts → Key concepts (bullets); reading_level → Reading level.

### Why only lesson needed the normaliser

I audited all four content shapes against their response schemas:

| File | Drift? |
|---|---|
| \`lesson_en.json\` | **yes** — covered here |
| \`quiz_set_*_en.json\` | no (10/10 top-level keys + nested question/option shapes match \`QuizResponse\` / \`QuizQuestion\` / \`QuizOption\`) |
| \`tutorial_en.json\` | no (matches \`TutorialResponse\` / \`TutorialSection\`) |
| \`experiment_en.json\` | n/a for Commerce; no drift in sampled units |

## Test plan

- [x] 7 unit tests in \`tests/test_content_lesson_normalizer.py\`:
  - legacy pass-through
  - new shape full mapping
  - grade parse across G5..G12 + non-G fallback
  - sparse / partial input → Overview fallback
  - \`language\` → \`lang\` key rename
  - legacy priority when both shapes collide
  - empty dict still validates under \`LessonResponse\`
- [x] End-to-end verified as Anya (G11 Commerce demo student) on a stack that has both #294 + this PR applied:
  - \`GET /content/G11-ACC-001/lesson\` → **200** with real AI content rendered through LessonResponse; 4 sections, 8 key_points, \`claude-sonnet-4-6\` metadata preserved
  - \`GET /content/G11-ACC-001/quiz\` → **200** with 8 real questions + real options (already worked — no drift)
  - \`GET /content/G11-ACC-001/tutorial\` → **200** with 5 real sections (already worked — no drift)

## Stacking note

Base branch is [\`fix/curriculum-resolver-stream\` (#294)](https://github.com/wegofwd2020-hub/StudyBuddy_OnDemand/pull/294), not \`main\` — retarget after #294 merges.

Pre-existing Frontend Lint typecheck debt will fail CI. Admin-merge past it as usual.

Closes #295 (tactically — Epic 12's structured content blocks will eventually replace this layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)