### PR TITLE
fix(a11y): bump content reading-surface font sizes to 16px (#365)

### DIFF
--- a/web/app/(admin)/admin/content-review/[version_id]/unit/[unit_id]/page.tsx
+++ b/web/app/(admin)/admin/content-review/[version_id]/unit/[unit_id]/page.tsx
@@ -318,7 +318,7 @@ function ExampleBlock({ text }: { text: string }) {
   // fenced code for code-heavy examples.
   return (
     <div className="rounded-md border border-gray-100 bg-gray-50 p-3">
-      <SBMarkdown className="text-xs text-gray-800">{text}</SBMarkdown>
+      <SBMarkdown className="text-sm text-gray-800">{text}</SBMarkdown>
     </div>
   );
 }

--- a/web/app/(school)/school/curriculum/content/[version_id]/unit/[unit_id]/page.tsx
+++ b/web/app/(school)/school/curriculum/content/[version_id]/unit/[unit_id]/page.tsx
@@ -207,7 +207,7 @@ function TutorialRenderer({ data }: { data: Record<string, unknown> }) {
               </p>
               {activeSection.examples.map((ex, j) => (
                 <div key={j} className="rounded-md border border-gray-100 bg-gray-50 p-3">
-                  <SBMarkdown className="text-xs text-gray-800">{ex}</SBMarkdown>
+                  <SBMarkdown className="text-sm text-gray-800">{ex}</SBMarkdown>
                 </div>
               ))}
             </div>

--- a/web/components/content/Markdown.tsx
+++ b/web/components/content/Markdown.tsx
@@ -25,6 +25,11 @@ import { cn } from "@/lib/utils";
  *   - Blockquote: left-border indent, italic — the attribution line
  *     (when present as em-dashed suffix, per C-9) inherits the same style.
  *   - Math: KaTeX CSS is imported globally from globals.css.
+ *   - Base size: text-base (16px) for readable body copy on content reading
+ *     surfaces (#365, a11y). Tables/code step down to text-sm (14px); inline
+ *     code uses 0.9em so it scales with surrounding prose. Do NOT drop the
+ *     wrapper below text-base — callers that pass a smaller `className` size
+ *     win via tailwind-merge, so keep overrides at text-sm or larger.
  */
 export function SBMarkdown({
   children,
@@ -34,14 +39,14 @@ export function SBMarkdown({
   className?: string;
 }) {
   return (
-    <div className={cn("font-heading text-sm text-gray-700", className)}>
+    <div className={cn("font-heading text-base leading-relaxed text-gray-700", className)}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[rehypeKatex]}
         components={{
           table: ({ children }) => (
             <div className="my-3 overflow-x-auto">
-              <table className="w-full border-collapse text-xs">{children}</table>
+              <table className="w-full border-collapse text-sm">{children}</table>
             </div>
           ),
           thead: ({ children }) => (
@@ -81,19 +86,19 @@ export function SBMarkdown({
             const isBlock = cname?.includes("language-");
             if (isBlock) {
               return (
-                <pre className="my-2 overflow-x-auto rounded-md bg-gray-50 p-3 font-mono text-xs text-gray-800">
+                <pre className="my-2 overflow-x-auto rounded-md bg-gray-50 p-3 font-mono text-sm text-gray-800">
                   <code>{children}</code>
                 </pre>
               );
             }
             return (
-              <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-xs text-indigo-700">
+              <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-[0.9em] text-indigo-700">
                 {children}
               </code>
             );
           },
           blockquote: ({ children }) => (
-            <blockquote className="my-3 border-l-4 border-indigo-200 bg-indigo-50/50 px-4 py-2 text-sm text-gray-700 italic">
+            <blockquote className="my-3 border-l-4 border-indigo-200 bg-indigo-50/50 px-4 py-2 text-base text-gray-700 italic">
               {children}
             </blockquote>
           ),


### PR DESCRIPTION
Closes #365.

## What
Raises the font-size floor on AI-generated **content reading surfaces** so body copy is a comfortable 16px. All four content viewers (lesson / tutorial / quiz / experiment) render through one component, `SBMarkdown` (Epic 11 C-3 consolidation), so the change lands in a single place:

| Element | Before | After |
|---|---|---|
| Body copy | `text-sm` (14px) | **`text-base` (16px)** + `leading-relaxed` |
| Tables | `text-xs` (12px) | `text-sm` (14px) |
| Fenced code | `text-xs` | `text-sm` |
| Inline code | `text-xs` | `text-[0.9em]` (scales with body) |
| Blockquote | `text-sm` | `text-base` |

Two callers (`school/curriculum/content/.../unit` and `admin/content-review/.../unit` "Examples" blocks) overrode with `text-xs` — which wins via `tailwind-merge` — so they're bumped to `text-sm`. A docstring note pins the 16px floor against future regressions.

## Why
Demo feedback 2026-05-24 — Gayathri Gowtham (GG-1): *"Fonts too small and cannot view it."* Readability/a11y blocker, not polish. Typeface is unchanged (Ashokan/Kalpana praised it) — this is size only.

## Scope
Deliberately limited to **content reading surfaces** (the AC's target). Portal-chrome text density is tracked separately (#366 / #368), not rewritten here.

## Test plan
Verified in a real browser via Playwright against the dev server (units are rem-based so they scale with zoom; tables/code already wrap in `overflow-x-auto`):
- Computed sizes: paragraph **16px**, blockquote **16px**, table cell **14px**, code **14px**.
- At **200% zoom**: `document.scrollWidth == innerWidth` (1280=1280); zero non-table elements overflow horizontally — clean reflow.

## Acceptance criteria
- [x] Base body text ≥16px on content reading surfaces
- [x] Text reflows at 200% zoom with no clipping / horizontal scroll
- [x] Verified on the content rendering path

## Note for reviewer
Markdown `##`/`###` headings inside `SBMarkdown` render at body size (no `h1–h6` overrides + Tailwind preflight resets heading sizes), so they don't stand out as headings. Pre-existing, unrelated to this change — flagging as a possible follow-up if section bodies contain markdown headings in practice.

Related: a11y debt #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)