### PR TITLE
ci: green Backend Lint — ignore PYSEC-2026-161 (starlette) with justification (#379)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,14 @@ jobs:
         working-directory: backend
         # PYSEC-2024-55: previously ignored
         # GHSA-5239-wwwm-4pmq: pygments transitive dep — no upstream fix available yet
-        run: pip-audit -r requirements.txt --ignore-vuln PYSEC-2024-55 --ignore-vuln GHSA-5239-wwwm-4pmq
+        # PYSEC-2026-161: starlette Host-header path poisoning. Fix is starlette 1.0.1,
+        #   but prometheus-fastapi-instrumentator (latest 7.1.0) hard-caps starlette<1.0.0,
+        #   so the patched version is currently uninstallable. The advisory's vector —
+        #   auth bypass when auth depends on the reconstructed URL path — does not apply
+        #   here: auth is JWT Bearer-header based, and request.url.path is used only to
+        #   exclude health/metrics paths from instrumentation, never for auth decisions.
+        #   Tracked by #379 — remove this ignore once the instrumentator supports starlette 1.0.
+        run: pip-audit -r requirements.txt --ignore-vuln PYSEC-2024-55 --ignore-vuln GHSA-5239-wwwm-4pmq --ignore-vuln PYSEC-2026-161
 
   # ── 2. Backend tests + coverage ──────────────────────────────────────────────
   backend-test:


### PR DESCRIPTION
Greens the **Backend — Lint & Security** job (the last red CI check on `main`).

## Situation
`pip-audit` flags **PYSEC-2026-161** — starlette 0.49.1 Host-header path poisoning (potential auth bypass *when auth depends on the reconstructed URL path*). Fixed in **starlette 1.0.1**.

## Why ignore rather than bump
- **Patch is blocked upstream:** `prometheus-fastapi-instrumentator` (latest 7.1.0) hard-caps `starlette<1.0.0` — starlette 1.0.1 is uninstallable without removing that observability dependency. (FastAPI itself is fine; 0.136.3 allows `starlette>=0.46.0`. Verified the conflict with a full `pip install --dry-run`.)
- **Vector doesn't apply here:** auth is JWT `Bearer`-header based (`HTTPBearer` + role checks). `request.url.path` is used only to exclude health/metrics paths from instrumentation (`observability.py`, `middleware.py`) — never for an auth decision. So Host-header path poisoning can't bypass auth.

## Change
- `.github/workflows/test.yml`: add `--ignore-vuln PYSEC-2026-161` to the pip-audit step with an inline justification (same pattern already used for PYSEC-2024-55 and GHSA-5239-wwwm-4pmq).
- No `requirements.txt` change.

## Tracking
**#379** — adopt starlette 1.0.1 + bump fastapi once `prometheus-fastapi-instrumentator` supports starlette 1.0, then remove this ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)