### PR TITLE
fix(ci): unbreak main — ruff format, ESLint refs, prettier, Playwright locators

### DIFF
--- a/backend/src/auth/router.py
+++ b/backend/src/auth/router.py
@@ -653,12 +653,8 @@ async def universal_login(
 
     if demo_teacher_row is not None:
         expires_at = demo_teacher_row["expires_at"]
-        expires_at_aware = (
-            expires_at if expires_at.tzinfo else expires_at.replace(tzinfo=UTC)
-        )
-        remaining_minutes = int(
-            (expires_at_aware - datetime.now(UTC)).total_seconds() / 60
-        )
+        expires_at_aware = expires_at if expires_at.tzinfo else expires_at.replace(tzinfo=UTC)
+        remaining_minutes = int((expires_at_aware - datetime.now(UTC)).total_seconds() / 60)
         token_ttl = min(settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES, remaining_minutes)
         if token_ttl <= 0:
             raise HTTPException(
@@ -713,12 +709,8 @@ async def universal_login(
 
     # demo_student_row branch
     expires_at = demo_student_row["expires_at"]
-    expires_at_aware = (
-        expires_at if expires_at.tzinfo else expires_at.replace(tzinfo=UTC)
-    )
-    remaining_minutes = int(
-        (expires_at_aware - datetime.now(UTC)).total_seconds() / 60
-    )
+    expires_at_aware = expires_at if expires_at.tzinfo else expires_at.replace(tzinfo=UTC)
+    remaining_minutes = int((expires_at_aware - datetime.now(UTC)).total_seconds() / 60)
     token_ttl = min(settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES, remaining_minutes)
     if token_ttl <= 0:
         raise HTTPException(

--- a/backend/src/demo/test_run_router.py
+++ b/backend/src/demo/test_run_router.py
@@ -349,9 +349,7 @@ async def verify_test_run(token: str, request: Request):
         inbox_email = student_email.replace("+student", "", 1)
         if meta_raw:
             try:
-                meta = json.loads(
-                    meta_raw if isinstance(meta_raw, str) else meta_raw.decode()
-                )
+                meta = json.loads(meta_raw if isinstance(meta_raw, str) else meta_raw.decode())
                 visitor_name = meta.get("name") or None
                 inbox_email = meta.get("original_email") or inbox_email
             except (ValueError, TypeError):

--- a/web/app/(admin)/admin/help/page.tsx
+++ b/web/app/(admin)/admin/help/page.tsx
@@ -32,7 +32,7 @@ const GETTING_STARTED = [
   {
     step: "5",
     title: "Demo Accounts & Test Runs",
-    body: "Student-only and teacher-only demo requests still appear on /admin/demo-accounts and /admin/demo-teacher-accounts. The new visitor-facing \"Try a test run\" form (one click → both teacher AND student credentials in one email) is managed on /admin/test-runs. Click Reset on a test-run row to purge the visitor's accounts AND their per-visitor classroom so they can re-submit a fresh request.",
+    body: 'Student-only and teacher-only demo requests still appear on /admin/demo-accounts and /admin/demo-teacher-accounts. The new visitor-facing "Try a test run" form (one click → both teacher AND student credentials in one email) is managed on /admin/test-runs. Click Reset on a test-run row to purge the visitor\'s accounts AND their per-visitor classroom so they can re-submit a fresh request.',
   },
 ];
 
@@ -133,7 +133,10 @@ export default function AdminHelpPage() {
                 ["View subscription MRR", "/admin/dashboard or /admin/analytics"],
                 ["Manage demo student accounts", "/admin/demo-accounts"],
                 ["Manage demo teacher accounts", "/admin/demo-teacher-accounts"],
-                ["Manage visitor test runs (one form → both teacher + student demo)", "/admin/test-runs"],
+                [
+                  "Manage visitor test runs (one form → both teacher + student demo)",
+                  "/admin/test-runs",
+                ],
                 ["View audit log", "/admin/audit"],
                 ["Check system health", "/admin/health"],
                 ["View student feedback", "/admin/feedback"],

--- a/web/app/(admin)/admin/test-runs/page.tsx
+++ b/web/app/(admin)/admin/test-runs/page.tsx
@@ -3,11 +3,7 @@
 import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import {
-  getTestRuns,
-  deleteTestRunByEmail,
-  type TestRunItem,
-} from "@/lib/api/admin";
+import { getTestRuns, deleteTestRunByEmail, type TestRunItem } from "@/lib/api/admin";
 import { useAdmin, hasPermission } from "@/lib/hooks/useAdmin";
 import {
   ShieldOff,
@@ -124,9 +120,8 @@ function ResetModal({
         </h2>
         <p className="mb-1 text-sm break-all text-gray-700">{item.email}</p>
         <p className="mb-4 text-sm text-gray-500">
-          Removes both the teacher and student demo accounts and their request
-          history so this email can submit a fresh test run. This cannot be
-          undone.
+          Removes both the teacher and student demo accounts and their request history so
+          this email can submit a fresh test run. This cannot be undone.
         </p>
         <div className="flex gap-2">
           <button
@@ -192,9 +187,9 @@ export default function AdminTestRunsPage() {
     <div className="mx-auto max-w-6xl p-8">
       <h1 className="mb-1 text-2xl font-bold text-gray-900">Test Runs</h1>
       <p className="mb-6 text-sm text-gray-500">
-        Visitors who submitted the &ldquo;Try a test run&rdquo; form. Each row
-        provisions both a teacher and a student demo account. Reset a row to
-        free the email for re-submission.
+        Visitors who submitted the &ldquo;Try a test run&rdquo; form. Each row provisions
+        both a teacher and a student demo account. Reset a row to free the email for
+        re-submission.
       </p>
 
       {/* Email search */}
@@ -326,14 +321,12 @@ export default function AdminTestRunsPage() {
         <div className="py-20 text-center text-gray-400">
           <FlaskConical className="mx-auto mb-3 h-10 w-10 opacity-40" />
           <p className="text-sm font-medium text-gray-600">
-            {emailSearch
-              ? "No test runs match your search."
-              : "No test runs yet."}
+            {emailSearch ? "No test runs match your search." : "No test runs yet."}
           </p>
           {!emailSearch && (
             <p className="mt-1 text-xs text-gray-400">
-              Visitors appear here after they submit the &ldquo;Try a test run&rdquo;
-              form on the demo home page.
+              Visitors appear here after they submit the &ldquo;Try a test run&rdquo; form
+              on the demo home page.
             </p>
           )}
         </div>

--- a/web/app/(public)/demo/test-run/verify/[token]/page.tsx
+++ b/web/app/(public)/demo/test-run/verify/[token]/page.tsx
@@ -87,9 +87,7 @@ function resolveState(err: unknown): Exclude<VerifyState, "loading" | "success">
 
 export default function TestRunVerifyPage() {
   const { token } = useParams<{ token: string }>();
-  const [state, setState] = useState<VerifyState>(() =>
-    token ? "loading" : "invalid",
-  );
+  const [state, setState] = useState<VerifyState>(() => (token ? "loading" : "invalid"));
 
   useEffect(() => {
     if (!token) return;

--- a/web/app/(public)/signin/page.tsx
+++ b/web/app/(public)/signin/page.tsx
@@ -27,10 +27,7 @@ import {
  * school portal server layout, and the demo session cookie writers in
  * (public)/demo/login + demo/teacher/login.
  */
-function persistSession(
-  res: UniversalLoginResponse,
-  email: string,
-): void {
+function persistSession(res: UniversalLoginResponse, email: string): void {
   const display = res.name || email;
   const sessionPayload = btoa(JSON.stringify({ name: display, email }));
   const secure = location.protocol === "https:" ? "; Secure" : "";
@@ -64,7 +61,11 @@ function persistSession(
   document.cookie = `sb_teacher_session=${sessionPayload}; path=/; SameSite=Lax; Max-Age=${60 * 60 * 48}${secure}`;
 }
 
-function destinationFor(track: AuthTrack, role: string, firstLogin: boolean | null): string {
+function destinationFor(
+  track: AuthTrack,
+  role: string,
+  firstLogin: boolean | null,
+): string {
   if (track === "local" && firstLogin) {
     return "/school/change-password?required=1";
   }
@@ -95,7 +96,9 @@ export default function SignInPage() {
       if (status === 401) {
         setError("Incorrect email or password.");
       } else if (status === 403) {
-        setError("This account is suspended or has expired. Please contact your administrator.");
+        setError(
+          "This account is suspended or has expired. Please contact your administrator.",
+        );
       } else if (status === 429) {
         setError("Too many sign-in attempts. Please wait a moment and try again.");
       } else {
@@ -159,13 +162,19 @@ export default function SignInPage() {
                   className="absolute top-1/2 right-3 -translate-y-1/2 text-gray-400 hover:text-gray-600"
                   aria-label={showPassword ? "Hide password" : "Show password"}
                 >
-                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  {showPassword ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
                 </button>
               </div>
             </div>
 
             {error && (
-              <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>
+              <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+                {error}
+              </p>
             )}
 
             <Button

--- a/web/app/(school)/school/class/[class_id]/page.tsx
+++ b/web/app/(school)/school/class/[class_id]/page.tsx
@@ -78,9 +78,7 @@ export default function ClassOverviewPage() {
     enabled: !!schoolId,
     staleTime: 60_000,
   });
-  const myClassrooms = (classrooms ?? []).filter(
-    (c) => c.teacher_id === teacherId,
-  );
+  const myClassrooms = (classrooms ?? []).filter((c) => c.teacher_id === teacherId);
 
   // Pull the per-classroom roster for each of my classrooms in parallel.
   // listClassrooms only returns counts; getClassroom returns the full
@@ -104,8 +102,7 @@ export default function ClassOverviewPage() {
 
   // Auto-fallback to "all" if the teacher leads no classrooms with students
   // (e.g. a school_admin browsing the school overview).
-  const effectiveScope: ScopeFilter =
-    scope === "mine" && myCount === 0 ? "all" : scope;
+  const effectiveScope: ScopeFilter = scope === "mine" && myCount === 0 ? "all" : scope;
 
   function toggleSort(key: SortKey) {
     if (sortKey === key) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
@@ -136,9 +133,11 @@ export default function ClassOverviewPage() {
   // current scope — keeps the rail tight when the teacher only has Grade 11
   // students, for example.
   const presentGrades = Array.from(
-    new Set((data?.students ?? [])
-      .filter((s) => effectiveScope === "all" || myStudentIds.has(s.student_id))
-      .map((s) => s.grade)),
+    new Set(
+      (data?.students ?? [])
+        .filter((s) => effectiveScope === "all" || myStudentIds.has(s.student_id))
+        .map((s) => s.grade),
+    ),
   ).sort((a, b) => a - b);
 
   return (

--- a/web/app/(school)/school/classrooms/page.tsx
+++ b/web/app/(school)/school/classrooms/page.tsx
@@ -246,15 +246,13 @@ export default function ClassroomsPage() {
   // How many classrooms the logged-in teacher leads. If zero (e.g. a brand-new
   // teacher account that hasn't been assigned anywhere), default to "all" so
   // the page isn't empty on first load.
-  const myCount =
-    classrooms?.filter((c) => c.teacher_id === teacherId).length ?? 0;
+  const myCount = classrooms?.filter((c) => c.teacher_id === teacherId).length ?? 0;
   const [scope, setScope] = useState<ScopeFilter>("mine");
 
   // Auto-fallback to "all" when the teacher leads nothing — once we know the
   // counts. Without this, a brand-new teacher would land on an empty Classrooms
   // page even though the school has plenty to show.
-  const effectiveScope: ScopeFilter =
-    scope === "mine" && myCount === 0 ? "all" : scope;
+  const effectiveScope: ScopeFilter = scope === "mine" && myCount === 0 ? "all" : scope;
 
   // Only offer grades that actually have at least one classroom — empty grades
   // would just give the dropdown stale clutter.
@@ -310,9 +308,7 @@ export default function ClassroomsPage() {
                 myCount === 0 && "cursor-not-allowed opacity-40",
               )}
               title={
-                myCount === 0
-                  ? "You aren't the lead of any classrooms yet."
-                  : undefined
+                myCount === 0 ? "You aren't the lead of any classrooms yet." : undefined
               }
             >
               My classrooms ({myCount})

--- a/web/app/(school)/school/curriculum/content/page.tsx
+++ b/web/app/(school)/school/curriculum/content/page.tsx
@@ -54,9 +54,7 @@ export default function SchoolContentPage() {
     enabled: !!schoolId,
     staleTime: 60_000,
   });
-  const myClassrooms = (classrooms ?? []).filter(
-    (c) => c.teacher_id === teacherId,
-  );
+  const myClassrooms = (classrooms ?? []).filter((c) => c.teacher_id === teacherId);
 
   // Pull full classroom details in parallel so we can read each one's package
   // list. listClassrooms only returns counts; getClassroom returns packages.
@@ -83,8 +81,7 @@ export default function SchoolContentPage() {
   // highest version_number as the "current" version, count the rest as
   // history. Without this, Grade 11 Chemistry v1..v4 shows up as four rows
   // and clutters the library page.
-  const rollupKey = (s: SchoolContentSubject) =>
-    `${s.curriculum_id}::${s.subject}`;
+  const rollupKey = (s: SchoolContentSubject) => `${s.curriculum_id}::${s.subject}`;
 
   const rolledSubjects = useMemo(() => {
     if (!subjects) return [];
@@ -111,14 +108,11 @@ export default function SchoolContentPage() {
   // nothing (e.g. school_admin browsing the school's full library). Count
   // rolled-up topics, not raw version rows.
   const myCount = useMemo(
-    () =>
-      rolledSubjects.filter((r) => myCurriculaIds.has(r.latest.curriculum_id))
-        .length,
+    () => rolledSubjects.filter((r) => myCurriculaIds.has(r.latest.curriculum_id)).length,
     [rolledSubjects, myCurriculaIds],
   );
 
-  const effectiveScope: ScopeFilter =
-    scope === "mine" && myCount === 0 ? "all" : scope;
+  const effectiveScope: ScopeFilter = scope === "mine" && myCount === 0 ? "all" : scope;
 
   // Apply scope first, then grade — narrows the rolled-up topic list step by step.
   const visibleRolledSubjects = useMemo(() => {
@@ -137,9 +131,7 @@ export default function SchoolContentPage() {
   const availableGrades = useMemo(() => {
     const base =
       effectiveScope === "mine"
-        ? rolledSubjects.filter((r) =>
-            myCurriculaIds.has(r.latest.curriculum_id),
-          )
+        ? rolledSubjects.filter((r) => myCurriculaIds.has(r.latest.curriculum_id))
         : rolledSubjects;
     return [...new Set(base.map((r) => r.latest.grade))].sort((a, b) => a - b);
   }, [rolledSubjects, effectiveScope, myCurriculaIds]);

--- a/web/app/(school)/school/curriculum/page.tsx
+++ b/web/app/(school)/school/curriculum/page.tsx
@@ -112,6 +112,7 @@ function JsonPipelineSection({ schoolId }: { schoolId: string }) {
   const [state, setState] = useState<UploadState>("idle");
   const [error, setError] = useState<string | null>(null);
   const [parsed, setParsed] = useState<{ grade: number; unitCount: number } | null>(null);
+  const [hasFile, setHasFile] = useState(false);
 
   const { data: limits } = useQuery({
     queryKey: ["school-limits", schoolId],
@@ -136,6 +137,7 @@ function JsonPipelineSection({ schoolId }: { schoolId: string }) {
 
   function handleFileChange() {
     const file = fileRef.current?.files?.[0];
+    setHasFile(!!file);
     if (!file) {
       setParsed(null);
       return;
@@ -190,11 +192,7 @@ function JsonPipelineSection({ schoolId }: { schoolId: string }) {
   }
 
   const canTrigger =
-    !IS_DEMO_MODE &&
-    !quotaExhausted &&
-    langs.size > 0 &&
-    !!fileRef.current?.files?.[0] &&
-    !error;
+    !IS_DEMO_MODE && !quotaExhausted && langs.size > 0 && hasFile && !error;
 
   return (
     <div className="space-y-4">
@@ -538,10 +536,7 @@ export default function CurriculumPage() {
         </LinkButton>
       </div>
 
-      <PendingSubscriptionBanner
-        message="Custom curriculum upload is available to schools with an active subscription. You can still explore the layout — uploads are disabled in this demo."
-      />
-
+      <PendingSubscriptionBanner message="Custom curriculum upload is available to schools with an active subscription. You can still explore the layout — uploads are disabled in this demo." />
 
       {/* Definitions panel */}
       <Link

--- a/web/app/(school)/school/digest/page.tsx
+++ b/web/app/(school)/school/digest/page.tsx
@@ -55,9 +55,7 @@ export default function DigestSettingsPage() {
       <p className="text-sm text-gray-500">
         Receive a weekly summary of your class performance every Monday morning.
       </p>
-      <PendingSubscriptionBanner
-        message="Weekly digest delivery is available to schools with an active subscription. You can preview the settings page, but saving is disabled in this demo."
-      />
+      <PendingSubscriptionBanner message="Weekly digest delivery is available to schools with an active subscription. You can preview the settings page, but saving is disabled in this demo." />
       <Card className="border shadow-sm">
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center gap-2 text-base">
@@ -113,10 +111,7 @@ export default function DigestSettingsPage() {
           </label>
           {error && <p className="text-sm text-red-600">{error}</p>}
           <div className="flex items-center gap-3 pt-1">
-            <Button
-              onClick={handleSave}
-              disabled={IS_DEMO_MODE || saving || !email}
-            >
+            <Button onClick={handleSave} disabled={IS_DEMO_MODE || saving || !email}>
               {saving ? "Saving…" : "Save settings"}
             </Button>
             {saved && (

--- a/web/app/(school)/school/help/page.tsx
+++ b/web/app/(school)/school/help/page.tsx
@@ -16,17 +16,17 @@ const GETTING_STARTED_TEACHER = [
   {
     step: "2",
     title: "Classrooms — focus on yours",
-    body: "Classrooms list defaults to a \"My classrooms\" view showing the rooms you lead. Toggle to \"All classrooms\" to peek at the rest of the school. The grade filter only lists grades that actually have a classroom — no clutter.",
+    body: 'Classrooms list defaults to a "My classrooms" view showing the rooms you lead. Toggle to "All classrooms" to peek at the rest of the school. The grade filter only lists grades that actually have a classroom — no clutter.',
   },
   {
     step: "3",
     title: "Class Overview — students you teach",
-    body: "Same toggle pattern: \"My students\" shows everyone enrolled in classrooms you lead; \"All school\" shows the wider roster. Grade pills auto-narrow to grades present in the current view.",
+    body: 'Same toggle pattern: "My students" shows everyone enrolled in classrooms you lead; "All school" shows the wider roster. Grade pills auto-narrow to grades present in the current view.',
   },
   {
     step: "4",
     title: "Content Library",
-    body: "Browse AI-generated lessons, tutorials, quizzes, and activities. Default view is \"My content\" — the subjects your classrooms have adopted. Each subject row rolls up multiple regenerations into one — if you see a \"4 versions\" chip, the link opens the latest. Lesson images are clickable — tap to enlarge in a lightbox.",
+    body: 'Browse AI-generated lessons, tutorials, quizzes, and activities. Default view is "My content" — the subjects your classrooms have adopted. Each subject row rolls up multiple regenerations into one — if you see a "4 versions" chip, the link opens the latest. Lesson images are clickable — tap to enlarge in a lightbox.',
   },
   {
     step: "5",

--- a/web/app/(school)/school/students/page.tsx
+++ b/web/app/(school)/school/students/page.tsx
@@ -82,9 +82,7 @@ function TeacherStudentView({
     enabled: !!schoolId,
     staleTime: 60_000,
   });
-  const myClassrooms = (classrooms ?? []).filter(
-    (c) => c.teacher_id === teacherId,
-  );
+  const myClassrooms = (classrooms ?? []).filter((c) => c.teacher_id === teacherId);
 
   // Pull per-classroom rosters in parallel — listClassrooms only returns
   // counts; getClassroom returns the full students array.
@@ -108,15 +106,13 @@ function TeacherStudentView({
   }, [myClassroomDetails]);
 
   const myCount = myStudentIds.size;
-  const effectiveScope: ScopeFilter =
-    scope === "mine" && myCount === 0 ? "all" : scope;
+  const effectiveScope: ScopeFilter = scope === "mine" && myCount === 0 ? "all" : scope;
 
   // Apply scope first, then grade.
   const scopedStudents = useMemo(() => {
     if (!metrics) return [];
     return metrics.students.filter((s) => {
-      const scopeOk =
-        effectiveScope === "all" || myStudentIds.has(s.student_id);
+      const scopeOk = effectiveScope === "all" || myStudentIds.has(s.student_id);
       const gradeOk = gradeFilter === "" || s.grade === gradeFilter;
       return scopeOk && gradeOk;
     });
@@ -202,9 +198,7 @@ function TeacherStudentView({
                     <button
                       type="button"
                       key={g}
-                      onClick={() =>
-                        setGradeFilter(g === gradeFilter ? "" : g)
-                      }
+                      onClick={() => setGradeFilter(g === gradeFilter ? "" : g)}
                       className={cn(
                         "rounded px-2 py-1 text-xs font-medium transition-colors",
                         gradeFilter === g
@@ -277,7 +271,7 @@ function TeacherStudentView({
                       className="px-4 py-8 text-center text-sm text-gray-400"
                     >
                       {effectiveScope === "mine"
-                        ? "No students in classrooms you lead. Switch to \"All school\" to browse the wider roster."
+                        ? 'No students in classrooms you lead. Switch to "All school" to browse the wider roster.'
                         : gradeFilter !== ""
                           ? `No Grade ${gradeFilter} students at this school.`
                           : "No students enrolled yet."}

--- a/web/components/demo/TestRunRequestModal.tsx
+++ b/web/components/demo/TestRunRequestModal.tsx
@@ -112,11 +112,7 @@ export function TestRunRequestModal({ trigger }: TestRunRequestModalProps) {
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogTrigger
-        render={
-          trigger ?? <Button size="default">Try a test run</Button>
-        }
-      />
+      <DialogTrigger render={trigger ?? <Button size="default">Try a test run</Button>} />
 
       <DialogContent className="sm:max-w-md">
         {submittedEmail ? (
@@ -129,9 +125,9 @@ export function TestRunRequestModal({ trigger }: TestRunRequestModalProps) {
               <DialogTitle className="text-center">Check your inbox</DialogTitle>
               <DialogDescription className="text-center">
                 We&apos;ve sent a verification link to{" "}
-                <span className="font-medium">{submittedEmail}</span>. Click the
-                link in the email — we&apos;ll then send you the teacher and
-                student login credentials in a second email.
+                <span className="font-medium">{submittedEmail}</span>. Click the link in
+                the email — we&apos;ll then send you the teacher and student login
+                credentials in a second email.
               </DialogDescription>
             </DialogHeader>
             <DialogFooter>
@@ -146,9 +142,8 @@ export function TestRunRequestModal({ trigger }: TestRunRequestModalProps) {
             <DialogHeader>
               <DialogTitle>Try a test run</DialogTitle>
               <DialogDescription>
-                Enter your name and email. We&apos;ll send you teacher and
-                student login credentials so you can explore StudyBuddy from
-                both sides.
+                Enter your name and email. We&apos;ll send you teacher and student login
+                credentials so you can explore StudyBuddy from both sides.
               </DialogDescription>
             </DialogHeader>
 

--- a/web/lib/api/auth.ts
+++ b/web/lib/api/auth.ts
@@ -135,10 +135,7 @@ export interface UniversalLoginResponse {
 export async function universalLogin(
   body: LocalLoginRequest,
 ): Promise<UniversalLoginResponse> {
-  const res = await publicApi.post<UniversalLoginResponse>(
-    "/auth/universal-login",
-    body,
-  );
+  const res = await publicApi.post<UniversalLoginResponse>("/auth/universal-login", body);
   return res.data;
 }
 

--- a/web/lib/api/demo.ts
+++ b/web/lib/api/demo.ts
@@ -84,10 +84,7 @@ export interface TestRunRequestPayload {
 export async function requestTestRun(
   payload: TestRunRequestPayload,
 ): Promise<DemoRequestResponse> {
-  const res = await api.post<DemoRequestResponse>(
-    "/demo/test-run/request",
-    payload,
-  );
+  const res = await api.post<DemoRequestResponse>("/demo/test-run/request", payload);
   return res.data;
 }
 
@@ -95,12 +92,8 @@ export async function requestTestRun(
  * GET /demo/test-run/verify/{token}
  * Verify the test-run email and trigger the combined credentials email.
  */
-export async function verifyTestRunEmail(
-  token: string,
-): Promise<DemoRequestResponse> {
-  const res = await api.get<DemoRequestResponse>(
-    `/demo/test-run/verify/${token}`,
-  );
+export async function verifyTestRunEmail(token: string): Promise<DemoRequestResponse> {
+  const res = await api.get<DemoRequestResponse>(`/demo/test-run/verify/${token}`);
   return res.data;
 }
 

--- a/web/tests/e2e/data/landing-page.ts
+++ b/web/tests/e2e/data/landing-page.ts
@@ -21,8 +21,10 @@ export const BANNER = {
 // ---------------------------------------------------------------------------
 
 export const HERO = {
-  // Matches en.json "hero_heading". Update here if the i18n value changes.
-  heading: "Study Buddy",
+  // Matches the rendered <h1> on app/(public)/page.tsx (en.json "hero_tagline").
+  // "Study Buddy" itself appears only as an aria-hidden decorative watermark,
+  // not as an addressable heading. Update here if the H1 copy changes.
+  heading: "Lessons, always current.",
   subheading: "Instant lessons, quizzes, and audio where available. Just learning.",
   ctaPrimary: { text: "Start free trial", href: "/signup" },
   ctaSecondary: { text: "See how it works", href: "/#features" },

--- a/web/tests/e2e/student_flow.spec.ts
+++ b/web/tests/e2e/student_flow.spec.ts
@@ -183,8 +183,11 @@ test("curriculum map → lesson navigation", async ({ page }) => {
   await page.goto("/curriculum");
   await page.waitForLoadState("networkidle");
 
-  // Cell Biology unit must be visible
-  await expect(page.getByText("Cell Biology")).toBeVisible();
+  // Cell Biology unit must be visible. Locate via the button's accessible
+  // name (computed from the sr-only label) — getByText('Cell Biology') would
+  // match both the visible label span and the sr-only span inside the same
+  // button, triggering strict-mode.
+  await expect(page.getByRole("button", { name: /^Cell Biology/ })).toBeVisible();
 
   // Click the Lesson link for G8-SCI-001 and land on the lesson page.
   // The link href is /lesson/G8-SCI-001; we navigate directly to be


### PR DESCRIPTION
## Context

CI on `main` has been red for the last 200 runs (back to **2026-04-15**, ~a month). Surfaced today while triaging PR #352 — its failures turned out to be inherited from main, not introduced by it. This PR unbreaks main so that #352 (and future PRs) can land cleanly.

## What's failing on main today

| Job | Step | Root cause |
|---|---|---|
| Backend — Lint & Security | `ruff format --check src/` | 2 files diverged from formatter — pure line-collapse |
| Frontend — Lint & Typecheck | `npm run lint -- --max-warnings=0` | `react-hooks/refs` rule: `fileRef.current?.files?.[0]` read during render |
| Frontend — Lint & Typecheck | `npm run format:check` | 14 files diverged from prettier — pure whitespace/wrap |
| E2E — Student Critical Paths | Playwright `student_flow.spec.ts` | (a) stale `HERO.heading` fixture vs. current `<h1>`; (b) `getByText('Cell Biology')` strict-mode violation |

## Fix per concern (3 commits)

1. **`fix(backend): ruff-format auth/router.py + demo/test_run_router.py`** — mechanical reformat.
2. **`fix(web): lift fileRef to state + prettier reformat across web/`**
   - Lift "user has picked a file" into a `hasFile` state set by the existing onChange handler; `canTrigger` now reads state, not the ref. Behavior identical.
   - Pure mechanical `prettier --write .` across 14 files.
3. **`fix(e2e): align student_flow locators with current UI`**
   - Update `HERO.heading` to the actually-rendered `<h1>` ("Lessons, always current." from `hero_tagline`). "Study Buddy" appears on the public landing only as an `aria-hidden` decorative watermark.
   - Switch `getByText('Cell Biology')` → `getByRole('button', { name: /^Cell Biology/ })` to target the unit button via its accessible name, avoiding the double-match against the sr-only label span.

## Verified locally

- `ruff format --check src/` (backend) — PASS
- `npm run lint -- --max-warnings=0` (web) — PASS
- `npm run format:check` (web) — PASS
- Playwright landing-page hero heading test — PASS

The two authenticated Playwright tests (curriculum map + learning loop) misbehave in my local dev env (redirect to /signin instead of reaching `/curriculum` and `/lesson`). CI has historically reached those pages (proven by the original strict-mode violation, which only fires when the page renders). I'm pushing to let CI judge — if CI also redirects, that's a separate auth-bypass issue worth its own investigation.

## Why a single bundled PR

Each of the 4 jobs is sequentially gated by the one above it (lint must pass before tests run), so splitting into 4 PRs would each only get 1 step further. Bundling lets us see all 4 jobs go green at once.

## Test plan

- [ ] Backend — Lint & Security passes
- [ ] Frontend — Lint & Typecheck passes
- [ ] Frontend — Tests passes (was previously SKIPPED behind Lint)
- [ ] Playwright Student Flow passes (all 3 tests)
- [ ] Vulnerability/SBOM/API contract checks unblock (were SKIPPED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)