### PR TITLE
fix(curriculum): school uploads must be owner_type='school' (RLS / pitfall #28)

### DIFF
--- a/backend/src/curriculum/upload_service.py
+++ b/backend/src/curriculum/upload_service.py
@@ -118,18 +118,28 @@ async def create_curriculum_from_json(
 
     curriculum_id = str(uuid.uuid4())
 
+    # A school-scoped upload must be owner_type='school' (not the column default
+    # 'platform'). Otherwise migration 0046's RESTRICTIVE no_write_platform_curricula_insert
+    # policy rejects the INSERT under any non-superuser session (pitfall #28) — it only
+    # "works" when the DB role is a superuser and bypasses FORCE RLS. owner_id mirrors
+    # school_id, matching the definition-trigger insert in pipeline_router.
+    sid = uuid.UUID(school_id) if school_id else None
+    owner_type = "school" if sid else "platform"
+
     await conn.execute(
         """
         INSERT INTO curricula
-            (curriculum_id, school_id, grade, year, name, source_type, status, created_by)
-        VALUES ($1, $2, $3, $4, $5, 'ui_form', 'draft', $6)
+            (curriculum_id, school_id, grade, year, name, source_type, status, created_by,
+             owner_type, owner_id)
+        VALUES ($1, $2, $3, $4, $5, 'ui_form', 'draft', $6, $7, $2)
         """,
         curriculum_id,
-        uuid.UUID(school_id) if school_id else None,
+        sid,
         grade,
         year,
         name,
         uuid.UUID(teacher_id) if teacher_id else None,
+        owner_type,
     )
 
     for seq, unit in enumerate(units, start=1):


### PR DESCRIPTION
## What
`POST /curriculum/upload` (JSON + XLSX, both via `create_curriculum_from_json`) inserted `curricula` rows **without** `owner_type`, falling back to the column default `'platform'`. Now sets `owner_type='school'` + `owner_id=school_id` for school-scoped uploads (matching the definition-trigger insert in `pipeline_router`), keeping the `'platform'` default only for the no-school path.

## Why
Migration 0046's RESTRICTIVE `no_write_platform_curricula_insert` policy rejects platform-owner `curricula` writes from any **non-superuser** session. The upload endpoint runs under tenant-stamped `get_db` (not bypass), so it only worked because the DB role happened to be a **superuser** that bypasses `FORCE ROW LEVEL SECURITY` — a latent production risk (pitfall #28), since production should not run as a superuser. Semantically, a school uploading its own curriculum is school-owned, not platform-wide (platform curricula are world-readable per 0028; school uploads should be tenant-scoped).

## How verified
Against the real RLS policy as a **non-superuser** role (rolled-back transaction): a `'platform'` insert is `InsufficientPrivilegeError`-blocked; a `'school'` insert clears the policy. The existing `test_curriculum_upload` + `test_enrolment` suites are the regression coverage — they fail under a non-superuser test DB without this fix and pass with it (and remain green under the superuser canonical runner).

## Risk
Low. Behavioural change: uploaded curricula become `owner_type='school'` (tenant-scoped) instead of `'platform'` (world-readable) — which is the correct, intended semantics. Matches the established `pipeline_router` pattern.

## Scope note
This is **1 of several** RLS-reliance issues that only surface under a non-superuser DB (the canonical `./dev_start.sh test` runner uses a superuser `studybuddy` that masks them). The systemic finding + remaining cases (test-fixture direct platform inserts, streams-merge UPDATE) are filed separately for a dedicated hardening pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)