### PR TITLE
chore(dx): add Prettier format:check to the pre-PR gates

### DIFF
--- a/.claude/commands/done.md
+++ b/.claude/commands/done.md
@@ -36,10 +36,16 @@ bandit -q -r backend/src/ -ll
 ### Web (if TS/TSX changed)
 
 ```bash
+cd web && npm run format:check
 cd web && npm run lint
 cd web && npm run typecheck
 cd web && npm test -- --run
 ```
+
+`format:check` is `prettier --check .` — CI runs it as a **separate** step from
+ESLint, so `npm run lint` passing does NOT mean formatting is clean. This is the
+most common avoidable red on frontend PRs. If it fails, `cd web && npm run
+format` writes the fixes, then re-run.
 
 ### Migrations (if any `backend/alembic/versions/*.py` touched)
 

--- a/.claude/commands/ship-ready.md
+++ b/.claude/commands/ship-ready.md
@@ -29,9 +29,9 @@ No `-x` here — we want the complete failure list, not the first one.
 
 ### Group B — Web full build
 ```bash
-cd web && npm run lint && npm run typecheck && npm test -- --run && npm run build
+cd web && npm run format:check && npm run lint && npm run typecheck && npm test -- --run && npm run build
 ```
-Production build catches type issues that `tsc --noEmit` misses (e.g., Next.js route-level static-analysis errors).
+`format:check` (`prettier --check .`) is a **separate** CI step from ESLint — `npm run lint` passing does not imply formatting is clean, and a Prettier miss reds the whole "Frontend — Lint & Typecheck" job. Fix with `npm run format`. Production build catches type issues that `tsc --noEmit` misses (e.g., Next.js route-level static-analysis errors).
 
 ### Group C — API contract drift
 ```bash

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -5,3 +5,17 @@
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 
 <!-- END:nextjs-agent-rules -->
+
+# Before opening a frontend PR
+
+CI runs **`npm run format:check` (Prettier) as a separate step from ESLint** in
+the "Frontend — Lint & Typecheck" job. `npm run lint` passing does **not** mean
+formatting is clean — a Prettier miss reds the whole job. Always run, from `web/`:
+
+```bash
+npm run format:check   # prettier --check .  (fix with: npm run format)
+npm run lint
+npm run typecheck
+```
+
+`/done` and `/ship-ready` include this; run them before `gh pr create`.


### PR DESCRIPTION
## What
Adds `npm run format:check` (Prettier) to the frontend pre-PR routine so formatting drift is caught locally, not at CI.

- **/done** (`.claude/commands/done.md`) — Web bucket now runs `format:check` first, with a note that CI runs Prettier as a *separate* step from ESLint.
- **/ship-ready** (`.claude/commands/ship-ready.md`) — `format:check` added to the Group B web chain.
- **web/AGENTS.md** — discoverability note (run `format:check` before lint/typecheck; fix with `npm run format`).

## Why
CI's "Frontend — Lint & Typecheck" job runs `npm run format:check` independently of `npm run lint`, so a passing ESLint doesn't mean formatting is clean. The #365–#371 frontend PRs each shipped Prettier violations that only surfaced during CI greening (#364) — this closes that gap in the routine.

No production code; docs/tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)