### PR TITLE
fix(demo): vm-localhost-bootstrap reliability fixes (PR #354 follow-ups)

### DIFF
--- a/docs/VM_LOCALHOST_BOOTSTRAP.md
+++ b/docs/VM_LOCALHOST_BOOTSTRAP.md
@@ -55,11 +55,11 @@ issues.
 
 | Step | What it does |
 |---|---|
-| **preflight** | Validates `IMAGE_STRATEGY`, `GHCR_PAT`, not running as root, sudo present |
+| **preflight** | Validates `IMAGE_STRATEGY`, `GHCR_PAT`, not running as root, sudo present. Primes `sudo -v` and starts a 60-second background refresher (killed on EXIT) so the script can't silently block on an expired sudo timestamp during long image-pull / db-init phases. |
 | **1/8** | Installs Docker Engine + Compose v2 + git + rsync. Detects Mint/Pop/Neon and uses the upstream Ubuntu/Debian apt repo. |
 | **2/8** | Clones the repo into `/opt/studybuddy`. If already cloned, attempts `git fetch + reset --hard`; continues with the existing checkout if offline. |
 | **3/8** | **GHCR login** (Path A — pull strategy) or **Docker daemon DNS sanity check** (Path B — local build strategy) |
-| **4/8** | Generates `.env.demo` with random secrets + stubbed Auth0/Stripe/SMTP values. Creates `.env` symlink, `web/.env.local` stub, patches `docker-compose.yml` to drop `pgbouncer` from depends-on anchors, writes `docker-compose.localhost.yml` with the three localhost-specific overrides (depends_on, python healthcheck, web volumes reset). |
+| **4/8** | Generates `.env.demo` with random secrets + stubbed Auth0/Stripe/SMTP values. **If a stale `.env.demo` with `<REPLACE_WITH...>` placeholders is detected (left over from a prior `provision.sh` attempt), it is backed up to `.env.demo.placeholder-bak` and regenerated** — otherwise redis fails with "requirepass wrong number of arguments" and postgres bakes the placeholder string as its password. Creates `.env` symlink, `web/.env.local` stub, patches `docker-compose.yml` to drop `pgbouncer` from depends-on anchors, writes `docker-compose.localhost.yml` with localhost-specific overrides (depends_on, python healthcheck, web volumes reset, **db `start_period: 300s` for slow-disk first-init grace**). |
 | **5/8** | Creates the content-store directories at `/opt/studybuddy/content_store_data` and `/opt/studybuddy/data` with mode 777 (so the container's non-root user can write). |
 | **6/8** | (Pull strategy only) `docker cp` extracts the prebuilt Next.js standalone `/app/server.js` from the GHCR web image into `/opt/studybuddy/web/`. This sidesteps a Compose volume-merge issue. |
 | **7/8** | `docker compose pull && up -d`, waits 45s, verifies `/healthz`, runs `alembic upgrade head`, copies `seed.sh` into the api container, runs all 5 seed scripts. |

--- a/docs/VM_LOCALHOST_BOOTSTRAP.md
+++ b/docs/VM_LOCALHOST_BOOTSTRAP.md
@@ -76,7 +76,7 @@ run to confirm what happened.
 | Var | Purpose | Default |
 |---|---|---|
 | `LOG_FILE` | Where to write the install log (text) | `/tmp/studybuddy-bootstrap-<UTC-ts>.log` |
-| `LOG_DIR` | Where to write the JSON deployment log | `/opt/studybuddy/logs` |
+| `LOG_DIR` | Where to write the JSON deployment log | `$HOME/Documents/studybuddy/logs` |
 | `IMAGE_STRATEGY` | `pull` (GHCR) or `build` (local) | `pull` |
 | `GHCR_PAT` | GitHub PAT with `read:packages` | **required if pull** |
 | `GHCR_USER` | GitHub owner for images | `wegofwd2020-hub` |
@@ -259,7 +259,7 @@ entry per step. Same shape as mambakkam-net's `scripts/launch/_log.sh`
 output — so any downstream tooling (Promtail/Loki, dashboards, grep+jq)
 treats both deployments uniformly.
 
-Default path: `/opt/studybuddy/logs/vm-localhost-bootstrap-<UTC-timestamp>.json`,
+Default path: `$HOME/Documents/studybuddy/logs/vm-localhost-bootstrap-<UTC-timestamp>.json`,
 plus a `vm-localhost-bootstrap-latest.json` symlink that always points at
 the most recent run. Override the directory with `LOG_DIR=/path/to/dir`.
 
@@ -296,14 +296,14 @@ Quick queries:
 ```bash
 # What step failed, on the latest run?
 jq '.steps[] | select(.status == "Error")' \
-  /opt/studybuddy/logs/vm-localhost-bootstrap-latest.json
+  $HOME/Documents/studybuddy/logs/vm-localhost-bootstrap-latest.json
 
 # Total wall-clock time per step, sorted descending (find the slow ones)
 jq -r '.steps[] | [.duration_ms, .name] | @tsv' \
-  /opt/studybuddy/logs/vm-localhost-bootstrap-latest.json | sort -rn
+  $HOME/Documents/studybuddy/logs/vm-localhost-bootstrap-latest.json | sort -rn
 
 # Compare run-time of the last 5 deployments
-ls -t /opt/studybuddy/logs/vm-localhost-bootstrap-2*.json | head -5 \
+ls -t $HOME/Documents/studybuddy/logs/vm-localhost-bootstrap-2*.json | head -5 \
   | xargs -I{} jq -r '[.started_at, .duration_ms, .exit_code] | @tsv' {}
 ```
 

--- a/scripts/demo/vm-localhost-bootstrap.sh
+++ b/scripts/demo/vm-localhost-bootstrap.sh
@@ -38,7 +38,9 @@
 #   LOG_FILE          where to write the install log
 #                     (default /tmp/studybuddy-bootstrap-<timestamp>.log)
 #   LOG_DIR           where to write the per-run JSON deployment log
-#                     (default /opt/studybuddy/logs)
+#                     (default $HOME/Documents/studybuddy/logs — kept
+#                     OUT of $INSTALL_DIR so the dir doesn't pre-exist
+#                     and block Step 2's git clone into /opt/studybuddy)
 #
 # Install log:
 #   Every step start, success, and failure is written to the log file.
@@ -122,9 +124,12 @@ _log_only() {
 # scripts/launch/_log.sh so any downstream tooling (Promtail/Loki,
 # dashboards) treats both deployments uniformly. Inlined rather than
 # sourced so the script stays curl-pipe friendly. Atomic tmp+mv on EXIT.
-LOG_DIR="${LOG_DIR:-/opt/studybuddy/logs}"
-sudo mkdir -p "$LOG_DIR" 2>/dev/null || mkdir -p "$LOG_DIR" 2>/dev/null || true
-sudo chown "$USER:$USER" "$LOG_DIR" 2>/dev/null || true
+# Keep the log dir out of $INSTALL_DIR so it doesn't pre-create
+# /opt/studybuddy/ and block Step 2's git clone (the clone needs the
+# target to be either non-existent or empty). $HOME is owned by the
+# running user, so no sudo dance needed here either.
+LOG_DIR="${LOG_DIR:-$HOME/Documents/studybuddy/logs}"
+mkdir -p "$LOG_DIR" 2>/dev/null || true
 JSON_LOG_FILE="$LOG_DIR/vm-localhost-bootstrap-${TIMESTAMP}.json"
 JSON_LOG_LATEST="$LOG_DIR/vm-localhost-bootstrap-latest.json"
 __JSON_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/scripts/demo/vm-localhost-bootstrap.sh
+++ b/scripts/demo/vm-localhost-bootstrap.sh
@@ -61,10 +61,20 @@
 #   2/8  Clone repo
 #   3/8  Image strategy (GHCR login OR Docker-DNS sanity check)
 #   4/8  Generate .env.demo + .env + web/.env.local + compose overrides
+#        (regenerates .env.demo if a stale file with <REPLACE_WITH...>
+#         placeholders is detected — left over from provision.sh runs)
 #   5/8  Content store directories
 #   6/8  Hydrate /opt/studybuddy/web from prebuilt image (pull strategy only)
 #   7/8  docker compose pull + up -d + migrations + seed
+#        (db healthcheck start_period bumped to 300s in the localhost
+#         override so slow disks don't time out on first postgres init)
 #   8/8  (optional) rsync content from OLD_HOST
+#
+# Sudo handling:
+#   The script primes sudo at preflight (`sudo -v`) then runs a background
+#   refresher every 60s so the bootstrap can't silently block on an expired
+#   sudo timestamp during the long image-pull / db-init phases. The
+#   refresher is killed in the EXIT trap.
 #
 # Exit codes:
 #   0   bootstrap complete
@@ -261,6 +271,27 @@ fi
 info "preflight green — IMAGE_STRATEGY=${IMAGE_STRATEGY}, INSTALL_DIR=${INSTALL_DIR}"
 step_ok
 
+# ── Sudo keepalive ─────────────────────────────────────────────────────────
+# Image-pull + first postgres init can take 15-25 min on slow disks. Default
+# sudo timestamp_timeout is 15 min, so without a refresher the script blocks
+# silently waiting for a password prompt mid-run (operator only finds out by
+# checking from another terminal). Prime the cache once here, then refresh
+# in the background until the script exits.
+info "priming sudo cache + starting background refresher (refreshes every 60s)"
+sudo -v
+( while true; do sudo -n true 2>/dev/null || exit 0; sleep 60; done ) &
+__SUDO_KEEPALIVE_PID=$!
+
+__sudo_keepalive_stop() {
+  if [[ -n "${__SUDO_KEEPALIVE_PID:-}" ]] && kill -0 "$__SUDO_KEEPALIVE_PID" 2>/dev/null; then
+    kill "$__SUDO_KEEPALIVE_PID" 2>/dev/null || true
+  fi
+}
+# Chain onto the existing EXIT trap (currently __json_finalize) — runs the
+# sudo cleanup first, then whatever was already installed.
+__PREV_EXIT_TRAP="$(trap -p EXIT | sed -E "s/^trap -- '(.*)' EXIT$/\1/")"
+trap "__sudo_keepalive_stop; ${__PREV_EXIT_TRAP:-:}" EXIT
+
 # ── 1/8  Install Docker, git, rsync ────────────────────────────────────────
 step "1/8  Install Docker, git, rsync"
 if ! command -v docker >/dev/null 2>&1; then
@@ -371,6 +402,21 @@ step_ok
 step "4/8  Generate .env.demo + .env symlink + web/.env.local + compose overrides"
 
 ENV_FILE="$INSTALL_DIR/.env.demo"
+
+# Detect provision.sh leftover with placeholder secrets — those will fail
+# downstream (redis "requirepass wrong number of arguments" because the
+# password value is empty after compose interpolation; postgres init bakes
+# the literal placeholder string as its password). Regenerate if found.
+if [[ -f "$ENV_FILE" ]] && grep -qE "<REPLACE_WITH_|<from-|<your-" "$ENV_FILE"; then
+  warn ".env.demo contains <REPLACE_WITH...> placeholder values"
+  warn "(left over from provision.sh, not vm-localhost-bootstrap.sh)"
+  warn "backing up to ${ENV_FILE}.placeholder-bak and regenerating"
+  mv "$ENV_FILE" "${ENV_FILE}.placeholder-bak"
+  # Drop the .env symlink too so it won't pin to the stale file via the
+  # base-compose env_file: directive once we recreate .env.demo below.
+  [[ -L "$INSTALL_DIR/.env" ]] && rm -f "$INSTALL_DIR/.env"
+fi
+
 if [[ -f "$ENV_FILE" ]]; then
   warn ".env.demo exists — leaving in place. Delete it and re-run to regenerate."
 else
@@ -585,6 +631,15 @@ services:
 
   web:
     volumes: []
+
+  # Slow VMs (HDD-backed, low IOPS) need >65s for the first postgres init.
+  # Base compose's healthcheck has start_period: 15s + 5x10s retries = 65s,
+  # which times out before postgres finishes its initdb + checkpoint cycle
+  # on slow disks. Bump to 5 minutes for first-init grace; existing-data
+  # restarts are unaffected (pg_isready returns OK in <1s once data exists).
+  db:
+    healthcheck:
+      start_period: 300s
 EOF
   info "created $LOCAL_OVERRIDE"
 fi


### PR DESCRIPTION
## Summary

Two follow-up fixes that landed on `feat/vm-bootstrap-json-log` after [PR #354](https://github.com/wegofwd2020-hub/StudyBuddy_OnDemand/pull/354) merged. Both observed end-to-end during the first-run debug on the local mambakkam VM.

- **`23f4c3d` fix(demo): three reliability fixes for vm-localhost-bootstrap.sh**
  1. Bump db healthcheck `start_period` to 300s — HDD-backed VMs were timing out at the 65s default during postgres `initdb` + checkpoint
  2. Prime sudo at preflight + 60s background refresher (killed in EXIT trap) — script was silently blocking on expired sudo timestamp during long image-pull / db-init phases
  3. Step 4 `.env.demo` placeholder detection — regenerate (with `.placeholder-bak` backup) when `<REPLACE_WITH...>` markers found, preventing the redis "requirepass wrong number of arguments" failure on retry

- **`62fae25` fix(demo): move JSON log dir out of `$INSTALL_DIR`**
  - Default `/opt/studybuddy/logs` was created at script init, which pre-populated `$INSTALL_DIR` before Step 2's `git clone` → fatal "destination path '.' already exists" on a fresh VM
  - New default: `$HOME/Documents/studybuddy/logs` — kept entirely outside `$INSTALL_DIR`, sudo dance no longer needed

## Test plan

- [ ] Re-run `scripts/demo/vm-localhost-bootstrap.sh` end-to-end on a clean VM
- [ ] Confirm Step 4 regenerates `.env.demo` if a placeholder-bearing copy is left over from a prior aborted run
- [ ] Confirm Step 7 db healthcheck no longer times out on HDD-backed VMs (uses `start_period: 300s`)
- [ ] Confirm Step 2 `git clone` succeeds against an empty `$INSTALL_DIR`
- [ ] Confirm long phases (>5 min) don't hang on sudo prompt — background refresher keeps cache primed

🤖 Generated with [Claude Code](https://claude.com/claude-code)