### PR TITLE
feat(school-nav): IA refresh — group rail, rename items, top-bar account menu (#367)

### DIFF
--- a/web/app/(school)/school/class/[class_id]/page.tsx
+++ b/web/app/(school)/school/class/[class_id]/page.tsx
@@ -143,7 +143,7 @@ export default function ClassOverviewPage() {
   return (
     <div className="max-w-5xl space-y-6 p-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-2xl font-bold text-gray-900">Class Overview</h1>
+        <h1 className="text-2xl font-bold text-gray-900">Student Progress</h1>
         <div className="flex flex-wrap items-center gap-3">
           {/* Scope toggle — default to "my students" so the page is focused for
               teachers who lead classrooms. Disabled / hidden when the user

--- a/web/app/(school)/school/content/[curriculum_id]/page.tsx
+++ b/web/app/(school)/school/content/[curriculum_id]/page.tsx
@@ -286,7 +286,7 @@ export default function ContentUnitsPage() {
         <div className="rounded-md border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-800">
           Navigate here from{" "}
           <a href="/school/library" className="underline">
-            Our Library
+            My Curricula
           </a>{" "}
           to enable Import actions.
         </div>

--- a/web/app/(school)/school/help/page.tsx
+++ b/web/app/(school)/school/help/page.tsx
@@ -20,12 +20,12 @@ const GETTING_STARTED_TEACHER = [
   },
   {
     step: "3",
-    title: "Class Overview — students you teach",
+    title: "Student Progress — students you teach",
     body: 'Same toggle pattern: "My students" shows everyone enrolled in classrooms you lead; "All school" shows the wider roster. Grade pills auto-narrow to grades present in the current view.',
   },
   {
     step: "4",
-    title: "Content Library",
+    title: "Lessons & Content",
     body: 'Browse AI-generated lessons, tutorials, quizzes, and activities. Default view is "My content" — the subjects your classrooms have adopted. Each subject row rolls up multiple regenerations into one — if you see a "4 versions" chip, the link opens the latest. Lesson images are clickable — tap to enlarge in a lightbox.',
   },
   {

--- a/web/app/(school)/school/library/page.tsx
+++ b/web/app/(school)/school/library/page.tsx
@@ -259,7 +259,7 @@ export default function LibraryPage() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <BookMarked className="h-6 w-6 text-indigo-600" />
-          <h1 className="text-2xl font-bold text-gray-900">Our Library</h1>
+          <h1 className="text-2xl font-bold text-gray-900">My Curricula</h1>
         </div>
         <LinkButton href="/school/catalog" size="sm">
           <LayoutGrid className="mr-1.5 h-4 w-4" />

--- a/web/components/layout/AccountMenu.tsx
+++ b/web/components/layout/AccountMenu.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+/**
+ * Top-bar account dropdown for the school/teacher portal (issue #367, AP-4).
+ *
+ * Per-user / account config (Settings, Digest Settings, Customize, Help) and
+ * Sign out used to live at the bottom of the left rail. Convention is for these
+ * to sit behind the username in the top bar — moving them here frees four rail
+ * slots and matches what reviewers expected. The username is the trigger.
+ */
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import {
+  ChevronDown,
+  Settings,
+  Mail,
+  Palette,
+  HelpCircle,
+  LogOut,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const ACCOUNT_LINKS: { label: string; href: string; icon: React.ReactNode }[] = [
+  { label: "Settings", href: "/school/settings", icon: <Settings className="h-4 w-4" /> },
+  { label: "Digest Settings", href: "/school/digest", icon: <Mail className="h-4 w-4" /> },
+  {
+    label: "Customize",
+    href: "/school/settings/customize",
+    icon: <Palette className="h-4 w-4" />,
+  },
+  { label: "Help", href: "/school/help", icon: <HelpCircle className="h-4 w-4" /> },
+];
+
+function handleLogout() {
+  if (typeof window !== "undefined") {
+    localStorage.removeItem("sb_teacher_token");
+    localStorage.removeItem("sb_teacher_refresh_token");
+    // /api/auth/logout clears session cookies and redirects to the correct
+    // destination (local-auth → /signin, Auth0 → /).
+    window.location.href = "/api/auth/logout";
+  }
+}
+
+export function AccountMenu({ userName }: { userName?: string }) {
+  const pathname = usePathname() ?? "";
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, []);
+
+  const active = ACCOUNT_LINKS.some((l) => pathname.startsWith(l.href));
+  const label = userName ?? "Account";
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Account menu"
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          "flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-sm transition-colors",
+          active || open
+            ? "border-blue-500 bg-blue-50 text-blue-700"
+            : "border-gray-200 text-gray-600 hover:border-gray-400 hover:text-gray-900",
+        )}
+      >
+        <span className="max-w-[160px] truncate font-medium">{label}</span>
+        <ChevronDown className="h-3.5 w-3.5" aria-hidden />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 z-50 mt-1 w-52 rounded-md border border-gray-100 bg-white py-1 shadow-lg"
+        >
+          {ACCOUNT_LINKS.map((l) => (
+            <Link
+              key={l.href}
+              role="menuitem"
+              href={l.href}
+              onClick={() => setOpen(false)}
+              className={cn(
+                "flex items-center gap-2.5 px-4 py-2 text-sm transition-colors",
+                pathname.startsWith(l.href)
+                  ? "bg-blue-50 font-medium text-blue-700"
+                  : "text-gray-700 hover:bg-gray-50",
+              )}
+            >
+              {l.icon}
+              {l.label}
+            </Link>
+          ))}
+          <div className="my-1 border-t border-gray-100" />
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              handleLogout();
+            }}
+            className="flex w-full items-center gap-2.5 px-4 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50"
+          >
+            <LogOut className="h-4 w-4" />
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/layout/CurriculumMenu.tsx
+++ b/web/components/layout/CurriculumMenu.tsx
@@ -16,10 +16,14 @@ import { BookMarked, ChevronDown } from "lucide-react";
 import { canManageCurriculum, useTeacher } from "@/lib/hooks/useTeacher";
 import { cn } from "@/lib/utils";
 
+// Labels name the verb/noun each surface actually represents (issue #367 AP-3).
+// Reviewers couldn't tell "Catalog" / "Our Library" / "Content Library" apart;
+// they are a pipeline: browse platform packages → adopt into your owned set →
+// open the generated lessons inside them.
 const CURRICULUM_LINKS: { label: string; href: string }[] = [
   { label: "Browse Catalog", href: "/school/catalog" },
-  { label: "Our Library", href: "/school/library" },
-  { label: "Content Library", href: "/school/curriculum/content" },
+  { label: "My Curricula", href: "/school/library" },
+  { label: "Lessons & Content", href: "/school/curriculum/content" },
   { label: "Curriculum Builder", href: "/school/curriculum" },
   { label: "Review Queue", href: "/school/review" },
 ];

--- a/web/components/layout/PortalHeader.tsx
+++ b/web/components/layout/PortalHeader.tsx
@@ -6,6 +6,7 @@ import { useDyslexia } from "@/lib/hooks/useDyslexia";
 import { Eye } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CurriculumMenu } from "@/components/layout/CurriculumMenu";
+import { AccountMenu } from "@/components/layout/AccountMenu";
 
 const PORTAL_ICONS = {
   public: { src: "/assets/home_banner.png", alt: "StudyBuddy" },
@@ -83,19 +84,34 @@ export function PortalHeader({
           <Eye className="h-4 w-4" aria-hidden />
         </button>
 
-        <div className="flex flex-col items-end text-sm">
-          {userName && (
-            <span className="max-w-[200px] truncate font-medium text-gray-700">
-              {userName}
-            </span>
-          )}
-          {now && (
-            <span className="whitespace-nowrap text-gray-500 tabular-nums">
-              {now.toLocaleDateString()}{" "}
-              {now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
-            </span>
-          )}
-        </div>
+        {/* School portal: username is the account-menu trigger (config + sign out
+            moved off the left rail — issue #367 AP-4). Other portals keep the
+            static username display. */}
+        {portal === "school" ? (
+          <div className="flex items-center gap-3">
+            <AccountMenu userName={userName} />
+            {now && (
+              <span className="hidden whitespace-nowrap text-sm text-gray-500 tabular-nums sm:inline">
+                {now.toLocaleDateString()}{" "}
+                {now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+              </span>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-col items-end text-sm">
+            {userName && (
+              <span className="max-w-[200px] truncate font-medium text-gray-700">
+                {userName}
+              </span>
+            )}
+            {now && (
+              <span className="whitespace-nowrap text-gray-500 tabular-nums">
+                {now.toLocaleDateString()}{" "}
+                {now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+              </span>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/components/layout/SchoolNav.tsx
+++ b/web/components/layout/SchoolNav.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
 import { useTeacher } from "@/lib/hooks/useTeacher";
 import { useSchoolTheme } from "@/lib/theme/SchoolThemeContext";
 import { useQuery } from "@tanstack/react-query";
@@ -10,23 +11,20 @@ import { cn } from "@/lib/utils";
 import {
   LayoutDashboard,
   Users,
+  LineChart,
   BarChart2,
   Bell,
   BookOpen,
-  HelpCircle,
-  Mail,
-  LogOut,
   GraduationCap,
-  Settings,
-  Palette,
   CreditCard,
   Archive,
   HardDrive,
   Images,
   DoorOpen,
   Database,
+  ChevronDown,
+  ChevronRight,
 } from "lucide-react";
-import { listReviewQueue } from "@/lib/api/school-admin";
 
 interface NavItem {
   label: string;
@@ -35,81 +33,96 @@ interface NavItem {
   adminOnly?: boolean;
 }
 
-const NAV_ITEMS: NavItem[] = [
+interface NavGroup {
+  /** Section heading; omit for the standalone top group (Dashboard). */
+  heading?: string;
+  items: NavItem[];
+  /** Collapsible groups render a toggle and hide items until expanded. */
+  collapsible?: boolean;
+  /** Whole group is hidden from non-admins. */
+  adminOnly?: boolean;
+}
+
+// Grouped navigation (issue #367, AP-1). Groups are ordered so Reports
+// (Insights) renders after Teachers (People) per VT-4. The curriculum nav
+// lives in the top-bar CurriculumMenu (#358); per-user config + sign out live
+// in the top-bar AccountMenu (#367 AP-4) — neither belongs in this rail.
+const NAV_GROUPS: NavGroup[] = [
   {
-    label: "Dashboard",
-    href: "/school/dashboard",
-    icon: <LayoutDashboard className="h-4 w-4" />,
+    items: [
+      {
+        label: "Dashboard",
+        href: "/school/dashboard",
+        icon: <LayoutDashboard className="h-4 w-4" />,
+      },
+    ],
   },
   {
-    label: "Classrooms",
-    href: "/school/classrooms",
-    icon: <DoorOpen className="h-4 w-4" />,
+    heading: "Teach",
+    items: [
+      {
+        label: "Classrooms",
+        href: "/school/classrooms",
+        icon: <DoorOpen className="h-4 w-4" />,
+      },
+      {
+        // Renamed from "Class Overview" (AP-2): this is a per-student
+        // performance table, not a per-class view. Distinct icon from
+        // "Students" (was a duplicate <Users>) per VT-5.
+        label: "Student Progress",
+        href: "/school/class/all",
+        icon: <LineChart className="h-4 w-4" />,
+      },
+      { label: "Alerts", href: "/school/alerts", icon: <Bell className="h-4 w-4" /> },
+    ],
   },
   {
-    label: "Class Overview",
-    href: "/school/class/all",
-    icon: <Users className="h-4 w-4" />,
+    heading: "People",
+    items: [
+      { label: "Students", href: "/school/students", icon: <Users className="h-4 w-4" /> },
+      {
+        label: "Teachers",
+        href: "/school/teachers",
+        icon: <GraduationCap className="h-4 w-4" />,
+        adminOnly: true,
+      },
+    ],
   },
   {
-    label: "Reports",
-    href: "/school/reports/overview",
-    icon: <BarChart2 className="h-4 w-4" />,
+    heading: "Insights",
+    items: [
+      {
+        label: "Reports",
+        href: "/school/reports/overview",
+        icon: <BarChart2 className="h-4 w-4" />,
+        adminOnly: true,
+      },
+    ],
+  },
+  {
+    heading: "Administration",
+    collapsible: true,
     adminOnly: true,
+    items: [
+      {
+        label: "Subscription",
+        href: "/school/subscription",
+        icon: <CreditCard className="h-4 w-4" />,
+      },
+      { label: "Storage", href: "/school/storage", icon: <HardDrive className="h-4 w-4" /> },
+      {
+        label: "Visual Library",
+        href: "/school/visuals",
+        icon: <Images className="h-4 w-4" />,
+      },
+      {
+        label: "Content Retention",
+        href: "/school/retention",
+        icon: <Archive className="h-4 w-4" />,
+      },
+      { label: "Backups", href: "/school/backups", icon: <Database className="h-4 w-4" /> },
+    ],
   },
-  // Curriculum nav (Curriculum Builder, Catalog, Our Library, Review Queue,
-  // Content Library) moved to the top-bar "Curriculum Management" menu, gated on
-  // the curriculum capability — see components/layout/CurriculumMenu.tsx (#358).
-  { label: "Students", href: "/school/students", icon: <Users className="h-4 w-4" /> },
-  {
-    label: "Teachers",
-    href: "/school/teachers",
-    icon: <GraduationCap className="h-4 w-4" />,
-    adminOnly: true,
-  },
-  { label: "Alerts", href: "/school/alerts", icon: <Bell className="h-4 w-4" /> },
-  {
-    label: "Digest Settings",
-    href: "/school/digest",
-    icon: <Mail className="h-4 w-4" />,
-  },
-  {
-    label: "Subscription",
-    href: "/school/subscription",
-    icon: <CreditCard className="h-4 w-4" />,
-    adminOnly: true,
-  },
-  {
-    label: "Storage",
-    href: "/school/storage",
-    icon: <HardDrive className="h-4 w-4" />,
-    adminOnly: true,
-  },
-  {
-    label: "Visual Library",
-    href: "/school/visuals",
-    icon: <Images className="h-4 w-4" />,
-    adminOnly: true,
-  },
-  {
-    label: "Content Retention",
-    href: "/school/retention",
-    icon: <Archive className="h-4 w-4" />,
-    adminOnly: true,
-  },
-  {
-    label: "Backups",
-    href: "/school/backups",
-    icon: <Database className="h-4 w-4" />,
-    adminOnly: true,
-  },
-  { label: "Settings", href: "/school/settings", icon: <Settings className="h-4 w-4" /> },
-  {
-    label: "Customize",
-    href: "/school/settings/customize",
-    icon: <Palette className="h-4 w-4" />,
-  },
-  { label: "Help", href: "/school/help", icon: <HelpCircle className="h-4 w-4" /> },
 ];
 
 const REPORT_SUB: { label: string; href: string }[] = [
@@ -126,6 +139,7 @@ export function SchoolNav() {
   const rawPathname = usePathname();
   const pathname = rawPathname ?? "";
   const teacher = useTeacher();
+  const isAdmin = teacher?.role === "school_admin";
   const schoolId = teacher?.school_id ?? "";
   const schoolTheme = useSchoolTheme();
   const schoolLogoText = schoolTheme.school.logoText;
@@ -137,26 +151,12 @@ export function SchoolNav() {
     staleTime: 60_000,
   });
 
-  const { data: reviewQueueData } = useQuery({
-    queryKey: ["review-queue", schoolId],
-    queryFn: () => listReviewQueue(schoolId),
-    enabled: !!schoolId && teacher?.role === "school_admin",
-    staleTime: 60_000,
-    refetchInterval: 60_000,
-  });
-
   const unreadAlerts = alertsData?.alerts?.filter((a) => !a.acknowledged).length ?? 0;
-  const pendingReviews = reviewQueueData?.total ?? 0;
   const inReports = pathname.startsWith("/school/reports");
 
-  function handleLogout() {
-    if (typeof window !== "undefined") {
-      localStorage.removeItem("sb_teacher_token");
-      localStorage.removeItem("sb_teacher_refresh_token");
-      // /api/auth/logout clears session cookies and redirects to the correct
-      // destination (local-auth → /signin, Auth0 → /).
-      window.location.href = "/api/auth/logout";
-    }
+  function itemIsActive(href: string): boolean {
+    if (href === "/school/reports/overview") return inReports;
+    return pathname === href || pathname.startsWith(href + "/");
   }
 
   return (
@@ -171,89 +171,135 @@ export function SchoolNav() {
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 space-y-0.5 overflow-y-auto px-2 py-3">
-        {NAV_ITEMS.filter(
-          (item) => !item.adminOnly || teacher?.role === "school_admin",
-        ).map((item) => {
-          const isAlerts = item.href === "/school/alerts";
-          const isReviewQueue = item.href === "/school/review";
-          const isReports = item.href.startsWith("/school/reports");
-          const isContentLib = item.href === "/school/curriculum/content";
-          const isCurriculumUpload = item.href === "/school/curriculum";
-          const isActive = isReports
-            ? inReports
-            : isContentLib
-              ? pathname.startsWith("/school/curriculum/content")
-              : isCurriculumUpload
-                ? pathname === "/school/curriculum" ||
-                  (pathname.startsWith("/school/curriculum") &&
-                    !pathname.startsWith("/school/curriculum/content"))
-                : pathname === item.href;
-
+      <nav className="flex-1 space-y-3 overflow-y-auto px-2 py-3">
+        {NAV_GROUPS.map((group, gi) => {
+          if (group.adminOnly && !isAdmin) return null;
+          const visibleItems = group.items.filter((it) => !it.adminOnly || isAdmin);
+          if (visibleItems.length === 0) return null;
           return (
-            <div key={item.href}>
-              <Link
-                href={item.href}
-                className={cn(
-                  "flex items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors",
-                  isActive
-                    ? "bg-blue-50 font-medium text-blue-700"
-                    : "text-gray-600 hover:bg-gray-50 hover:text-gray-900",
-                )}
-              >
-                {item.icon}
-                <span className="flex-1">{item.label}</span>
-                {isAlerts && unreadAlerts > 0 && (
-                  <span className="ml-auto flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs font-medium text-white">
-                    {unreadAlerts > 9 ? "9+" : unreadAlerts}
-                  </span>
-                )}
-                {isReviewQueue && pendingReviews > 0 && (
-                  <span className="ml-auto flex h-4 w-4 items-center justify-center rounded-full bg-amber-500 text-xs font-medium text-white">
-                    {pendingReviews > 9 ? "9+" : pendingReviews}
-                  </span>
-                )}
-              </Link>
-
-              {/* Reports sub-nav */}
-              {isReports && inReports && (
-                <div className="mt-0.5 ml-4 space-y-0.5">
-                  {REPORT_SUB.map((sub) => (
-                    <Link
-                      key={sub.href}
-                      href={sub.href}
-                      className={cn(
-                        "block rounded px-3 py-1.5 text-xs transition-colors",
-                        pathname === sub.href
-                          ? "bg-blue-100 font-medium text-blue-700"
-                          : "text-gray-500 hover:text-gray-800",
-                      )}
-                    >
-                      {sub.label}
-                    </Link>
-                  ))}
-                </div>
-              )}
-            </div>
+            <NavSection
+              key={group.heading ?? `group-${gi}`}
+              group={group}
+              items={visibleItems}
+              pathname={pathname}
+              inReports={inReports}
+              unreadAlerts={unreadAlerts}
+              itemIsActive={itemIsActive}
+            />
           );
         })}
       </nav>
 
-      {/* Footer */}
-      <div className="border-t border-gray-100 px-2 py-3">
-        {teacher && (
-          <p className="mb-2 truncate px-3 text-xs text-gray-400">
-            {teacher.role === "school_admin" ? "Admin" : "Teacher"}
-          </p>
-        )}
-        <button
-          onClick={handleLogout}
-          className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-900"
-        >
-          <LogOut className="h-4 w-4" />
-          Sign out
-        </button>
-      </div>
+      {/* Footer — role label only; sign out moved to the top-bar AccountMenu (AP-4) */}
+      {teacher && (
+        <div className="border-t border-gray-100 px-5 py-3">
+          <p className="truncate text-xs text-gray-400">{isAdmin ? "Admin" : "Teacher"}</p>
+        </div>
+      )}
     </aside>
+  );
+}
+
+function NavSection({
+  group,
+  items,
+  pathname,
+  inReports,
+  unreadAlerts,
+  itemIsActive,
+}: {
+  group: NavGroup;
+  items: NavItem[];
+  pathname: string;
+  inReports: boolean;
+  unreadAlerts: number;
+  itemIsActive: (href: string) => boolean;
+}) {
+  const containsActive = items.some((it) => itemIsActive(it.href));
+  // Collapsible groups start open only when one of their routes is active.
+  const [open, setOpen] = useState(containsActive);
+
+  const links = (
+    <div className="space-y-0.5">
+      {items.map((item) => {
+        const isActive = itemIsActive(item.href);
+        const isAlerts = item.href === "/school/alerts";
+        const isReports = item.href === "/school/reports/overview";
+        return (
+          <div key={item.href}>
+            <Link
+              href={item.href}
+              className={cn(
+                "flex items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors",
+                isActive
+                  ? "bg-blue-50 font-medium text-blue-700"
+                  : "text-gray-600 hover:bg-gray-50 hover:text-gray-900",
+              )}
+            >
+              {item.icon}
+              <span className="flex-1">{item.label}</span>
+              {isAlerts && unreadAlerts > 0 && (
+                <span className="ml-auto flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs font-medium text-white">
+                  {unreadAlerts > 9 ? "9+" : unreadAlerts}
+                </span>
+              )}
+            </Link>
+
+            {/* Reports sub-nav */}
+            {isReports && inReports && (
+              <div className="mt-0.5 ml-4 space-y-0.5">
+                {REPORT_SUB.map((sub) => (
+                  <Link
+                    key={sub.href}
+                    href={sub.href}
+                    className={cn(
+                      "block rounded px-3 py-1.5 text-xs transition-colors",
+                      pathname === sub.href
+                        ? "bg-blue-100 font-medium text-blue-700"
+                        : "text-gray-500 hover:text-gray-800",
+                    )}
+                  >
+                    {sub.label}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  // Standalone group (no heading) — render links directly.
+  if (!group.heading) return links;
+
+  if (group.collapsible) {
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          className="flex w-full items-center justify-between px-3 py-1 text-xs font-semibold tracking-wide text-gray-400 uppercase transition-colors hover:text-gray-600"
+        >
+          {group.heading}
+          {open ? (
+            <ChevronDown className="h-3.5 w-3.5" aria-hidden />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" aria-hidden />
+          )}
+        </button>
+        {open && <div className="mt-0.5">{links}</div>}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p className="px-3 py-1 text-xs font-semibold tracking-wide text-gray-400 uppercase">
+        {group.heading}
+      </p>
+      <div className="mt-0.5">{links}</div>
+    </div>
   );
 }

--- a/web/tests/e2e/data/class-overview-page.ts
+++ b/web/tests/e2e/data/class-overview-page.ts
@@ -85,7 +85,7 @@ export const MOCK_CLASS_METRICS_EMPTY: ClassMetricsResponse = {
 // ---------------------------------------------------------------------------
 
 export const CLASS_STRINGS = {
-  pageHeading: "Class Overview",
+  pageHeading: "Student Progress",
   detailBtn: "Detail",
   noStudents: "No students found.",
   gradeAll: "All",


### PR DESCRIPTION
Closes #367.

## What
Reworks the school portal information architecture flagged by two reviewers (Ashokan AP-1–AP-4, Venkatesh VT-4/VT-5).

| Item | Before | After |
|---|---|---|
| **AP-1** rail clutter | 16 flat items | Grouped: **Teach** / **People** / **Insights** / **Administration** (admin-only, **collapsible**) |
| **AP-2 / VT-5** | "Class Overview" + `<Users>` (dupe of Students) | "**Student Progress**" + distinct `LineChart` icon |
| **AP-3** | "Our Library", "Content Library" (indistinct) | "**My Curricula**", "**Lessons & Content**" in the top-bar Curriculum menu |
| **AP-4** | Settings/Digest/Customize/Help + Sign out on the rail | New top-bar **AccountMenu** behind the username |
| **VT-4** | Reports before Teachers | Reports (Insights) after Teachers (People) |

New component: `web/components/layout/AccountMenu.tsx`. Page headings, the `/school/help` entries, and a back-link were aligned so a renamed nav item lands on a matching title. `class-overview-page.ts` fixture updated to match the new heading (its unit test reads the heading from that fixture, so it stays green).

## Why
Demo feedback 2026-05-21 / 2026-05-24 — see `docs/feedback/FEEDBACK_TRACKER.md` (AP-1…AP-4, VT-4/VT-5). Reviewers: "left menu has too many items", "Catalog vs Library indistinguishable", same icon for Student/Class Overview, config belongs on the top bar.

## Scope / risk
Frontend IA only — **no backend or migration changes**. The AccountMenu reuses the existing logout flow. The curriculum items already lived in the top-bar `CurriculumMenu` (#358), so AP-3 was a label change there, not a rail move.

## Test plan (verified in-browser via Playwright against the dev server)
- **Admin** rail: sections `[Teach, People, Insights, Administration]`; links `[Dashboard, Classrooms, Student Progress, Alerts, Students, Teachers, Reports]` (Reports after Teachers ✓).
- Clicking **Administration** expands to `[Subscription, Storage, Visual Library, Content Retention, Backups]`.
- **Plain teacher** rail: only `[Teach, People]` → `[Dashboard, Classrooms, Student Progress, Alerts, Students]` (admin items + empty Insights group hidden).
- **Account menu**: `[Settings, Digest Settings, Customize, Help, Sign out]`.
- **Curriculum menu**: `[Browse Catalog, My Curricula, Lessons & Content, Curriculum Builder, Review Queue]`.
- Existing `teacher-accessibility.spec.ts` nav assertions still hold (Dashboard present; Reports visible for admin, hidden for teacher).

## Acceptance criteria
- [x] Nav grouped, not one flat list; admin-only group collapsible
- [x] Content items renamed so Catalog→Library→Content is legible
- [x] Class Overview renamed + distinct icon
- [x] Per-user config moved to a top-bar menu
- [x] Reports ordered after Teachers

## Screenshot (admin, account menu open)
Grouped rail + top-bar account menu verified locally; sections and icons render as described above.

Source: `docs/feedback/FEEDBACK_TRACKER.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)