### PR TITLE
chore(ci): add 4 nightly scanners — doc-drift, glossary-drift, vuln-scan, secrets-scan

### DIFF
--- a/.github/workflows/doc-drift.yml
+++ b/.github/workflows/doc-drift.yml
@@ -1,0 +1,93 @@
+name: Documentation Drift Check
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # 03:00 UTC = 22:00 EST (23:00 EDT in summer)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    env:
+      DOCS_TOKEN_PRESENT: ${{ secrets.DOCS_REPO_TOKEN != '' }}
+    steps:
+      - name: Skip if DOCS_REPO_TOKEN not configured
+        if: env.DOCS_TOKEN_PRESENT == 'false'
+        run: |
+          echo "::warning::DOCS_REPO_TOKEN not set — drift check skipped."
+          echo "Add a PAT with Contents:read on wegofwd2020-hub/studybuddy-docs as repo secret DOCS_REPO_TOKEN."
+          exit 0
+
+      - name: Checkout application repo
+        if: env.DOCS_TOKEN_PRESENT == 'true'
+        uses: actions/checkout@v4
+        with:
+          path: app
+
+      - name: Checkout docs repo
+        if: env.DOCS_TOKEN_PRESENT == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: wegofwd2020-hub/studybuddy-docs
+          token: ${{ secrets.DOCS_REPO_TOKEN }}
+          path: docs
+
+      - name: Set up Python
+        if: env.DOCS_TOKEN_PRESENT == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run drift scanner
+        if: env.DOCS_TOKEN_PRESENT == 'true'
+        id: drift
+        run: |
+          set +e
+          python3 app/scripts/check_doc_drift.py \
+            --app app \
+            --docs docs/docs \
+            --out drift-report.md
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert drift issue
+        if: env.DOCS_TOKEN_PRESENT == 'true' && steps.drift.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: app
+        run: |
+          # Ensure label exists (idempotent).
+          gh label create doc-drift --color FFA500 --description "Documentation references that no longer exist in source" 2>/dev/null || true
+
+          body=$(cat ../drift-report.md)
+          existing=$(gh issue list --label doc-drift --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body "$body"
+            echo "Updated existing drift issue #$existing"
+          else
+            gh issue create \
+              --title "Documentation drift detected ($(date -u +%F))" \
+              --label doc-drift \
+              --body "$body"
+          fi
+
+      - name: Close drift issue if clean
+        if: env.DOCS_TOKEN_PRESENT == 'true' && steps.drift.outputs.exit_code == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: app
+        run: |
+          for n in $(gh issue list --label doc-drift --state open --json number --jq '.[].number'); do
+            gh issue close "$n" --comment "Drift resolved as of $(date -u +%F)."
+          done
+
+      - name: Upload report artifact
+        if: env.DOCS_TOKEN_PRESENT == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: drift-report
+          path: drift-report.md
+          retention-days: 14

--- a/.github/workflows/glossary-drift.yml
+++ b/.github/workflows/glossary-drift.yml
@@ -1,0 +1,94 @@
+name: Glossary Drift Check
+
+# Flags ALLCAPS acronyms that appear in the studybuddy-docs prose but aren't
+# defined in GLOSSARY.md. Same issue-on-drift pattern as doc-drift.
+
+on:
+  schedule:
+    - cron: "45 4 * * *" # 04:45 UTC = 23:45 EST — after api-docs (04:00)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    env:
+      DOCS_TOKEN_PRESENT: ${{ secrets.DOCS_REPO_TOKEN != '' }}
+    steps:
+      - name: Skip if DOCS_REPO_TOKEN not configured
+        if: env.DOCS_TOKEN_PRESENT == 'false'
+        run: |
+          echo "::warning::DOCS_REPO_TOKEN not set — glossary drift check skipped."
+          exit 0
+
+      - name: Checkout application repo
+        if: env.DOCS_TOKEN_PRESENT == 'true'
+        uses: actions/checkout@v4
+        with:
+          path: app
+
+      - name: Checkout docs repo
+        if: env.DOCS_TOKEN_PRESENT == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: wegofwd2020-hub/studybuddy-docs
+          token: ${{ secrets.DOCS_REPO_TOKEN }}
+          path: docs
+
+      - name: Set up Python
+        if: env.DOCS_TOKEN_PRESENT == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run glossary-drift scanner
+        if: env.DOCS_TOKEN_PRESENT == 'true'
+        id: drift
+        run: |
+          set +e
+          python3 app/scripts/check_glossary_drift.py \
+            --glossary docs/GLOSSARY.md \
+            --docs docs \
+            --out glossary-drift-report.md \
+            --project "StudyBuddy OnDemand"
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert glossary-drift issue
+        if: env.DOCS_TOKEN_PRESENT == 'true' && steps.drift.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: app
+        run: |
+          gh label create glossary-drift --color 8A2BE2 --description "Acronyms in docs not defined in GLOSSARY.md" 2>/dev/null || true
+
+          body=$(cat ../glossary-drift-report.md)
+          existing=$(gh issue list --label glossary-drift --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body "$body"
+          else
+            gh issue create \
+              --title "Glossary drift detected ($(date -u +%F))" \
+              --label glossary-drift \
+              --body "$body"
+          fi
+
+      - name: Close glossary-drift issue if clean
+        if: env.DOCS_TOKEN_PRESENT == 'true' && steps.drift.outputs.exit_code == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: app
+        run: |
+          for n in $(gh issue list --label glossary-drift --state open --json number --jq '.[].number'); do
+            gh issue close "$n" --comment "Glossary drift resolved as of $(date -u +%F)."
+          done
+
+      - name: Upload report artifact
+        if: env.DOCS_TOKEN_PRESENT == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: glossary-drift-report
+          path: glossary-drift-report.md
+          retention-days: 14

--- a/.github/workflows/nightly-secrets-scan.yml
+++ b/.github/workflows/nightly-secrets-scan.yml
@@ -1,0 +1,107 @@
+name: Nightly Secrets Scan
+
+# Runs gitleaks against the full git history and upserts a single open
+# GitHub issue on findings. Auto-closes the issue when clean.
+#
+# Allowlist lives in .gitleaksignore (fingerprint-based — each entry is a
+# specific commit:file:rule:line, reviewed manually). Do NOT add path-level
+# allowlists there; they would silence new leaks in the same file.
+
+on:
+  schedule:
+    - cron: "30 6 * * *" # 06:30 UTC — after vuln-scan (05:30)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history — gitleaks scans every commit
+
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.28.0/gitleaks_8.28.0_linux_x64.tar.gz \
+            | tar -xz -C /tmp
+          chmod +x /tmp/gitleaks
+
+      - name: Run gitleaks
+        id: scan
+        run: |
+          set +e
+          /tmp/gitleaks detect \
+            --source . \
+            --redact \
+            --no-banner \
+            --report-format json \
+            --report-path gitleaks-report.json \
+            > gitleaks-output.txt 2>&1
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          cat gitleaks-output.txt
+
+      - name: Build report markdown
+        if: steps.scan.outputs.exit_code != '0'
+        run: |
+          {
+            echo "# 🚨 Secrets Scan — StudyBuddy OnDemand"
+            echo
+            echo "_Nightly \`gitleaks\` scan: $(date -u +%FT%TZ)_"
+            echo
+            echo "> **Treat this as URGENT.** If any finding is a real secret,"
+            echo "> rotate it immediately. Rewriting git history alone is not"
+            echo "> sufficient — assume the value is already compromised."
+            echo
+            echo "## Triage checklist per finding"
+            echo
+            echo "1. Open the flagged commit and line."
+            echo "2. If the value is a real secret: **rotate at the source** (Stripe, Auth0, Anthropic, DB, etc.), then open a separate issue to plan history rewriting."
+            echo "3. If the value is a test fixture or dev stub: add its fingerprint to \`.gitleaksignore\` with a comment explaining the review."
+            echo
+            echo "## Findings"
+            echo
+            echo '```'
+            cat gitleaks-output.txt
+            echo '```'
+            echo
+            echo "Full JSON report uploaded as workflow artifact \`secrets-report\`."
+          } > secrets-report.md
+
+      - name: Upsert secrets-scan issue
+        if: steps.scan.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create secrets-scan --color B60205 --description "Potential secrets detected in git history" 2>/dev/null || true
+
+          body=$(cat secrets-report.md)
+          existing=$(gh issue list --label secrets-scan --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body "$body"
+          else
+            gh issue create \
+              --title "🚨 Potential secret detected in git history ($(date -u +%F))" \
+              --label secrets-scan \
+              --body "$body"
+          fi
+
+      - name: Close secrets-scan issue if clean
+        if: steps.scan.outputs.exit_code == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for n in $(gh issue list --label secrets-scan --state open --json number --jq '.[].number'); do
+            gh issue close "$n" --comment "Secrets scan clean as of $(date -u +%F)."
+          done
+
+      - name: Upload JSON report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: secrets-report
+          path: gitleaks-report.json
+          retention-days: 30

--- a/.github/workflows/nightly-vuln-scan.yml
+++ b/.github/workflows/nightly-vuln-scan.yml
@@ -1,0 +1,107 @@
+name: Nightly Vulnerability Scan
+
+# Runs pip-audit against backend/requirements.txt and upserts a single open
+# GitHub issue on findings. Auto-closes the issue when clean.
+#
+# Strategy: install the pinned set with --no-deps (skipping dependency
+# resolution entirely), then run pip-audit against the installed venv.
+# This sidesteps known resolution conflicts (e.g. celery[redis]==5.6.3 vs
+# redis[asyncio]==7.4.0) while catching any CVE in the pinned-direct set.
+# Transitive deps are NOT audited by this path — revisit once the
+# requirements.txt conflict is resolved (see issue on that work).
+
+on:
+  schedule:
+    - cron: "30 5 * * *" # 05:30 UTC — after glossary-drift (04:45)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Create audit venv + install pinned set (no dep resolution)
+        run: |
+          python3 -m venv /tmp/audit-venv
+          /tmp/audit-venv/bin/pip install --upgrade pip
+          /tmp/audit-venv/bin/pip install pip-audit
+          # --no-deps skips dependency resolution; we audit only the direct pins
+          /tmp/audit-venv/bin/pip install --no-deps -r backend/requirements.txt
+
+      - name: Run pip-audit against the venv
+        id: audit
+        run: |
+          set +e
+          /tmp/audit-venv/bin/pip-audit \
+            --format markdown \
+            > audit-raw.md 2>&1
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          cat audit-raw.md
+
+      - name: Build report markdown
+        run: |
+          {
+            echo "# Vulnerability scan — StudyBuddy OnDemand"
+            echo
+            echo "_Nightly \`pip-audit\` scan: $(date -u +%FT%TZ)_"
+            echo
+            echo "Source: \`backend/requirements.txt\` audited against the PyPI advisory DB."
+            echo
+            if [ "${{ steps.audit.outputs.exit_code }}" = "0" ]; then
+              echo "✅ **No vulnerabilities found.**"
+            else
+              echo "## Findings"
+              echo
+              cat audit-raw.md
+              echo
+              echo "---"
+              echo
+              echo "**Next steps:** review each CVE, check whether the affected"
+              echo "package is reachable in prod, and either upgrade or add a"
+              echo "justified \`--ignore-vuln\` to the workflow."
+            fi
+          } > vuln-report.md
+
+      - name: Upsert vuln-scan issue
+        if: steps.audit.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create vuln-scan --color FF0000 --description "CVEs detected in dependencies" 2>/dev/null || true
+
+          body=$(cat vuln-report.md)
+          existing=$(gh issue list --label vuln-scan --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body "$body"
+          else
+            gh issue create \
+              --title "Vulnerabilities detected in dependencies ($(date -u +%F))" \
+              --label vuln-scan \
+              --body "$body"
+          fi
+
+      - name: Close vuln-scan issue if clean
+        if: steps.audit.outputs.exit_code == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for n in $(gh issue list --label vuln-scan --state open --json number --jq '.[].number'); do
+            gh issue close "$n" --comment "Vuln scan clean as of $(date -u +%F)."
+          done
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vuln-report
+          path: vuln-report.md
+          retention-days: 30

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,19 @@
+# Gitleaks fingerprint allowlist.
+# Format: <commit-sha>:<path>:<rule-id>:<line>
+#
+# Add an entry here only after manually verifying the finding is a known
+# test fixture, dev stub, or other non-sensitive value. Every line should
+# have a comment explaining what was reviewed and by whom.
+
+# Reviewed 2026-04-20 — all 4 findings are obvious test/dev placeholders
+# matching gitleaks' `generic-api-key` heuristic. No real secrets leaked.
+
+# test-jwt-secret / test-admin-secret — unit-test fixture constants
+f8ed6d068ea4b6c3f58a9a4fbf948d15feffe9f8:backend/tests/test_connection_pool_arithmetic.py:generic-api-key:32
+f9773d543d55613d819186f4a517011b463e7aaf:backend/tests/test_connection_pool_arithmetic.py:generic-api-key:32
+
+# stub-jwt-secret / stub-admin-secret — OpenAPI export dev stubs
+7b7f8a6dd457964f8f306196946ff401b568e758:backend/scripts/export_openapi.py:generic-api-key:35
+
+# `secret123` + fake JWT — Playwright e2e login-page fixtures
+d621175321803f8d5de254e72c83d8b39cd8d538:web/tests/e2e/data/admin-login-page.ts:generic-api-key:18

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Scan studybuddy-docs for API-route and env-var references that no longer
+exist in StudyBuddy_OnDemand's backend source.
+
+Scope is deliberately narrow: routes (drift → 404s) + env vars (drift → failed
+boots). Python fence content and Pydantic field references are out of scope
+until the docs repo carries more of them.
+
+Exit 0 = clean. Exit 1 = drift detected. Report markdown goes to --out.
+
+Ignore marker: a line containing `drift:ignore` immediately before a reference
+suppresses that single reference (per CLAUDE.md §16, generalised beyond fences).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# --- Source-side extraction ----------------------------------------------------
+
+ROUTE_DECORATOR_RE = re.compile(
+    r"""@(?:router|app)\.(get|post|put|patch|delete)\s*\(\s*["']([^"']+)["']""",
+    re.IGNORECASE,
+)
+# Pydantic-settings field: CAPS_NAME: type = default  (inside the Settings class)
+SETTINGS_FIELD_RE = re.compile(r"^\s+([A-Z][A-Z0-9_]+)\s*:\s*[A-Za-z]", re.MULTILINE)
+
+
+def extract_source_routes(app_root: Path) -> set[str]:
+    """Return the set of decorator path strings found in FastAPI routers."""
+    paths: set[str] = set()
+    for f in app_root.rglob("*.py"):
+        if "__pycache__" in f.parts or "alembic" in f.parts:
+            continue
+        try:
+            text = f.read_text()
+        except UnicodeDecodeError:
+            continue
+        for _method, path in ROUTE_DECORATOR_RE.findall(text):
+            paths.add(path)
+    return paths
+
+
+def extract_env_vars(config_path: Path) -> set[str]:
+    """Parse backend/config.py Settings class for CAPS field declarations."""
+    if not config_path.exists():
+        return set()
+    text = config_path.read_text()
+    return set(SETTINGS_FIELD_RE.findall(text))
+
+
+# --- Docs-side extraction ------------------------------------------------------
+
+# A docs route reference: `GET /api/v1/whatever/{id}` (inside prose or backticks)
+DOCS_ROUTE_RE = re.compile(
+    r"`?\b(GET|POST|PUT|PATCH|DELETE)\s+(/api/v\d+/[A-Za-z0-9_/{}\-]+)`?"
+)
+# A docs env-var reference: backtick-wrapped ALLCAPS identifier, length >= 5,
+# containing at least one underscore (filters out things like `JSON`, `TODO`).
+DOCS_ENVVAR_RE = re.compile(r"`([A-Z][A-Z0-9]*_[A-Z0-9_]+)`")
+IGNORE_TOKEN = "drift:ignore"
+
+
+def extract_docs_refs(docs_root: Path) -> tuple[list[dict], list[dict]]:
+    """Return (route_refs, envvar_refs). Each ref carries file, line, value."""
+    route_refs: list[dict] = []
+    envvar_refs: list[dict] = []
+    for f in docs_root.rglob("*.md"):
+        try:
+            lines = f.read_text().splitlines()
+        except UnicodeDecodeError:
+            continue
+        for i, line in enumerate(lines):
+            prev = lines[i - 1] if i > 0 else ""
+            ignored = IGNORE_TOKEN in prev
+            for m in DOCS_ROUTE_RE.finditer(line):
+                if ignored:
+                    continue
+                route_refs.append(
+                    {
+                        "file": f,
+                        "line": i + 1,
+                        "method": m.group(1).upper(),
+                        "path": m.group(2),
+                        "raw": line.strip()[:120],
+                    }
+                )
+            for m in DOCS_ENVVAR_RE.finditer(line):
+                if ignored:
+                    continue
+                envvar_refs.append(
+                    {
+                        "file": f,
+                        "line": i + 1,
+                        "name": m.group(1),
+                        "raw": line.strip()[:120],
+                    }
+                )
+    return route_refs, envvar_refs
+
+
+# --- Matching ------------------------------------------------------------------
+
+
+def normalize_path(p: str) -> str:
+    p = p.rstrip("/").lower()
+    p = re.sub(r"\{[^}]+\}", "{}", p)
+    return p
+
+
+def route_matches(doc_path: str, source_paths: set[str]) -> bool:
+    """Drift-free if any source decorator path is a suffix of doc path."""
+    doc_n = normalize_path(doc_path)
+    for sp in source_paths:
+        sp_n = normalize_path(sp)
+        if doc_n == sp_n or doc_n.endswith(sp_n):
+            return True
+    return False
+
+
+# Known env-var-looking backtick tokens that aren't app env vars. Extend as
+# false positives emerge.
+ENV_ALLOWLIST = {
+    "GITHUB_TOKEN",
+    "DOCS_REPO_TOKEN",
+    "GH_TOKEN",
+    "PYTHONPATH",
+    "PATH",
+    "HOME",
+    "USER",
+}
+
+
+# --- Report --------------------------------------------------------------------
+
+
+def render_report(
+    missing_routes: list[dict],
+    missing_envvars: list[dict],
+    source_route_count: int,
+    source_env_count: int,
+    docs_root: Path,
+) -> str:
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    lines = [
+        "# Documentation Drift — StudyBuddy OnDemand",
+        "",
+        f"_Scan run: {now}_",
+        "",
+        f"Scanned {source_route_count} source routes + {source_env_count} "
+        "env vars against `studybuddy-docs/docs/**/*.md`.",
+        "",
+    ]
+    if not missing_routes and not missing_envvars:
+        lines += ["✅ **No drift detected.**", ""]
+        return "\n".join(lines)
+
+    if missing_routes:
+        by_path: dict[str, list[dict]] = defaultdict(list)
+        for r in missing_routes:
+            by_path[r["path"]].append(r)
+        lines += [
+            f"## Routes referenced in docs but not found in source ({len(by_path)})",
+            "",
+            "| Doc route | References | First location |",
+            "|---|---|---|",
+        ]
+        for path, refs in sorted(by_path.items()):
+            first = refs[0]
+            rel = first["file"].relative_to(docs_root)
+            lines.append(
+                f"| `{first['method']} {path}` | {len(refs)} | `{rel}:{first['line']}` |"
+            )
+        lines.append("")
+
+    if missing_envvars:
+        by_name: dict[str, list[dict]] = defaultdict(list)
+        for r in missing_envvars:
+            by_name[r["name"]].append(r)
+        lines += [
+            f"## Env vars referenced in docs but not found in backend/config.py "
+            f"({len(by_name)})",
+            "",
+            "| Env var | References | First location |",
+            "|---|---|---|",
+        ]
+        for name, refs in sorted(by_name.items()):
+            first = refs[0]
+            rel = first["file"].relative_to(docs_root)
+            lines.append(
+                f"| `{name}` | {len(refs)} | `{rel}:{first['line']}` |"
+            )
+        lines.append("")
+
+    lines += [
+        "---",
+        "",
+        "**To silence a false positive:** add `<!-- drift:ignore -->` on the line "
+        "immediately before the reference.",
+        "",
+        "**To fix real drift:** update either the doc (if the symbol was renamed "
+        "or removed) or the source (if the doc is describing intended state).",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+# --- Main ----------------------------------------------------------------------
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--app", required=True, help="Path to StudyBuddy_OnDemand root")
+    ap.add_argument("--docs", required=True, help="Path to studybuddy-docs/docs root")
+    ap.add_argument("--out", required=True, help="Write markdown report here")
+    args = ap.parse_args()
+
+    app = Path(args.app).resolve()
+    docs = Path(args.docs).resolve()
+    out = Path(args.out).resolve()
+
+    source_routes = extract_source_routes(app / "backend" / "src")
+    source_envs = extract_env_vars(app / "backend" / "config.py") | ENV_ALLOWLIST
+
+    route_refs, envvar_refs = extract_docs_refs(docs)
+
+    missing_routes = [r for r in route_refs if not route_matches(r["path"], source_routes)]
+    missing_envvars = [r for r in envvar_refs if r["name"] not in source_envs]
+
+    report = render_report(
+        missing_routes, missing_envvars, len(source_routes), len(source_envs), docs
+    )
+    out.write_text(report)
+
+    if missing_routes or missing_envvars:
+        print(
+            f"Drift detected: {len(missing_routes)} route refs, "
+            f"{len(missing_envvars)} env-var refs. Report: {out}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Clean. Report: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_glossary_drift.py
+++ b/scripts/check_glossary_drift.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Scan docs for ALLCAPS acronyms that aren't defined in the glossary.
+
+Reads `GLOSSARY.md` (markdown tables with `**Term**` in the first column),
+then walks all `*.md` files under --docs and extracts capitalized
+acronym-shaped tokens. Tokens present in docs but absent from the glossary
+are reported as drift candidates.
+
+Exit 0 = clean, 1 = drift detected. Report markdown goes to --out.
+
+Ignore conventions:
+  - Tokens in the `ALLOWLIST` below are never reported (HTTP verbs, file
+    formats, currency codes, etc.) even when not in the glossary.
+  - A line containing `glossary:ignore` immediately before a reference
+    suppresses that single reference.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Match bolded first-column entries in any markdown table row. The glossary
+# uses `**TERM**` or `**Term**` — pick them all up.
+TERM_RE = re.compile(r"^\|\s*\*\*([^|*]+?)\*\*\s*\|", re.MULTILINE)
+
+# Candidate acronyms: 3-8 chars, uppercase letter start. Negative lookbehind
+# rejects tokens inside a structured ID like `FR-RPT-001` / `NFR-OBS-012`
+# (where `RPT` and `OBS` are category codes, not project acronyms). Negative
+# lookahead rejects tokens immediately followed by `-<digit>` (same reason).
+ACRONYM_RE = re.compile(r"(?<![A-Z]-)\b[A-Z][A-Z0-9]{2,7}\b(?!-\d)")
+
+IGNORE_TOKEN = "glossary:ignore"
+
+# Words that look like acronyms but are not project-specific — HTTP verbs,
+# file formats, currency codes, etc. Extend as false positives emerge.
+ALLOWLIST = {
+    # HTTP verbs + status-related
+    "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS",
+    "HTTP", "HTTPS", "REST", "GRPC",
+    # File formats + data
+    "JSON", "YAML", "TOML", "XML", "HTML", "CSS", "CSV", "PDF", "SQL",
+    "MD", "PNG", "JPG", "JPEG", "SVG", "GIF",
+    # Currency ISO codes (common ones — extend if you add more)
+    "USD", "CAD", "INR", "GBP", "EUR", "AUD",
+    # Country ISO codes (common ones)
+    "US", "CA", "IN", "UK", "GB", "EU", "AU",
+    # Time zones / dates
+    "UTC", "EST", "EDT", "GMT", "PST", "PDT", "IST",
+    # Common generic infra / ops
+    "AWS", "GCP", "AZURE", "DNS", "TCP", "UDP", "TLS", "SSL",
+    "IPV4", "IPV6", "IP", "ID", "URL", "URI",
+    "CPU", "RAM", "GB", "MB", "KB", "TB",
+    "OS", "VM", "K8S", "POD", "JVM", "NPM",
+    # Misc generic
+    "FAQ", "TBD", "TODO", "FIXME", "ETA", "ROI", "SLA", "SLO", "SLI",
+    "ACID", "CRUD", "MVP", "NPS",
+    # Log levels — generic across every project
+    "INFO", "WARN", "WARNING", "ERROR", "DEBUG", "TRACE", "FATAL", "NOTICE",
+    # SQL keywords + DML ops that commonly appear in prose discussion of schemas
+    "NULL", "DEFAULT", "TRUE", "FALSE", "CHECK", "UNIQUE", "PRIMARY",
+    "FOREIGN", "CASCADE", "ASC", "DESC", "NOW", "JSONB",
+    "INSERT", "UPDATE", "SELECT", "MERGE", "TABLE", "INDEX",
+    "CREATE", "ALTER", "DROP", "VIEW", "FROM", "WHERE",
+    # Common English words that match the regex shape — source of noise
+    "THE", "AND", "FOR", "NOT", "YES", "NO", "ONE", "TWO", "NEW", "OLD",
+    "ALL", "ANY", "GET", "SET", "RUN", "USE", "HIGH", "LOW", "NEAR",
+    "MID", "TOTAL", "NONE", "TRUE", "FALSE",
+    # Standards-body prefixes — "ISO 3166", "ISO 8601" etc. appear verbatim
+    "ISO", "ISO8601", "RFC", "ANSI",
+}
+
+
+def extract_glossary_terms(glossary_path: Path) -> set[str]:
+    text = glossary_path.read_text()
+    terms: set[str] = set()
+    for m in TERM_RE.findall(text):
+        # Normalise — glossary may list `DOP / DoP` or `bcrypt`. We want an
+        # all-uppercase comparable key. Split on `/` and take any pure-caps
+        # sub-word.
+        for part in re.split(r"[/,\s]+", m.strip()):
+            part = part.strip()
+            if part and part.upper() == part and len(part) >= 2:
+                terms.add(part)
+    return terms
+
+
+INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+FENCE_RE = re.compile(r"^\s*```")
+
+
+def scan_docs_for_acronyms(docs_root: Path) -> list[dict]:
+    """Return {file, line, token} for each acronym occurrence in *prose*.
+
+    Skips content inside fenced code blocks (```...```), strips inline `code`
+    spans before matching, and honors `glossary:ignore` markers.
+    """
+    hits: list[dict] = []
+    for f in sorted(docs_root.rglob("*.md")):
+        try:
+            lines = f.read_text().splitlines()
+        except UnicodeDecodeError:
+            continue
+        in_fence = False
+        for i, line in enumerate(lines):
+            if FENCE_RE.match(line):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+            prev = lines[i - 1] if i > 0 else ""
+            if IGNORE_TOKEN in prev or IGNORE_TOKEN in line:
+                continue
+            stripped = INLINE_CODE_RE.sub(" ", line)
+            for m in ACRONYM_RE.finditer(stripped):
+                hits.append({"file": f, "line": i + 1, "token": m.group(0)})
+    return hits
+
+
+def render_report(
+    undefined: dict[str, list[dict]],
+    glossary_size: int,
+    scan_size: int,
+    docs_root: Path,
+    project: str,
+) -> str:
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    lines = [
+        f"# Glossary Drift — {project}",
+        "",
+        f"_Scan run: {now}_",
+        "",
+        f"Scanned {scan_size} acronym occurrences against {glossary_size} "
+        "terms defined in the glossary.",
+        "",
+    ]
+    if not undefined:
+        lines += ["✅ **No drift detected.**", ""]
+        return "\n".join(lines)
+
+    lines += [
+        f"## Acronyms mentioned in docs but not defined in the glossary "
+        f"({len(undefined)})",
+        "",
+        "| Token | Mentions | First location |",
+        "|---|---|---|",
+    ]
+    for token, refs in sorted(undefined.items(), key=lambda kv: (-len(kv[1]), kv[0])):
+        first = refs[0]
+        rel = first["file"].relative_to(docs_root)
+        lines.append(f"| `{token}` | {len(refs)} | `{rel}:{first['line']}` |")
+    lines.append("")
+    lines += [
+        "---",
+        "",
+        "**To silence a false positive** that isn't project-specific: add it "
+        "to `ALLOWLIST` in `scripts/check_glossary_drift.py` (CI env / shell / "
+        "infrastructure words live there already).",
+        "",
+        "**To silence one-off uses**: add `<!-- glossary:ignore -->` on the "
+        "line immediately before the reference.",
+        "",
+        "**To fix real drift**: add the term + definition to the glossary, "
+        "or rename/remove the undocumented acronym in the doc.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--glossary", required=True, help="Path to glossary markdown")
+    ap.add_argument("--docs", required=True, help="Path to docs root")
+    ap.add_argument("--out", required=True, help="Write report markdown here")
+    ap.add_argument("--project", default="Project", help="Project name for report header")
+    args = ap.parse_args()
+
+    glossary = Path(args.glossary).resolve()
+    docs = Path(args.docs).resolve()
+    out = Path(args.out).resolve()
+
+    defined = extract_glossary_terms(glossary) | ALLOWLIST
+    hits = scan_docs_for_acronyms(docs)
+
+    undefined: dict[str, list[dict]] = defaultdict(list)
+    for h in hits:
+        if h["token"] not in defined:
+            undefined[h["token"]].append(h)
+
+    report = render_report(undefined, len(defined), len(hits), docs, args.project)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(report)
+
+    if undefined:
+        print(
+            f"Drift detected: {len(undefined)} undefined acronyms. Report: {out}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Clean. Report: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Recovers 4 nightly automation workflows stranded since 2026-04-20 on stale topic branches (`origin/glossary-drift-nightly`, `origin/nightly-vuln-scan`, `origin/nightly-secrets-scan`) and one dangling commit (`9454557`, doc-drift)
- Those branches diverged ~1900 files behind main and cannot be merged directly; this PR cherry-picks just the new files (4 workflows + 2 scripts + `.gitleaksignore`) onto a fresh branch off main

## What each scanner does
| Scanner | When | What it does | Issue label |
|---|---|---|---|
| `doc-drift` | 03:00 UTC | Scans `studybuddy-docs` for FastAPI route + env-var refs that no longer exist in `backend/` | `doc-drift` |
| `glossary-drift` | 04:45 UTC | Flags ALLCAPS acronyms in `studybuddy-docs` prose not defined in `GLOSSARY.md` | `glossary-drift` |
| `nightly-vuln-scan` | 05:30 UTC | `pip-audit` against `backend/requirements.txt` (with `--no-deps` to dodge known resolution conflicts) | `vuln-scan` |
| `nightly-secrets-scan` | 06:30 UTC | `gitleaks` against full git history; allowlist in `.gitleaksignore` (4 reviewed test/dev fixtures) | `secrets-scan` |

Each scanner upserts a single open issue with its label and auto-closes when clean.

## Required secrets
- `DOCS_REPO_TOKEN` (fine-grained PAT, Contents:read on `wegofwd2020-hub/studybuddy-docs`) — needed by doc-drift and glossary-drift only. Both workflows skip gracefully if it isn't set.

## Sanity checks done
- Both Python scripts compile (`py_compile`)
- All referenced paths exist on main (`backend/requirements.txt`, `backend/src`, `backend/tests`, `backend/config.py`)
- All 4 commit SHAs in `.gitleaksignore` still exist in git history

## Caveat — read before merging
The thittam-side equivalents have been running nightly for 23 days with very low signal:
- doc-drift: 0 issues filed
- glossary-drift: 0 issues filed
- vuln-scan: 1 issue (#101), unactioned for 5 days
- secrets-scan: 0 findings

Per the "every automation = a notification stream you must read" principle: re-evaluate these in 2 weeks. If they aren't producing actionable signal, delete them.

## After merge
- Delete the stale branches: `origin/glossary-drift-nightly`, `origin/nightly-vuln-scan`, `origin/nightly-secrets-scan`

## Test plan
- [ ] Add `DOCS_REPO_TOKEN` repo secret (or merge first and confirm graceful skip)
- [ ] Manually dispatch each workflow once after merge; confirm artifacts upload
- [ ] Watch the first nightly cycle for issue upsert behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)