### PR TITLE
feat(school): curriculum_mgmt capability — two-gate delegated curriculum management (#358)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,6 +412,8 @@ Current migrations (as of last commit):
 | 0055 | Epic 15 — `schools.backup_cron` column (default `0 2 * * *` nightly at 02:00 UTC) |
 | 0056 | Visual library — `visual_library_entries` table (kind, subject, topic_phrase, keywords, s3_path, license, source_unit, embedding) |
 | 0057 | Visual library — `embedding` column → pgvector type for cosine similarity search |
+| 0058 | Demo request — `name` column on demo lead requests |
+| 0059 | Epic/#358 — `teacher_capabilities` table (RLS): additive `curriculum.commission` / `curriculum.review` / `curriculum_mgmt` grants |
 
 ---
 

--- a/backend/alembic/versions/0059_teacher_capabilities.py
+++ b/backend/alembic/versions/0059_teacher_capabilities.py
@@ -1,0 +1,80 @@
+"""0059 — Teacher capabilities (curriculum_mgmt)
+
+Adds the additive-capability grant store behind issue #358. A school_admin can
+grant a teacher one or more curriculum-management capabilities WITHOUT promoting
+them to school_admin. The grant travels alongside the single `role` JWT claim as
+a `capabilities[]` array, minted at login.
+
+Capabilities (CHECK-constrained):
+  curriculum.commission  — Gate 1: approve/adopt/load + trigger generation (spend)
+  curriculum.review      — Gate 2: approve/publish generated content (editorial)
+  curriculum_mgmt        — umbrella, covers both gates
+
+school_admin is an implicit superset (no row needed); these grants exist to
+empower *non-admin* teachers.
+
+teacher_capabilities  (new table)
+  teacher_id   UUID  FK → teachers  ON DELETE CASCADE
+  school_id    UUID  FK → schools   ON DELETE CASCADE  (denormalised for RLS)
+  capability   TEXT  CHECK in the 3 values above
+  granted_by   UUID  FK → teachers  ON DELETE SET NULL
+  granted_at   TIMESTAMPTZ DEFAULT now()
+  PRIMARY KEY (teacher_id, capability)
+
+RLS: standard tenant-isolation on app.current_school_id ('bypass' for the login
+mint / service role). school_id is denormalised onto the row so the policy needs
+no subquery (consistent with school_adopted_curricula, classroom_students).
+
+Downgrade: DROP TABLE — additive, no dependents, no data-only pre-drop needed.
+
+Revision ID: 0059
+Revises: 0058
+Create Date: 2026-05-21
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0059"
+down_revision: str | None = "0058"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS teacher_capabilities (
+            teacher_id   UUID         NOT NULL
+                             REFERENCES teachers(teacher_id) ON DELETE CASCADE,
+            school_id    UUID         NOT NULL
+                             REFERENCES schools(school_id) ON DELETE CASCADE,
+            capability   TEXT         NOT NULL
+                             CHECK (capability IN
+                                 ('curriculum.commission', 'curriculum.review', 'curriculum_mgmt')),
+            granted_by   UUID         REFERENCES teachers(teacher_id) ON DELETE SET NULL,
+            granted_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+            PRIMARY KEY (teacher_id, capability)
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_teacher_capabilities_school_id "
+        "ON teacher_capabilities(school_id)"
+    )
+
+    # ── RLS ───────────────────────────────────────────────────────────────────
+    op.execute("ALTER TABLE teacher_capabilities ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE teacher_capabilities FORCE ROW LEVEL SECURITY")
+    op.execute("""
+        CREATE POLICY tenant_isolation ON teacher_capabilities
+            USING (
+                school_id::TEXT = current_setting('app.current_school_id', TRUE)
+                OR current_setting('app.current_school_id', TRUE) = 'bypass'
+            )
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS teacher_capabilities CASCADE")

--- a/backend/src/auth/router.py
+++ b/backend/src/auth/router.py
@@ -245,11 +245,25 @@ async def exchange_teacher_token(
     teacher_id = str(teacher["teacher_id"])
     school_id = teacher.get("school_id")
 
+    # Curriculum capabilities (issue #358) — bypass RLS to read the grants.
+    capabilities: list[str] = []
+    async with request.app.state.pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        try:
+            cap_rows = await conn.fetch(
+                "SELECT capability FROM teacher_capabilities WHERE teacher_id = $1::uuid",
+                teacher_id,
+            )
+            capabilities = sorted(r["capability"] for r in cap_rows)
+        finally:
+            await conn.execute("SELECT set_config('app.current_school_id', '', false)")
+
     jwt_payload = {
         "teacher_id": teacher_id,
         "school_id": str(school_id) if school_id else None,
         "role": role,
         "account_status": account_status,
+        "capabilities": capabilities,
     }
     token = create_internal_jwt(
         jwt_payload, settings.JWT_SECRET, settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES
@@ -335,11 +349,19 @@ async def refresh_token(body: RefreshRequest, request: Request):
                         "correlation_id": cid,
                     },
                 )
+            # Re-read capabilities so they survive the ~15-min access-token cycle
+            # (issue #358). get_db stamps 'bypass' on unauthenticated refresh, so
+            # the teacher_capabilities RLS policy permits this read.
+            cap_rows = await conn.fetch(
+                "SELECT capability FROM teacher_capabilities WHERE teacher_id = $1",
+                teacher["teacher_id"],
+            )
             payload = {
                 "teacher_id": str(teacher["teacher_id"]),
                 "school_id": str(teacher["school_id"]) if teacher["school_id"] else None,
                 "role": teacher["role"],
                 "account_status": teacher["account_status"],
+                "capabilities": sorted(r["capability"] for r in cap_rows),
             }
             secret = settings.JWT_SECRET
 
@@ -434,6 +456,9 @@ async def local_login(
             "role": role,
             "account_status": user["account_status"],
             "first_login": first_login,
+            # Curriculum-management capabilities (issue #358). Empty list for
+            # teachers with no grants; school_admin is an implicit superset.
+            "capabilities": user.get("capabilities", []),
         }
     else:
         # student
@@ -518,6 +543,7 @@ async def universal_login(
     local_row = None
     demo_teacher_row = None
     demo_student_row = None
+    local_capabilities: list[str] = []
     async with pool.acquire() as conn:
         # RLS bypass: login is unauthenticated, must read across schools.
         await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
@@ -543,6 +569,13 @@ async def universal_login(
                     """,
                     email,
                 )
+            # Curriculum capabilities (issue #358) — read under bypass for teachers.
+            if local_row is not None and local_row["user_type"] == "teacher":
+                cap_rows = await conn.fetch(
+                    "SELECT capability FROM teacher_capabilities WHERE teacher_id = $1::uuid",
+                    local_row["user_id"],
+                )
+                local_capabilities = sorted(r["capability"] for r in cap_rows)
             if local_row is None:
                 demo_teacher_row = await get_demo_teacher_account_for_login(conn, email)
             if local_row is None and demo_teacher_row is None:
@@ -610,6 +643,7 @@ async def universal_login(
                 "role": role,
                 "account_status": local_row["account_status"],
                 "first_login": first_login,
+                "capabilities": local_capabilities,
             }
         else:
             student_row = await pool.fetchrow(

--- a/backend/src/auth/service.py
+++ b/backend/src/auth/service.py
@@ -410,6 +410,18 @@ async def login_local_user(
                 """,
                 email,
             )
+
+        # Curriculum capabilities (issue #358) — read while bypass is still set so
+        # the RLS policy on teacher_capabilities does not hide the grants. Teachers
+        # only; students never hold curriculum capabilities.
+        capabilities: list[str] = []
+        if row is not None and row["user_type"] == "teacher":
+            cap_rows = await conn.fetch(
+                "SELECT capability FROM teacher_capabilities WHERE teacher_id = $1::uuid",
+                row["user_id"],
+            )
+            capabilities = sorted(r["capability"] for r in cap_rows)
+
         # Reset session var before returning connection to pool.
         await conn.execute("SELECT set_config('app.current_school_id', '', false)")
 
@@ -439,7 +451,9 @@ async def login_local_user(
             detail={"error": "unauthenticated", "detail": "Account has been deleted."},
         )
 
-    return dict(row)
+    result = dict(row)
+    result["capabilities"] = capabilities
+    return result
 
 
 # ── Auth0 Management API ──────────────────────────────────────────────────────

--- a/backend/src/core/permissions.py
+++ b/backend/src/core/permissions.py
@@ -88,6 +88,53 @@ ROLE_PERMISSIONS: dict[str, set[str]] = {
 
 _bearer = HTTPBearer(auto_error=False)
 
+# ── Additive capabilities (issue #358) ────────────────────────────────────────
+# Capabilities are an *additive* grant carried in the JWT `capabilities[]` array
+# alongside the single `role` claim. Unlike ROLE_PERMISSIONS (deploy-time, per
+# role), capabilities are granted per teacher at runtime and minted into the JWT
+# at login. school_admin is an implicit superset — it never needs a grant.
+ALLOWED_CAPABILITIES: set[str] = {
+    "curriculum.commission",  # Gate 1 — approve/adopt/load + trigger generation
+    "curriculum.review",      # Gate 2 — approve/publish generated content
+    "curriculum_mgmt",        # umbrella — covers both gates
+}
+
+# Umbrella capability → the specific capabilities it satisfies.
+_CAPABILITY_UMBRELLAS: dict[str, set[str]] = {
+    "curriculum_mgmt": {"curriculum.commission", "curriculum.review", "curriculum_mgmt"},
+}
+
+# Roles that implicitly hold every curriculum capability (superset).
+_CAPABILITY_SUPERSET_ROLES: set[str] = {"school_admin"}
+
+
+def _is_capability_superset(role: str) -> bool:
+    """True if the role implicitly holds all capabilities (school_admin, or a
+    wildcard admin role such as super_admin)."""
+    return role in _CAPABILITY_SUPERSET_ROLES or "*" in ROLE_PERMISSIONS.get(role, set())
+
+
+def has_capability(payload: dict, capability: str) -> bool:
+    """Return True if the JWT payload grants *capability*.
+
+    Passes when the role is a superset (school_admin / super_admin), the exact
+    capability is held, or an umbrella capability covering it is held.
+    """
+    if _is_capability_superset(payload.get("role", "")):
+        return True
+    held: list[str] = payload.get("capabilities") or []
+    if capability in held:
+        return True
+    return any(capability in _CAPABILITY_UMBRELLAS.get(h, set()) for h in held)
+
+
+def has_any_curriculum_capability(payload: dict) -> bool:
+    """Return True if the payload holds *any* curriculum capability (the view
+    tier — lets a reviewer see what's been commissioned and vice versa)."""
+    if _is_capability_superset(payload.get("role", "")):
+        return True
+    return bool(set(payload.get("capabilities") or []) & ALLOWED_CAPABILITIES)
+
 
 def _has_permission(role: str, permission: str) -> bool:
     """Return True if the role grants the given permission."""

--- a/backend/src/school/capability_guards.py
+++ b/backend/src/school/capability_guards.py
@@ -1,0 +1,67 @@
+"""
+backend/src/school/capability_guards.py
+
+Three-tier curriculum-capability guards (issue #358), shared across the school
+routers so the same authorization logic isn't duplicated.
+
+Each guard takes the decoded teacher JWT payload, the path school_id, and the
+request (for the correlation id), and raises HTTP 403 when the caller is not
+authorized. They are *the* authorization gate — hiding a nav button is never
+sufficient (pitfall #10).
+
+Tiers
+─────
+  require_curriculum_view  — any curriculum capability (or school_admin). Lets a
+                             reviewer see what's been commissioned and vice versa.
+  require_commission       — Gate 1: curriculum.commission | umbrella | school_admin
+  require_review           — Gate 2: curriculum.review     | umbrella | school_admin
+
+All three first enforce that the caller belongs to the path school.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request
+
+from src.core.permissions import has_any_curriculum_capability, has_capability
+
+
+def _cid(request: Request) -> str:
+    return getattr(request.state, "correlation_id", "")
+
+
+def _forbidden(request: Request, detail: str) -> HTTPException:
+    return HTTPException(
+        status_code=403,
+        detail={"error": "forbidden", "detail": detail, "correlation_id": _cid(request)},
+    )
+
+
+def _assert_same_school(teacher: dict, school_id: str, request: Request) -> None:
+    if teacher.get("school_id") != school_id:
+        raise _forbidden(request, "Cannot manage curriculum for a different school.")
+
+
+def require_curriculum_view(teacher: dict, school_id: str, request: Request) -> None:
+    """Tier 0 — view the pending-approval / content-review queues."""
+    _assert_same_school(teacher, school_id, request)
+    if not has_any_curriculum_capability(teacher):
+        raise _forbidden(request, "Requires a curriculum-management capability to view this.")
+
+
+def require_commission(teacher: dict, school_id: str, request: Request) -> None:
+    """Gate 1 — commission: approve/adopt/load + trigger generation (spends budget)."""
+    _assert_same_school(teacher, school_id, request)
+    if not has_capability(teacher, "curriculum.commission"):
+        raise _forbidden(
+            request, "Requires the 'curriculum.commission' capability (or school_admin)."
+        )
+
+
+def require_review(teacher: dict, school_id: str, request: Request) -> None:
+    """Gate 2 — review: approve/publish generated content (editorial)."""
+    _assert_same_school(teacher, school_id, request)
+    if not has_capability(teacher, "curriculum.review"):
+        raise _forbidden(
+            request, "Requires the 'curriculum.review' capability (or school_admin)."
+        )

--- a/backend/src/school/pipeline_router.py
+++ b/backend/src/school/pipeline_router.py
@@ -42,6 +42,7 @@ from src.core.db import get_db
 from src.core.redis_client import get_redis
 from src.core.stripe_async import run_stripe
 from src.pricing import AI_COST, EXTRA_BUILD_PRICE_USD
+from src.school.capability_guards import require_commission
 from src.school.schemas import (
     PipelineEstimateResponse,
     PipelineTriggerFromDefinitionRequest,
@@ -145,7 +146,7 @@ async def upload_school_curriculum(
     so re-uploads add new units without overwriting existing ones. Use
     pipeline trigger with force=True to rebuild content for changed units.
     """
-    _assert_school_match(teacher, school_id, request)
+    require_commission(teacher, school_id, request)
 
     raw = await file.read()
     try:
@@ -333,7 +334,7 @@ async def trigger_school_pipeline(
     """
     from src.core.celery_app import celery_app as _celery
 
-    _assert_school_match(teacher, school_id, request)
+    require_commission(teacher, school_id, request)
     teacher_id = teacher.get("teacher_id", "")
     curriculum_id = f"{school_id}-{body.year}-g"
 
@@ -707,7 +708,7 @@ async def estimate_definition_pipeline(
     - within_allowance = True  → build is covered by plan quota or rollover credits
     - within_allowance = False → extra_build_charge_usd is set; school will be charged on trigger
     """
-    _assert_school_match(teacher, school_id, request)
+    require_commission(teacher, school_id, request)
 
     async with get_db(request) as conn:
         defn = await _get_definition_or_404(conn, definition_id, school_id, request)
@@ -793,7 +794,7 @@ async def trigger_pipeline_from_definition(
     """
     from src.core.celery_app import celery_app as _celery
 
-    _assert_school_match(teacher, school_id, request)
+    require_commission(teacher, school_id, request)
 
     if not body.confirm:
         raise HTTPException(

--- a/backend/src/school/router.py
+++ b/backend/src/school/router.py
@@ -22,7 +22,14 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from src.auth.dependencies import get_current_student, get_current_teacher
 from src.core.db import get_db
+from src.core.events import emit_event, write_audit_log
+from src.core.permissions import has_any_curriculum_capability
 from src.core.storage import get_storage
+from src.school.capability_guards import (
+    require_commission,
+    require_curriculum_view,
+    require_review,
+)
 from src.school.enrolment_service import (
     assign_student,
     get_roster,
@@ -38,6 +45,7 @@ from src.school.schemas import (
     AssignStudentRequest,
     BulkReassignRequest,
     BulkReassignResponse,
+    CapabilityGrantRequest,
     CatalogResponse,
     ClassroomCreateRequest,
     ClassroomDetailResponse,
@@ -75,6 +83,7 @@ from src.school.schemas import (
     SetupStatusResponse,
     StudentAssignmentRequest,
     StudentAssignmentResponse,
+    TeacherCapabilitiesResponse,
     TeacherGradeAssignRequest,
     TeacherGradeAssignResponse,
     TeacherInviteRequest,
@@ -564,12 +573,18 @@ async def list_teachers(
             SELECT t.teacher_id::text, t.name, t.email, t.role,
                    t.account_status::text,
                    COALESCE(
-                       array_agg(tga.grade ORDER BY tga.grade)
+                       array_agg(DISTINCT tga.grade ORDER BY tga.grade)
                        FILTER (WHERE tga.grade IS NOT NULL), '{}'
-                   ) AS assigned_grades
+                   ) AS assigned_grades,
+                   COALESCE(
+                       array_agg(DISTINCT tc.capability)
+                       FILTER (WHERE tc.capability IS NOT NULL), '{}'
+                   ) AS capabilities
             FROM teachers t
             LEFT JOIN teacher_grade_assignments tga
                 ON tga.teacher_id = t.teacher_id
+            LEFT JOIN teacher_capabilities tc
+                ON tc.teacher_id = t.teacher_id
             WHERE t.school_id = $1
             GROUP BY t.teacher_id, t.name, t.email, t.role, t.account_status
             ORDER BY t.name
@@ -585,6 +600,7 @@ async def list_teachers(
                 "role": r["role"],
                 "account_status": r["account_status"],
                 "assigned_grades": list(r["assigned_grades"]),
+                "capabilities": sorted(r["capabilities"]),
             }
             for r in rows
         ]
@@ -670,6 +686,102 @@ async def assign_teacher_grades(
         teacher_id=teacher_id,
         school_id=school_id,
         assigned_grades=sorted(body.grades),
+    )
+
+
+# ── Curriculum-management capabilities (issue #358) ──────────────────────────
+
+
+@router.put(
+    "/schools/{school_id}/teachers/{teacher_id}/capabilities",
+    response_model=TeacherCapabilitiesResponse,
+)
+async def set_teacher_capabilities(
+    school_id: str,
+    teacher_id: str,
+    body: CapabilityGrantRequest,
+    request: Request,
+    teacher: Annotated[dict, Depends(get_current_teacher)],
+) -> TeacherCapabilitiesResponse:
+    """Replace a teacher's curriculum capabilities (school_admin only).
+
+    Full-replace set semantics: the request body is the complete desired set, so
+    sending `[]` revokes all. Unknown capabilities are rejected (422) at the
+    schema layer. school_admin is an implicit superset and never needs a grant.
+    """
+    _require_school_admin(teacher, school_id, request)
+
+    import uuid as _uuid
+
+    tid = _uuid.UUID(teacher_id)
+    sid = _uuid.UUID(school_id)
+    granted_by = _uuid.UUID(teacher["teacher_id"])
+
+    async with get_db(request) as conn:
+        exists = await conn.fetchval(
+            "SELECT 1 FROM teachers WHERE teacher_id = $1 AND school_id = $2", tid, sid
+        )
+        if not exists:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "error": "not_found",
+                    "detail": "Teacher not found in this school.",
+                    "correlation_id": _cid(request),
+                },
+            )
+        async with conn.transaction():
+            await conn.execute("DELETE FROM teacher_capabilities WHERE teacher_id = $1", tid)
+            if body.capabilities:
+                await conn.executemany(
+                    """
+                    INSERT INTO teacher_capabilities (teacher_id, school_id, capability, granted_by)
+                    VALUES ($1, $2, $3, $4)
+                    ON CONFLICT (teacher_id, capability) DO NOTHING
+                    """,
+                    [(tid, sid, cap, granted_by) for cap in body.capabilities],
+                )
+
+    emit_event(
+        "school",
+        "capabilities_changed",
+        school_id=school_id,
+        teacher_id=teacher_id,
+        capabilities=body.capabilities,
+    )
+    write_audit_log(
+        event_type="teacher.capabilities_changed",
+        actor_type="teacher",
+        actor_id=granted_by,
+        target_type="teacher",
+        target_id=tid,
+        metadata={"capabilities": body.capabilities, "school_id": school_id},
+    )
+    return TeacherCapabilitiesResponse(teacher_id=teacher_id, capabilities=body.capabilities)
+
+
+@router.get(
+    "/schools/{school_id}/teachers/{teacher_id}/capabilities",
+    response_model=TeacherCapabilitiesResponse,
+)
+async def get_teacher_capabilities(
+    school_id: str,
+    teacher_id: str,
+    request: Request,
+    teacher: Annotated[dict, Depends(get_current_teacher)],
+) -> TeacherCapabilitiesResponse:
+    """Read a teacher's curriculum capabilities (school_admin only)."""
+    _require_school_admin(teacher, school_id, request)
+
+    import uuid as _uuid
+
+    async with get_db(request) as conn:
+        rows = await conn.fetch(
+            "SELECT capability FROM teacher_capabilities WHERE teacher_id = $1",
+            _uuid.UUID(teacher_id),
+        )
+    return TeacherCapabilitiesResponse(
+        teacher_id=teacher_id, capabilities=sorted(r["capability"] for r in rows)
     )
 
 
@@ -1262,8 +1374,10 @@ async def list_definitions_endpoint(
     if teacher["school_id"] != school_id:
         raise HTTPException(status_code=403, detail="Forbidden")
 
-    is_admin = teacher.get("role") == "school_admin"
-    teacher_filter = None if is_admin else teacher["teacher_id"]
+    # Anyone with a curriculum capability (or school_admin) sees the whole
+    # pending-approval queue; a plain proposing teacher sees only their own.
+    can_view_all = teacher.get("role") == "school_admin" or has_any_curriculum_capability(teacher)
+    teacher_filter = None if can_view_all else teacher["teacher_id"]
 
     async with get_db(request) as conn:
         definitions = await list_definitions(
@@ -1301,8 +1415,8 @@ async def get_definition_endpoint(
     if not defn:
         raise HTTPException(status_code=404, detail="Definition not found")
 
-    is_admin = teacher.get("role") == "school_admin"
-    if not is_admin and defn["submitted_by"] != teacher["teacher_id"]:
+    can_view_all = teacher.get("role") == "school_admin" or has_any_curriculum_capability(teacher)
+    if not can_view_all and defn["submitted_by"] != teacher["teacher_id"]:
         raise HTTPException(status_code=403, detail="Forbidden")
 
     return CurriculumDefinitionResponse(**defn)
@@ -1324,10 +1438,7 @@ async def approve_definition_endpoint(
     After approval the school admin can trigger the pipeline (Phase E).
     Returns 409 if the definition is not in 'pending_approval' state.
     """
-    if teacher.get("role") != "school_admin":
-        raise HTTPException(status_code=403, detail="Only school_admin can approve definitions")
-    if teacher["school_id"] != school_id:
-        raise HTTPException(status_code=403, detail="Forbidden")
+    require_commission(teacher, school_id, request)
 
     async with get_db(request) as conn:
         result = await approve_definition(
@@ -1360,10 +1471,7 @@ async def reject_definition_endpoint(
     The rejection reason is stored and surfaced to the submitting teacher.
     Returns 409 if the definition is not in 'pending_approval' state.
     """
-    if teacher.get("role") != "school_admin":
-        raise HTTPException(status_code=403, detail="Only school_admin can reject definitions")
-    if teacher["school_id"] != school_id:
-        raise HTTPException(status_code=403, detail="Forbidden")
+    require_commission(teacher, school_id, request)
 
     async with get_db(request) as conn:
         result = await reject_definition(
@@ -1555,7 +1663,7 @@ async def adopt_curriculum(
     idempotent: if the curriculum is already adopted, it returns the existing
     adoption record.
     """
-    _require_school_admin(teacher, school_id, request)
+    require_commission(teacher, school_id, request)
 
     async with get_db(request) as conn:
         # Verify the curriculum exists and is a platform OOB curriculum.
@@ -1645,7 +1753,7 @@ async def update_adoption(
     school_admin only. Deactivating does NOT delete the fork or any overrides —
     it only hides the curriculum from the active library view.
     """
-    _require_school_admin(teacher, school_id, request)
+    require_commission(teacher, school_id, request)
 
     if body.status is None and body.notes is None:
         raise HTTPException(status_code=422, detail="Nothing to update")
@@ -2159,7 +2267,7 @@ async def get_review_queue(
     """
     from src.school.schemas import ReviewQueueItem, ReviewQueueResponse
 
-    _require_school_admin(teacher, school_id, request)
+    require_curriculum_view(teacher, school_id, request)
 
     async with get_db(request) as conn:
         rows = await conn.fetch(
@@ -2849,7 +2957,7 @@ async def approve_unit_content(
     """
     from src.school.schemas import ApproveRequest
 
-    _require_school_admin(teacher, school_id, request)
+    require_review(teacher, school_id, request)
 
     if not isinstance(body, ApproveRequest):
         raise HTTPException(status_code=422, detail="Invalid body")
@@ -2930,7 +3038,7 @@ async def reject_unit_content(
     """
     from src.school.schemas import RejectRequest
 
-    _require_school_admin(teacher, school_id, request)
+    require_review(teacher, school_id, request)
 
     if not isinstance(body, RejectRequest):
         raise HTTPException(status_code=422, detail="Invalid body")
@@ -2984,7 +3092,7 @@ async def publish_unit_content(
     Upserts into unit_content_active_versions. Separate from approve() so the
     admin can batch-approve many units and then publish in one sweep.
     """
-    _require_school_admin(teacher, school_id, request)
+    require_review(teacher, school_id, request)
 
     async with get_db(request) as conn:
         await _assert_school_owns_curriculum(conn, school_id, curriculum_id)

--- a/backend/src/school/schemas.py
+++ b/backend/src/school/schemas.py
@@ -66,6 +66,7 @@ class TeacherRosterItem(BaseModel):
     role: str
     account_status: str
     assigned_grades: list[int]
+    capabilities: list[str] = []
 
 
 class TeacherRosterResponse(BaseModel):
@@ -80,6 +81,28 @@ class TeacherGradeAssignResponse(BaseModel):
     teacher_id: str
     school_id: str
     assigned_grades: list[int]
+
+
+class CapabilityGrantRequest(BaseModel):
+    """Full-replace set of curriculum capabilities to grant a teacher (issue #358)."""
+
+    capabilities: list[str]
+
+    @field_validator("capabilities")
+    @classmethod
+    def _validate_capabilities(cls, v: list[str]) -> list[str]:
+        # Imported here to avoid a module-load cycle (permissions imports fastapi).
+        from src.core.permissions import ALLOWED_CAPABILITIES
+
+        unknown = sorted({c for c in v if c not in ALLOWED_CAPABILITIES})
+        if unknown:
+            raise ValueError(f"Unknown capabilities: {unknown}")
+        return sorted(set(v))  # dedupe, deterministic order
+
+
+class TeacherCapabilitiesResponse(BaseModel):
+    teacher_id: str
+    capabilities: list[str]
 
 
 # ── Phase 9 — Enrolment ────────────────────────────────────────────────────────

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,9 +17,8 @@ from __future__ import annotations
 
 import asyncio
 import os
-import uuid
-from typing import AsyncGenerator
-from unittest.mock import AsyncMock, patch, MagicMock
+from collections.abc import AsyncGenerator
+from unittest.mock import patch
 
 import asyncpg
 import fakeredis.aioredis
@@ -50,9 +49,8 @@ os.environ.setdefault("CONTENT_STORE_PATH", "/tmp/studybuddy-test-content")
 # ── Now safe to import app ────────────────────────────────────────────────────
 
 from main import app
+
 from tests.helpers.token_factory import (
-    TEST_ADMIN_JWT_SECRET,
-    TEST_JWT_SECRET,
     make_admin_token,
     make_student_token,
     make_teacher_token,
@@ -164,11 +162,25 @@ async def client(fake_redis, db_conn) -> AsyncGenerator[AsyncClient, None]:
     Injects a fake Redis and a real asyncpg pool (pointing to test DB).
     Mocks all Celery task dispatch to be no-ops.
     """
-    pool = await asyncpg.create_pool(TEST_DB_URL, min_size=1, max_size=5, statement_cache_size=0)
+    # Mirror the production pool's connection init so json/jsonb columns are
+    # encoded/decoded with the same codecs (app_factory._init_db_conn). Without
+    # this the test pool returns/binds jsonb as raw strings and every jsonb
+    # write path fails with "expected str, got list" (regression after the
+    # asyncpg codec change in commit 7dec328).
+    from src.core.app_factory import _init_db_conn
+
+    pool = await asyncpg.create_pool(
+        TEST_DB_URL,
+        min_size=1,
+        max_size=5,
+        statement_cache_size=0,
+        init=_init_db_conn,
+    )
     app.state.pool = pool
     app.state.redis = fake_redis
 
     from config import settings as _cfg
+
     from src.core.limiter import limiter
     from src.core.storage import LocalStorage
     app.state.limiter = limiter

--- a/backend/tests/helpers/token_factory.py
+++ b/backend/tests/helpers/token_factory.py
@@ -67,6 +67,7 @@ def make_teacher_token(
     role: str = "teacher",
     account_status: str = "active",
     expire_minutes: int = 15,
+    capabilities: list[str] | None = None,
 ) -> str:
     """Return a signed teacher JWT for testing.
 
@@ -75,6 +76,9 @@ def make_teacher_token(
     teachers without a school affiliation).
 
     Omitting school_id (or passing the _UNSET sentinel) uses _DEFAULT_SCHOOL_ID.
+
+    capabilities populates the curriculum-capability grants (issue #358); the
+    real login/exchange/refresh mints read these from teacher_capabilities.
     """
     tid = teacher_id or _DEFAULT_TEACHER_ID
     sid = _DEFAULT_SCHOOL_ID if school_id is _UNSET else school_id
@@ -83,6 +87,7 @@ def make_teacher_token(
         "teacher_id": tid,
         "role": role,
         "account_status": account_status,
+        "capabilities": capabilities or [],
         "iat": now,
         "exp": now + timedelta(minutes=expire_minutes),
         "jti": str(uuid.uuid4()),

--- a/backend/tests/test_curriculum_mgmt_capability.py
+++ b/backend/tests/test_curriculum_mgmt_capability.py
@@ -1,0 +1,305 @@
+"""
+tests/test_curriculum_mgmt_capability.py
+
+Issue #358 — curriculum_mgmt additive capability.
+
+Covers:
+  has_capability / has_any_curriculum_capability helpers (unit, no DB)
+  PUT/GET /api/v1/schools/{id}/teachers/{tid}/capabilities  — assign / read
+  Three-tier guards on the curriculum endpoints:
+    Tier 0 view       — any curriculum capability (or school_admin)
+    Tier 1 commission — curriculum.commission | umbrella | school_admin
+    Tier 2 review     — curriculum.review     | umbrella | school_admin
+  Gate isolation (commission ≠ review) and the read/act split.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from src.core.permissions import has_any_curriculum_capability, has_capability
+from tests.helpers.token_factory import make_teacher_token
+
+_PW = "SecureTestPwd1!"
+
+_VALID_DEFN = {
+    "name": "Grade 8 STEM — Semester 1",
+    "grade": 8,
+    "languages": ["en"],
+    "subjects": [
+        {"subject_label": "Mathematics", "units": [{"title": "Quadratics"}]},
+    ],
+}
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+async def _register_school(client: AsyncClient, name: str, email: str) -> dict:
+    r = await client.post(
+        "/api/v1/schools/register",
+        json={"school_name": name, "contact_email": email, "country": "CA", "password": _PW},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _provision_teacher(
+    client: AsyncClient, school_id: str, admin_token: str, email: str
+) -> str:
+    with patch("src.email.service.send_welcome_teacher_email", new=AsyncMock()):
+        r = await client.post(
+            f"/api/v1/schools/{school_id}/teachers",
+            json={"name": "Test Teacher", "email": email},
+            headers=_auth(admin_token),
+        )
+    assert r.status_code == 201, r.text
+    return r.json()["teacher_id"]
+
+
+async def _grant(client, school_id, admin_token, tid, caps) -> None:
+    r = await client.put(
+        f"/api/v1/schools/{school_id}/teachers/{tid}/capabilities",
+        json={"capabilities": caps},
+        headers=_auth(admin_token),
+    )
+    assert r.status_code == 200, r.text
+
+
+async def _submit_defn(client, school_id, admin_token) -> str:
+    r = await client.post(
+        f"/api/v1/schools/{school_id}/curriculum/definitions",
+        json=_VALID_DEFN,
+        headers=_auth(admin_token),
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["definition_id"]
+
+
+# ── has_capability unit tests (no DB) ─────────────────────────────────────────
+
+
+def test_admin_has_all_capabilities():
+    assert has_capability({"role": "school_admin"}, "curriculum.commission") is True
+    assert has_capability({"role": "school_admin"}, "curriculum.review") is True
+
+
+def test_exact_grant_is_gate_isolated():
+    p = {"role": "teacher", "capabilities": ["curriculum.commission"]}
+    assert has_capability(p, "curriculum.commission") is True
+    assert has_capability(p, "curriculum.review") is False
+
+
+def test_umbrella_covers_both_gates():
+    p = {"role": "teacher", "capabilities": ["curriculum_mgmt"]}
+    assert has_capability(p, "curriculum.commission") is True
+    assert has_capability(p, "curriculum.review") is True
+
+
+def test_missing_capabilities_key_defaults_false():
+    assert has_capability({"role": "teacher"}, "curriculum.review") is False
+
+
+def test_any_curriculum_capability():
+    assert has_any_curriculum_capability({"role": "teacher", "capabilities": ["curriculum.review"]})
+    assert has_any_curriculum_capability({"role": "school_admin"})
+    assert not has_any_curriculum_capability({"role": "teacher", "capabilities": []})
+
+
+# ── Assign endpoint ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_admin_grants_and_reads_back(client: AsyncClient, db_conn) -> None:
+    school = await _register_school(client, "Cap S1", "cap1@example.com")
+    sid, admin = school["school_id"], school["access_token"]
+    tid = await _provision_teacher(client, sid, admin, "t1@example.com")
+
+    r = await client.put(
+        f"/api/v1/schools/{sid}/teachers/{tid}/capabilities",
+        json={"capabilities": ["curriculum.commission"]},
+        headers=_auth(admin),
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["capabilities"] == ["curriculum.commission"]
+
+    r = await client.get(
+        f"/api/v1/schools/{sid}/teachers/{tid}/capabilities", headers=_auth(admin)
+    )
+    assert r.json()["capabilities"] == ["curriculum.commission"]
+
+
+@pytest.mark.asyncio
+async def test_revocation(client: AsyncClient, db_conn) -> None:
+    school = await _register_school(client, "Cap S2", "cap2@example.com")
+    sid, admin = school["school_id"], school["access_token"]
+    tid = await _provision_teacher(client, sid, admin, "t2@example.com")
+
+    await _grant(client, sid, admin, tid, ["curriculum_mgmt"])
+    await _grant(client, sid, admin, tid, [])  # revoke
+
+    r = await client.get(
+        f"/api/v1/schools/{sid}/teachers/{tid}/capabilities", headers=_auth(admin)
+    )
+    assert r.json()["capabilities"] == []
+
+
+@pytest.mark.asyncio
+async def test_assign_requires_admin(client: AsyncClient, db_conn) -> None:
+    school = await _register_school(client, "Cap S3", "cap3@example.com")
+    sid = school["school_id"]
+    cm = make_teacher_token(
+        teacher_id="d2000000-0000-0000-0000-000000000099",
+        school_id=sid,
+        role="teacher",
+        capabilities=["curriculum_mgmt"],
+    )
+    r = await client.put(
+        f"/api/v1/schools/{sid}/teachers/d2000000-0000-0000-0000-000000000098/capabilities",
+        json={"capabilities": ["curriculum_mgmt"]},
+        headers=_auth(cm),
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_cross_school_grant_forbidden(client: AsyncClient, db_conn) -> None:
+    school = await _register_school(client, "Cap S4", "cap4@example.com")
+    sid = school["school_id"]
+    other_admin = make_teacher_token(
+        teacher_id="d2000000-0000-0000-0000-000000000097",
+        school_id="d3000000-0000-0000-0000-0000000000ff",
+        role="school_admin",
+    )
+    r = await client.put(
+        f"/api/v1/schools/{sid}/teachers/d2000000-0000-0000-0000-000000000096/capabilities",
+        json={"capabilities": ["curriculum_mgmt"]},
+        headers=_auth(other_admin),
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("caps", [["bogus_cap"], ["curriculum_mgmt", "bogus"]])
+async def test_unknown_capability_rejected(client: AsyncClient, db_conn, caps) -> None:
+    school = await _register_school(client, f"Cap S5 {caps}", f"cap5{len(caps[0])}@example.com")
+    sid, admin = school["school_id"], school["access_token"]
+    tid = await _provision_teacher(client, sid, admin, f"t5{len(caps[0])}@example.com")
+    r = await client.put(
+        f"/api/v1/schools/{sid}/teachers/{tid}/capabilities",
+        json={"capabilities": caps},
+        headers=_auth(admin),
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_unknown_teacher_404(client: AsyncClient, db_conn) -> None:
+    school = await _register_school(client, "Cap S6", "cap6@example.com")
+    sid, admin = school["school_id"], school["access_token"]
+    r = await client.put(
+        f"/api/v1/schools/{sid}/teachers/d2000000-0000-0000-0000-0000000000aa/capabilities",
+        json={"capabilities": ["curriculum_mgmt"]},
+        headers=_auth(admin),
+    )
+    assert r.status_code == 404
+
+
+# ── Gate 1 (commission) guard on approve_definition ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_commission_teacher_can_approve_definition(client: AsyncClient, db_conn) -> None:
+    school = await _register_school(client, "Cap G1", "g1@example.com")
+    sid, admin = school["school_id"], school["access_token"]
+    tid = await _provision_teacher(client, sid, admin, "g1t@example.com")
+    await _grant(client, sid, admin, tid, ["curriculum.commission"])
+    defn_id = await _submit_defn(client, sid, admin)
+
+    tok = make_teacher_token(
+        teacher_id=tid, school_id=sid, role="teacher", capabilities=["curriculum.commission"]
+    )
+    r = await client.post(
+        f"/api/v1/schools/{sid}/curriculum/definitions/{defn_id}/approve", headers=_auth(tok)
+    )
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.asyncio
+async def test_plain_teacher_cannot_approve_definition(client: AsyncClient, db_conn) -> None:
+    school = await _register_school(client, "Cap G2", "g2@example.com")
+    sid, admin = school["school_id"], school["access_token"]
+    defn_id = await _submit_defn(client, sid, admin)
+    tok = make_teacher_token(
+        teacher_id="d2000000-0000-0000-0000-0000000000b1", school_id=sid, role="teacher"
+    )
+    r = await client.post(
+        f"/api/v1/schools/{sid}/curriculum/definitions/{defn_id}/approve", headers=_auth(tok)
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_school_admin_implicit_approve(client: AsyncClient, db_conn) -> None:
+    school = await _register_school(client, "Cap G3", "g3@example.com")
+    sid, admin = school["school_id"], school["access_token"]
+    defn_id = await _submit_defn(client, sid, admin)
+    r = await client.post(
+        f"/api/v1/schools/{sid}/curriculum/definitions/{defn_id}/approve", headers=_auth(admin)
+    )
+    assert r.status_code == 200, r.text
+
+
+# ── Gate isolation + read/act split ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_review_grant_cannot_clear_commission_gate(client: AsyncClient, db_conn) -> None:
+    school = await _register_school(client, "Cap GI", "gi@example.com")
+    sid, admin = school["school_id"], school["access_token"]
+    defn_id = await _submit_defn(client, sid, admin)
+    tok = make_teacher_token(
+        teacher_id="d2000000-0000-0000-0000-0000000000c1",
+        school_id=sid,
+        role="teacher",
+        capabilities=["curriculum.review"],
+    )
+    r = await client.post(
+        f"/api/v1/schools/{sid}/curriculum/definitions/{defn_id}/approve", headers=_auth(tok)
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cap", ["curriculum.commission", "curriculum.review", "curriculum_mgmt"]
+)
+async def test_any_capability_can_view_review_queue(client: AsyncClient, db_conn, cap) -> None:
+    school = await _register_school(client, f"Cap V {cap}", f"v{cap[-4:]}@example.com")
+    sid = school["school_id"]
+    tok = make_teacher_token(
+        teacher_id="d2000000-0000-0000-0000-0000000000d1",
+        school_id=sid,
+        role="teacher",
+        capabilities=[cap],
+    )
+    r = await client.get(f"/api/v1/schools/{sid}/content/review-queue", headers=_auth(tok))
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.asyncio
+async def test_plain_teacher_cannot_view_review_queue(client: AsyncClient, db_conn) -> None:
+    school = await _register_school(client, "Cap VP", "vp@example.com")
+    sid = school["school_id"]
+    tok = make_teacher_token(
+        teacher_id="d2000000-0000-0000-0000-0000000000e1", school_id=sid, role="teacher"
+    )
+    r = await client.get(f"/api/v1/schools/{sid}/content/review-queue", headers=_auth(tok))
+    assert r.status_code == 403

--- a/docs/DESIGN_curriculum_mgmt_capability.md
+++ b/docs/DESIGN_curriculum_mgmt_capability.md
@@ -1,6 +1,6 @@
 # Design — `curriculum_mgmt` capability
 
-**Status:** Proposed · **Date:** 2026-05-21 · **Extends:** [ADR-001](ADR_001_tenancy_and_subscription_model.md) (role model)
+**Status:** Implemented (migration 0059, branch `feat/curriculum-mgmt-capability`, issue #358) · **Date:** 2026-05-21 · **Extends:** [ADR-001](ADR_001_tenancy_and_subscription_model.md) (role model)
 
 Lets a school_admin delegate curriculum-management powers to a chosen teacher
 **without** promoting them to full school_admin, and groups all curriculum nav

--- a/docs/SPEC_curriculum_mgmt_capability.md
+++ b/docs/SPEC_curriculum_mgmt_capability.md
@@ -1,11 +1,13 @@
 # Spec — `curriculum_mgmt` capability
 
-**Status:** Awaiting approval (spec-first; no source touched) · **Date:** 2026-05-21
+**Status:** Implemented (migration **0059**; issue #358) · **Date:** 2026-05-21
 **Design:** [DESIGN_curriculum_mgmt_capability.md](DESIGN_curriculum_mgmt_capability.md)
 
 Grounded patterns: guard helper `_require_school_admin(teacher, school_id, request)`
-at `backend/src/school/router.py:407`; test tokens via `make_teacher_token(...)` in
-`backend/tests/helpers/token_factory.py`; next migration = **0058**.
+at `backend/src/school/router.py`; capability guards in `backend/src/school/capability_guards.py`;
+test tokens via `make_teacher_token(..., capabilities=[...])` in
+`backend/tests/helpers/token_factory.py`. Migration landed as **0059** (0058 was
+taken by `demo_request_name`).
 
 ---
 
@@ -361,6 +363,15 @@ CREATE INDEX ix_teacher_capabilities_school ON teacher_capabilities(school_id);
 - **Revocation latency** (design open-Q #1): spec trusts the JWT claim; a removed grant is honored until token expiry. The revocation test asserts the *grant store* is cleared, not that live tokens are killed. Flag if instant revoke required → adds a per-request grant check.
 
 ---
+
+## Implementation notes (2026-05-21)
+
+- Migration landed as **0059** (0058 was `demo_request_name`, undocumented drift — now added to the CLAUDE.md table).
+- Guards live in `backend/src/school/capability_guards.py` (`require_curriculum_view` / `require_commission` / `require_review`), wired into `school/router.py` and `pipeline_router.py`. The school "load new curriculum" surface = `POST …/curriculum/upload` + the pipeline triggers, all now commission-gated.
+- JWT mint adds `capabilities[]` on **all four** teacher token paths: `/auth/login`, `/auth/universal-login`, `/auth/refresh` (so it survives the ~15-min cycle), and the Auth0 teacher exchange.
+- **Harness fix:** the conftest test pool was missing the production jsonb codec (`init=_init_db_conn`), which had silently broken every jsonb-write endpoint in tests since the May-19 codec commit. Added it — un-breaks `test_phase_d_definitions` (19) + `test_epic12_content_authoring` (27).
+- **e2e deferred:** the 3 persona Playwright specs are not yet committed (require host browser per pitfall #26 + persona-capability fixtures); the vitest + backend guard matrix cover the gating logic. Tracked as follow-up on #358.
+- **Pre-existing failures unrelated to this work:** 19 full-suite failures remain on `main` (pipeline `ModuleNotFoundError`; `curricula` platform-write RLS, pitfall #28) — verified independent of these changes.
 
 ## Resolved decisions (2026-05-21)
 

--- a/web/app/(school)/school/teachers/page.tsx
+++ b/web/app/(school)/school/teachers/page.tsx
@@ -9,6 +9,8 @@ import {
   provisionTeacher,
   resetTeacherPassword,
   promoteTeacher,
+  setTeacherCapabilities,
+  CURRICULUM_CAPABILITIES,
   type TeacherRosterItem,
 } from "@/lib/api/school-admin";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -26,9 +28,16 @@ import {
   X,
   KeyRound,
   Crown,
+  BookMarked,
 } from "lucide-react";
 
 const ALL_GRADES = [5, 6, 7, 8, 9, 10, 11, 12];
+
+const CAP_LABELS: Record<string, string> = {
+  "curriculum.commission": "Commission",
+  "curriculum.review": "Review",
+  curriculum_mgmt: "Curriculum Mgmt",
+};
 
 // ── Grade badge chip ──────────────────────────────────────────────────────────
 
@@ -110,6 +119,73 @@ function GradeEditor({
   );
 }
 
+// ── Inline capability editor (issue #358) ────────────────────────────────────
+
+function CapabilityEditor({
+  teacherId,
+  schoolId,
+  current,
+  onDone,
+}: {
+  teacherId: string;
+  schoolId: string;
+  current: string[];
+  onDone: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [selected, setSelected] = useState<Set<string>>(new Set(current));
+  const [error, setError] = useState<string | null>(null);
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: () => setTeacherCapabilities(schoolId, teacherId, [...selected]),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["teachers", schoolId] });
+      onDone();
+    },
+    onError: () => setError("Failed to save. Please try again."),
+  });
+
+  function toggle(cap: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(cap)) next.delete(cap);
+      else next.add(cap);
+      return next;
+    });
+  }
+
+  return (
+    <div className="mt-2 rounded-lg border border-blue-100 bg-blue-50 p-3">
+      <p className="mb-2 text-xs font-medium text-gray-600">
+        Curriculum capabilities — grant the two gates separately for maker-checker, or
+        the umbrella for both:
+      </p>
+      <div className="space-y-1.5">
+        {CURRICULUM_CAPABILITIES.map((c) => (
+          <label key={c.value} className="flex items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={selected.has(c.value)}
+              onChange={() => toggle(c.value)}
+              className="h-4 w-4 rounded border-gray-300 text-blue-600"
+            />
+            {c.label}
+          </label>
+        ))}
+      </div>
+      {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
+      <div className="mt-3 flex gap-2">
+        <Button size="sm" onClick={() => mutate()} disabled={isPending}>
+          {isPending ? "Saving…" : "Save"}
+        </Button>
+        <Button size="sm" variant="outline" onClick={onDone} disabled={isPending}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 // ── Teacher row ───────────────────────────────────────────────────────────────
 
 function TeacherRow({
@@ -123,6 +199,7 @@ function TeacherRow({
 }) {
   const queryClient = useQueryClient();
   const [editing, setEditing] = useState(false);
+  const [editingCaps, setEditingCaps] = useState(false);
   const [confirmReset, setConfirmReset] = useState(false);
   const [confirmPromote, setConfirmPromote] = useState(false);
   const [actionMsg, setActionMsg] = useState<string | null>(null);
@@ -185,6 +262,21 @@ function TeacherRow({
               <span className="text-xs text-gray-400 italic">No grades assigned</span>
             )}
           </div>
+
+          {/* Curriculum capabilities (issue #358) — admins have these implicitly */}
+          {item.role !== "school_admin" && item.capabilities.length > 0 && (
+            <div className="mt-2 flex flex-wrap items-center gap-1.5">
+              {item.capabilities.map((c) => (
+                <span
+                  key={c}
+                  className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700"
+                >
+                  <BookMarked className="h-3 w-3" />
+                  {CAP_LABELS[c] ?? c}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
 
         {/* Action buttons */}
@@ -215,6 +307,17 @@ function TeacherRow({
               title="Reset password"
             >
               <KeyRound className="h-4 w-4" />
+            </button>
+          )}
+          {isAdmin && item.role !== "school_admin" && (
+            <button
+              type="button"
+              onClick={() => setEditingCaps((v) => !v)}
+              className="rounded-md p-1.5 text-gray-400 hover:bg-blue-50 hover:text-blue-600"
+              aria-label="Edit curriculum capabilities"
+              title="Curriculum capabilities"
+            >
+              <BookMarked className="h-4 w-4" />
             </button>
           )}
           <button
@@ -330,6 +433,15 @@ function TeacherRow({
           schoolId={schoolId}
           current={item.assigned_grades}
           onDone={() => setEditing(false)}
+        />
+      )}
+
+      {editingCaps && (
+        <CapabilityEditor
+          teacherId={item.teacher_id}
+          schoolId={schoolId}
+          current={item.capabilities}
+          onDone={() => setEditingCaps(false)}
         />
       )}
     </div>

--- a/web/components/layout/CurriculumMenu.tsx
+++ b/web/components/layout/CurriculumMenu.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Top-bar "Curriculum Management" dropdown (issue #358).
+ *
+ * Renders only when the logged-in teacher holds a curriculum capability (or is a
+ * school_admin superset) — see canManageCurriculum. Groups the curriculum nav
+ * that used to live in the left rail. This is a convenience surface; the backend
+ * enforces each action's gate independently (hiding a link is never the control).
+ */
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { BookMarked, ChevronDown } from "lucide-react";
+import { canManageCurriculum, useTeacher } from "@/lib/hooks/useTeacher";
+import { cn } from "@/lib/utils";
+
+const CURRICULUM_LINKS: { label: string; href: string }[] = [
+  { label: "Browse Catalog", href: "/school/catalog" },
+  { label: "Our Library", href: "/school/library" },
+  { label: "Content Library", href: "/school/curriculum/content" },
+  { label: "Curriculum Builder", href: "/school/curriculum" },
+  { label: "Review Queue", href: "/school/review" },
+];
+
+export function CurriculumMenu() {
+  const teacher = useTeacher();
+  const pathname = usePathname() ?? "";
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, []);
+
+  // Hidden entirely unless the teacher may manage curriculum.
+  if (!canManageCurriculum(teacher)) return null;
+
+  const active = CURRICULUM_LINKS.some((l) => pathname.startsWith(l.href));
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          "flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm transition-colors",
+          active
+            ? "border-blue-500 bg-blue-50 font-medium text-blue-700"
+            : "border-gray-200 text-gray-600 hover:border-gray-400 hover:text-gray-900",
+        )}
+      >
+        <BookMarked className="h-4 w-4" aria-hidden />
+        Curriculum Management
+        <ChevronDown className="h-3.5 w-3.5" aria-hidden />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 z-50 mt-1 w-52 rounded-md border border-gray-100 bg-white py-1 shadow-lg"
+        >
+          {CURRICULUM_LINKS.map((l) => (
+            <Link
+              key={l.href}
+              role="menuitem"
+              href={l.href}
+              onClick={() => setOpen(false)}
+              className={cn(
+                "block px-4 py-2 text-sm transition-colors",
+                pathname.startsWith(l.href)
+                  ? "bg-blue-50 font-medium text-blue-700"
+                  : "text-gray-700 hover:bg-gray-50",
+              )}
+            >
+              {l.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/layout/PortalHeader.tsx
+++ b/web/components/layout/PortalHeader.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { useDyslexia } from "@/lib/hooks/useDyslexia";
 import { Eye } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { CurriculumMenu } from "@/components/layout/CurriculumMenu";
 
 const PORTAL_ICONS = {
   public: { src: "/assets/home_banner.png", alt: "StudyBuddy" },
@@ -58,8 +59,10 @@ export function PortalHeader({
         />
       </div>
 
-      {/* Right: accessibility toggle + username + live datetime */}
+      {/* Right: curriculum menu (school) + accessibility toggle + username + live datetime */}
       <div className="flex items-center gap-3">
+        {/* Curriculum Management dropdown — renders only for capability holders (issue #358) */}
+        {portal === "school" && <CurriculumMenu />}
         {/* Dyslexia-friendly font toggle — accessible from topbar (Rule 18) */}
         <button
           onClick={() => toggleDyslexic()}

--- a/web/components/layout/SchoolNav.tsx
+++ b/web/components/layout/SchoolNav.tsx
@@ -16,18 +16,14 @@ import {
   HelpCircle,
   Mail,
   LogOut,
-  BookMarked,
   GraduationCap,
   Settings,
   Palette,
   CreditCard,
-  Library,
   Archive,
   HardDrive,
   Images,
   DoorOpen,
-  LayoutGrid,
-  ClipboardCheck,
   Database,
 } from "lucide-react";
 import { listReviewQueue } from "@/lib/api/school-admin";
@@ -61,32 +57,9 @@ const NAV_ITEMS: NavItem[] = [
     icon: <BarChart2 className="h-4 w-4" />,
     adminOnly: true,
   },
-  {
-    label: "Curriculum",
-    href: "/school/curriculum",
-    icon: <BookMarked className="h-4 w-4" />,
-  },
-  {
-    label: "Catalog",
-    href: "/school/catalog",
-    icon: <LayoutGrid className="h-4 w-4" />,
-  },
-  {
-    label: "Our Library",
-    href: "/school/library",
-    icon: <BookMarked className="h-4 w-4" />,
-  },
-  {
-    label: "Review Queue",
-    href: "/school/review",
-    icon: <ClipboardCheck className="h-4 w-4" />,
-    adminOnly: true,
-  },
-  {
-    label: "Content Library",
-    href: "/school/curriculum/content",
-    icon: <Library className="h-4 w-4" />,
-  },
+  // Curriculum nav (Curriculum Builder, Catalog, Our Library, Review Queue,
+  // Content Library) moved to the top-bar "Curriculum Management" menu, gated on
+  // the curriculum capability — see components/layout/CurriculumMenu.tsx (#358).
   { label: "Students", href: "/school/students", icon: <Users className="h-4 w-4" /> },
   {
     label: "Teachers",

--- a/web/lib/api/school-admin.ts
+++ b/web/lib/api/school-admin.ts
@@ -376,6 +376,26 @@ export interface TeacherRosterItem {
   role: string;
   account_status: string;
   assigned_grades: number[];
+  capabilities: string[];
+}
+
+/** Curriculum-management capabilities a school_admin can grant (issue #358). */
+export const CURRICULUM_CAPABILITIES = [
+  { value: "curriculum.commission", label: "Commission (create / load / approve definitions)" },
+  { value: "curriculum.review", label: "Review (approve / publish generated content)" },
+  { value: "curriculum_mgmt", label: "Full curriculum management (both gates)" },
+] as const;
+
+export async function setTeacherCapabilities(
+  schoolId: string,
+  teacherId: string,
+  capabilities: string[],
+): Promise<{ teacher_id: string; capabilities: string[] }> {
+  const res = await schoolApi.put(
+    `/schools/${schoolId}/teachers/${teacherId}/capabilities`,
+    { capabilities },
+  );
+  return res.data;
 }
 
 export async function listTeachers(schoolId: string): Promise<TeacherRosterItem[]> {

--- a/web/lib/hooks/useTeacher.ts
+++ b/web/lib/hooks/useTeacher.ts
@@ -10,6 +10,9 @@ export interface TeacherClaims {
   teacher_id: string;
   school_id: string;
   role: "teacher" | "school_admin";
+  /** Additive curriculum-management capabilities (issue #358). Empty for teachers
+   *  with no grants. school_admin is an implicit superset (see canManageCurriculum). */
+  capabilities: string[];
   /** True when logged in with a system-issued default password — client must redirect to change-password */
   first_login: boolean;
 }
@@ -24,27 +27,58 @@ function decodeJwtPayload(token: string): Record<string, unknown> | null {
   }
 }
 
+/** Pure claims-extraction from a decoded JWT payload. Exported for unit testing. */
+export function claimsFromPayload(
+  payload: Record<string, unknown> | null,
+): TeacherClaims | null {
+  if (!payload) return null;
+  const teacher_id = payload.teacher_id as string | undefined;
+  const school_id = payload.school_id as string | undefined;
+  const role = payload.role as string | undefined;
+  if (!teacher_id || !school_id) return null;
+  const rawCaps = payload.capabilities;
+  return {
+    teacher_id,
+    school_id,
+    role: (role === "school_admin"
+      ? "school_admin"
+      : "teacher") as TeacherClaims["role"],
+    // Never let the role coercion drop capabilities — default to [] when absent.
+    capabilities: Array.isArray(rawCaps) ? (rawCaps as string[]) : [],
+    first_login: Boolean(payload.first_login),
+  };
+}
+
 function readTeacherClaims(): TeacherClaims | null {
   try {
     const token = localStorage.getItem("sb_teacher_token");
     if (!token) return null;
-    const payload = decodeJwtPayload(token);
-    if (!payload) return null;
-    const teacher_id = payload.teacher_id as string | undefined;
-    const school_id = payload.school_id as string | undefined;
-    const role = payload.role as string | undefined;
-    if (!teacher_id || !school_id) return null;
-    return {
-      teacher_id,
-      school_id,
-      role: (role === "school_admin"
-        ? "school_admin"
-        : "teacher") as TeacherClaims["role"],
-      first_login: Boolean(payload.first_login),
-    };
+    return claimsFromPayload(decodeJwtPayload(token));
   } catch {
     return null;
   }
+}
+
+/** True if the teacher may manage curriculum at all (holds any curriculum
+ *  capability, or is a school_admin superset). Drives the top-bar menu. */
+export function canManageCurriculum(teacher: TeacherClaims | null): boolean {
+  if (!teacher) return false;
+  if (teacher.role === "school_admin") return true;
+  return teacher.capabilities.some((c) => c.startsWith("curriculum"));
+}
+
+/** True if the teacher can clear a specific gate (exact capability, the
+ *  curriculum_mgmt umbrella, or school_admin superset). */
+export function hasCapability(
+  teacher: TeacherClaims | null,
+  capability: "curriculum.commission" | "curriculum.review",
+): boolean {
+  if (!teacher) return false;
+  if (teacher.role === "school_admin") return true;
+  return (
+    teacher.capabilities.includes(capability) ||
+    teacher.capabilities.includes("curriculum_mgmt")
+  );
 }
 
 export function useTeacher(): TeacherClaims | null {

--- a/web/tests/unit/useTeacher-capabilities.test.ts
+++ b/web/tests/unit/useTeacher-capabilities.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  claimsFromPayload,
+  canManageCurriculum,
+  hasCapability,
+  type TeacherClaims,
+} from "@/lib/hooks/useTeacher";
+
+const base = { teacher_id: "t1", school_id: "s1" };
+
+describe("claimsFromPayload — capabilities (issue #358)", () => {
+  it("exposes capabilities array from the payload", () => {
+    const c = claimsFromPayload({ ...base, role: "teacher", capabilities: ["curriculum_mgmt"] });
+    expect(c?.capabilities).toEqual(["curriculum_mgmt"]);
+    expect(c?.role).toBe("teacher");
+  });
+
+  it("defaults capabilities to [] when absent (coercion must not drop it)", () => {
+    const c = claimsFromPayload({ ...base, role: "teacher" });
+    expect(c?.capabilities).toEqual([]);
+    expect(c?.role).toBe("teacher");
+  });
+
+  it("returns null when required ids are missing", () => {
+    expect(claimsFromPayload({ role: "teacher" })).toBeNull();
+    expect(claimsFromPayload(null)).toBeNull();
+  });
+});
+
+describe("canManageCurriculum", () => {
+  const make = (role: TeacherClaims["role"], caps: string[]): TeacherClaims => ({
+    ...base,
+    role,
+    capabilities: caps,
+    first_login: false,
+  });
+
+  it("true for school_admin (implicit superset)", () => {
+    expect(canManageCurriculum(make("school_admin", []))).toBe(true);
+  });
+  it("true for any curriculum capability", () => {
+    expect(canManageCurriculum(make("teacher", ["curriculum.review"]))).toBe(true);
+    expect(canManageCurriculum(make("teacher", ["curriculum.commission"]))).toBe(true);
+  });
+  it("false for a plain teacher", () => {
+    expect(canManageCurriculum(make("teacher", []))).toBe(false);
+    expect(canManageCurriculum(null)).toBe(false);
+  });
+});
+
+describe("hasCapability — gate isolation", () => {
+  const make = (caps: string[]): TeacherClaims => ({
+    ...base,
+    role: "teacher",
+    capabilities: caps,
+    first_login: false,
+  });
+
+  it("exact grant clears only its gate", () => {
+    const t = make(["curriculum.commission"]);
+    expect(hasCapability(t, "curriculum.commission")).toBe(true);
+    expect(hasCapability(t, "curriculum.review")).toBe(false);
+  });
+
+  it("umbrella clears both gates", () => {
+    const t = make(["curriculum_mgmt"]);
+    expect(hasCapability(t, "curriculum.commission")).toBe(true);
+    expect(hasCapability(t, "curriculum.review")).toBe(true);
+  });
+
+  it("school_admin clears both gates implicitly", () => {
+    const t: TeacherClaims = { ...base, role: "school_admin", capabilities: [], first_login: false };
+    expect(hasCapability(t, "curriculum.commission")).toBe(true);
+    expect(hasCapability(t, "curriculum.review")).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #358.

## What
Adds a grantable **`curriculum_mgmt`** capability so a school_admin can delegate curriculum-management powers to a teacher **without** promoting them to full school_admin. The grant is additive — carried in the JWT `capabilities[]` alongside the single `role` claim — and `school_admin` is an implicit superset.

Two distinct approval gates, each a separately-grantable capability (plus an umbrella), with a view/act split:

| Capability | Clears | Surfaces |
|---|---|---|
| `curriculum.commission` | Gate 1 — create/load/spend | adopt, definition approve/reject/estimate/trigger, curriculum upload + pipeline trigger |
| `curriculum.review` | Gate 2 — publish content | content approve/reject/publish |
| `curriculum_mgmt` | both (umbrella) | — |
| _any curriculum capability_ | **view** | definition list, content review-queue |

## Why
Schools need to let a trusted subject-matter teacher manage curriculum without handing over full admin (which also controls students, billing, teachers). Splitting commission vs publication enables maker-checker (grant the two gates to different people) while staying optional for small schools (umbrella to one person). Design + spec: `docs/DESIGN_curriculum_mgmt_capability.md`, `docs/SPEC_curriculum_mgmt_capability.md`.

## How
- **Migration 0059** `teacher_capabilities` — RLS, per-school tenant isolation (mirrors 0028/0050).
- `core/permissions.py`: `has_capability` / `has_any_curriculum_capability` + `ALLOWED_CAPABILITIES`.
- `school/capability_guards.py`: `require_curriculum_view` / `require_commission` / `require_review`, wired into `school/router.py` + `pipeline_router.py`.
- `PUT/GET /schools/{id}/teachers/{tid}/capabilities` (school_admin only).
- `capabilities[]` minted on **all four** teacher token paths: login, universal-login, refresh (survives the ~15-min cycle), Auth0 exchange.
- Frontend: `useTeacher` exposes `capabilities[]` + `canManageCurriculum`/`hasCapability`; top-bar **Curriculum Management** menu (gated); curriculum items removed from the left rail; capability assign UI on the teacher page.

## Alternatives considered
- **Standalone role** (replace `teacher` with `curriculum_mgmt`): cheaper, but a person can't be both a teacher and a curriculum manager. Rejected — doesn't match "assign to a persona."
- **Multi-role array** replacing single `role`: touches every `role ==` check across the codebase. Out of scope; the capability channel avoids it.
- **Single capability** (no commission/review split): deferred maker-checker. Rejected in favour of the two-gate model.

## Risk
- Low architectural risk; no change to the single-`role` model. Backend is the real gate (hiding the nav button is not the control).
- **Revocation latency**: a removed grant is honoured until the access token expires (~15 min). Accepted; per-request check is a future option if instant revoke is needed.
- **Tightening**: estimate/trigger/upload were previously open to any teacher in the school (`_assert_school_match` only) — now commission-gated. School_admin tokens are unaffected (superset), so existing tests pass.

## Test plan
- 20 backend tests (`test_curriculum_mgmt_capability.py`) — guard matrix, gate isolation, read/act split, `has_capability` unit.
- 9 vitest (`useTeacher-capabilities.test.ts`).
- Migration downgrade→upgrade cycle clean; `FORCE ROW LEVEL SECURITY` + `tenant_isolation` verified on the test DB.
- No regressions: school/pipeline (27), epic12 (27), phase_d (19), auth-related (148) all pass. Web typecheck/lint/build green; backend feature files ruff-clean.

## Notes for reviewers
- **Harness fix included**: the conftest test pool was missing the production jsonb codec (`init=_init_db_conn`), which had silently broken every jsonb-write endpoint in tests since the May-19 codec commit. Fixed here — un-breaks `test_phase_d_definitions` + `test_epic12_content_authoring` (which were failing on `main`).
- **Deferred**: 3 persona Playwright e2e specs (need host browser + capability fixtures, pitfall #26).
- **Pre-existing, unrelated**: 19 full-suite failures remain on `main` (pipeline `ModuleNotFoundError`; `curricula` platform-write RLS, pitfall #28) — verified independent of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)