### PR TITLE
feat(authoring): Curriculum Authoring Studio — PR-A (intake → analyze → structure → materialize)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,6 +292,19 @@ All admin routes live under `/admin/` and require a valid `sb_admin_token` JWT c
 | `/admin/feedback` | Student feedback list |
 | `/admin/audit` | Audit log |
 
+**Curriculum Authoring Studio (super-admin only, API surface — PR-A, no web UI yet):**
+Gated by the `curriculum:author` permission, which only `super_admin` holds (via its
+`{"*"}` wildcard); `product_admin` and below get 403. Endpoints under
+`/api/v1/admin/authoring/` (`backend/src/admin/authoring_router.py`):
+`POST /projects` (create from pasted free-text TOC) · `GET /projects` · `GET /projects/{id}` ·
+`POST /projects/{id}/analyze` (Celery: structure + advisory flow, 202) ·
+`PUT /projects/{id}/structure` (save edits) ·
+`POST /projects/{id}/materialize` (→ staged platform curriculum, `owner_type='platform'`,
+`source_type='admin_authored'`, `is_default=FALSE`, no `school_id`). TOC structuring +
+flow analysis live in `pipeline/toc_structurer.py` + `pipeline/flow_analyzer.py`; the cheap
+no-LLM ordering check is `backend/src/admin/authoring_flow.py`. PR-B adds
+generate/review/regenerate/snapshot/publish + Mermaid prompt emphasis.
+
 ---
 
 ## Three Runtime Contexts
@@ -414,6 +427,7 @@ Current migrations (as of last commit):
 | 0057 | Visual library — `embedding` column → pgvector type for cosine similarity search |
 | 0058 | Demo request — `name` column on demo lead requests |
 | 0059 | Epic/#358 — `teacher_capabilities` table (RLS): additive `curriculum.commission` / `curriculum.review` / `curriculum_mgmt` grants |
+| 0060 | Authoring Studio (PR-A) — `authoring_projects`, `authoring_topic_versions`, `authoring_active_versions`, `authoring_snapshots` (platform/admin-scoped, no tenant RLS); extends `curricula.source_type` CHECK with `admin_authored`. Downgrade deletes `source_type='admin_authored'` curricula before reverting the CHECK |
 
 ---
 

--- a/backend/alembic/versions/0060_curriculum_authoring_studio.py
+++ b/backend/alembic/versions/0060_curriculum_authoring_studio.py
@@ -1,0 +1,175 @@
+"""0060 — Curriculum Authoring Studio (super-admin)
+
+Super-admin TOC-driven content authoring. A super-admin pastes a free-text
+table of contents; the system structures it (LLM), runs an advisory flow
+analysis, lets the admin edit the structured tree, materialises it as a
+*staged* platform curriculum, generates per-topic content, and (PR-B) supports
+unlimited regenerate-with-reason, per-topic append-only versioning, whole-
+curriculum manifest snapshots/restore, and publish (private | school catalog).
+
+Scope distinction (requirement d — "not mixed with other school curriculum"):
+authored curricula are created with owner_type='platform' and
+source_type='admin_authored', is_default=FALSE while staged. They never carry a
+school_id, so they live in the platform namespace, isolated from school forks.
+On publish-to-catalog the row's is_default flips TRUE and it becomes adoptable
+via the Epic 12 school library.
+
+Tables (all platform/admin-scoped — NOT tenant-scoped, like pipeline_jobs):
+  authoring_projects        one row per authoring session (state machine)
+  authoring_topic_versions  append-only per-topic content versions
+  authoring_active_versions mutable pointer: which version is "live" per topic
+  authoring_snapshots       whole-curriculum manifest snapshots (point-in-time)
+
+RLS: these tables are not tenant-scoped (no school_id, gated by admin JWT +
+the curriculum:author permission), so they get no app.current_school_id policy
+— consistent with pipeline_jobs. The curricula/curriculum_units rows the
+service writes ARE under the migration-0046 platform write-guard, so the
+service path uses get_db() which stamps app.current_school_id='bypass' for
+admin requests (pitfall #28).
+
+Also extends curricula.source_type CHECK to allow 'admin_authored'.
+
+Revision ID: 0060
+Revises: 0059
+Create Date: 2026-05-26
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0060"
+down_revision: str | None = "0059"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ── curricula.source_type: allow 'admin_authored' ─────────────────────────
+    op.execute("ALTER TABLE curricula DROP CONSTRAINT IF EXISTS curricula_source_type_check")
+    op.execute("""
+        ALTER TABLE curricula
+            ADD CONSTRAINT curricula_source_type_check
+            CHECK (source_type IN ('default', 'xlsx_upload', 'ui_form', 'school', 'admin_authored'))
+    """)
+
+    # ── authoring_projects ────────────────────────────────────────────────────
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS authoring_projects (
+            project_id          UUID         NOT NULL DEFAULT gen_random_uuid(),
+            title               TEXT         NOT NULL,
+            grade               INT          CHECK (grade BETWEEN 1 AND 12),
+            languages           TEXT[]       NOT NULL DEFAULT '{en}',
+            raw_toc             TEXT,
+            structured_toc      JSONB,
+            flow_report         JSONB,
+            status              TEXT         NOT NULL DEFAULT 'draft'
+                                    CHECK (status IN (
+                                        'draft', 'analyzing', 'analyzed', 'structured',
+                                        'generating', 'generated', 'published')),
+            curriculum_id       TEXT         REFERENCES curricula(curriculum_id) ON DELETE SET NULL,
+            visibility          TEXT         NOT NULL DEFAULT 'private'
+                                    CHECK (visibility IN ('private', 'catalog')),
+            current_snapshot_id UUID,
+            analyze_error       TEXT,
+            created_by          UUID,
+            created_at          TIMESTAMPTZ  NOT NULL DEFAULT now(),
+            updated_at          TIMESTAMPTZ  NOT NULL DEFAULT now(),
+            PRIMARY KEY (project_id)
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_authoring_projects_status "
+        "ON authoring_projects(status)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_authoring_projects_curriculum_id "
+        "ON authoring_projects(curriculum_id) WHERE curriculum_id IS NOT NULL"
+    )
+
+    # ── authoring_topic_versions (append-only) ────────────────────────────────
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS authoring_topic_versions (
+            topic_version_id  UUID         NOT NULL DEFAULT gen_random_uuid(),
+            project_id        UUID         NOT NULL
+                                  REFERENCES authoring_projects(project_id) ON DELETE CASCADE,
+            unit_id           TEXT         NOT NULL,
+            lang              TEXT         NOT NULL DEFAULT 'en',
+            content_type      TEXT         NOT NULL
+                                  CHECK (content_type IN (
+                                      'lesson', 'tutorial',
+                                      'quiz_set_1', 'quiz_set_2', 'quiz_set_3',
+                                      'experiment')),
+            body              JSONB        NOT NULL,
+            version_number    INT          NOT NULL,
+            regen_reason      TEXT,
+            flow_recheck      JSONB,
+            ai_model          TEXT,
+            tokens_used       INT,
+            cost_usd          NUMERIC(10, 4),
+            review_status     TEXT         NOT NULL DEFAULT 'pending'
+                                  CHECK (review_status IN ('pending', 'accepted')),
+            created_by        UUID,
+            created_at        TIMESTAMPTZ  NOT NULL DEFAULT now(),
+            PRIMARY KEY (topic_version_id),
+            UNIQUE (project_id, unit_id, lang, content_type, version_number)
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_authoring_topic_versions_lookup "
+        "ON authoring_topic_versions(project_id, unit_id, lang, content_type)"
+    )
+
+    # ── authoring_active_versions (mutable pointer) ───────────────────────────
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS authoring_active_versions (
+            project_id        UUID         NOT NULL
+                                  REFERENCES authoring_projects(project_id) ON DELETE CASCADE,
+            unit_id           TEXT         NOT NULL,
+            lang              TEXT         NOT NULL,
+            content_type      TEXT         NOT NULL,
+            topic_version_id  UUID         NOT NULL
+                                  REFERENCES authoring_topic_versions(topic_version_id) ON DELETE RESTRICT,
+            activated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+            PRIMARY KEY (project_id, unit_id, lang, content_type)
+        )
+    """)
+
+    # ── authoring_snapshots (whole-curriculum manifest) ───────────────────────
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS authoring_snapshots (
+            snapshot_id      UUID         NOT NULL DEFAULT gen_random_uuid(),
+            project_id       UUID         NOT NULL
+                                 REFERENCES authoring_projects(project_id) ON DELETE CASCADE,
+            snapshot_number  INT          NOT NULL,
+            manifest         JSONB        NOT NULL,
+            label            TEXT,
+            created_by       UUID,
+            created_at       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+            PRIMARY KEY (snapshot_id),
+            UNIQUE (project_id, snapshot_number)
+        )
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS authoring_snapshots CASCADE")
+    op.execute("DROP TABLE IF EXISTS authoring_active_versions CASCADE")
+    op.execute("DROP TABLE IF EXISTS authoring_topic_versions CASCADE")
+    op.execute("DROP TABLE IF EXISTS authoring_projects CASCADE")
+
+    # Remove the feature's own staged curricula before reverting the CHECK —
+    # otherwise the narrower constraint can't be re-added while admin_authored
+    # rows exist. These are studio artifacts; removing them is the documented,
+    # safe downgrade behaviour. curriculum_units cascade via their FK.
+    op.execute("DELETE FROM curricula WHERE source_type = 'admin_authored'")
+
+    # Revert source_type CHECK to the pre-0060 set.
+    op.execute("ALTER TABLE curricula DROP CONSTRAINT IF EXISTS curricula_source_type_check")
+    op.execute("""
+        ALTER TABLE curricula
+            ADD CONSTRAINT curricula_source_type_check
+            CHECK (source_type IN ('default', 'xlsx_upload', 'ui_form', 'school'))
+    """)

--- a/backend/src/admin/authoring_flow.py
+++ b/backend/src/admin/authoring_flow.py
@@ -1,0 +1,95 @@
+"""
+backend/src/admin/authoring_flow.py
+
+Cheap, deterministic flow checks for the Curriculum Authoring Studio.
+
+This is the no-LLM, no-cost companion to pipeline/flow_analyzer.py. It runs on
+every topic change (requirement f) where a paid LLM pass would be too slow and
+expensive. It catches the mechanical class of flow breakage — a prerequisite
+that is taught *after* the unit that needs it, and prerequisites that name a
+unit not present in the curriculum — by inspecting document order alone.
+
+The richer pedagogical analysis (conceptual gaps, redundancy) is left to the
+on-demand LLM analyzer.
+
+Pure function, no I/O, no DB — trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _norm(title: str) -> str:
+    return " ".join(str(title).strip().lower().split())
+
+
+def _to_plain(structured: Any) -> dict:
+    """Accept a StructuredTOC, a pydantic model, or a plain dict."""
+    if hasattr(structured, "model_dump"):
+        return structured.model_dump()
+    return structured or {}
+
+
+def check_topic_ordering(structured: Any) -> list[dict]:
+    """Flag prerequisites that resolve to a later (or missing) unit.
+
+    Args:
+        structured: StructuredTOC | dict with shape
+            ``{"subjects": [{"subject_label", "units": [{"title",
+              "prerequisites": [...]}]}]}``.
+
+    Returns:
+        A list of warning dicts, each:
+            ``{"kind", "unit", "subject", "detail"}``
+        where ``kind`` is "prerequisite_after_use" or "missing_prerequisite".
+        Empty list means no mechanical ordering problems were found.
+    """
+    plain = _to_plain(structured)
+    subjects = plain.get("subjects", []) or []
+
+    # Flatten units in document order; map normalised title → first global index.
+    ordered: list[tuple[int, str, str]] = []  # (global_index, subject_label, title)
+    title_index: dict[str, int] = {}
+    idx = 0
+    for subject in subjects:
+        subject_label = subject.get("subject_label", "")
+        for unit in subject.get("units", []) or []:
+            title = unit.get("title", "")
+            ordered.append((idx, subject_label, title))
+            title_index.setdefault(_norm(title), idx)
+            idx += 1
+
+    warnings: list[dict] = []
+    pos = 0
+    for subject in subjects:
+        subject_label = subject.get("subject_label", "")
+        for unit in subject.get("units", []) or []:
+            title = unit.get("title", "")
+            for prereq in unit.get("prerequisites", []) or []:
+                key = _norm(prereq)
+                if key == _norm(title):
+                    continue  # a unit listing itself — ignore
+                prereq_idx = title_index.get(key)
+                if prereq_idx is None:
+                    warnings.append({
+                        "kind": "missing_prerequisite",
+                        "unit": title,
+                        "subject": subject_label,
+                        "detail": (
+                            f"Prerequisite {prereq!r} is not a unit in this curriculum."
+                        ),
+                    })
+                elif prereq_idx > pos:
+                    warnings.append({
+                        "kind": "prerequisite_after_use",
+                        "unit": title,
+                        "subject": subject_label,
+                        "detail": (
+                            f"Unit {title!r} requires {prereq!r}, but {prereq!r} is "
+                            f"sequenced after it."
+                        ),
+                    })
+            pos += 1
+
+    return warnings

--- a/backend/src/admin/authoring_router.py
+++ b/backend/src/admin/authoring_router.py
@@ -1,0 +1,296 @@
+"""
+backend/src/admin/authoring_router.py
+
+Curriculum Authoring Studio — super-admin TOC-driven content authoring.
+
+PR-A endpoints (intake → analyze → structure → materialize):
+  POST   /admin/authoring/projects                       create
+  GET    /admin/authoring/projects                       list
+  GET    /admin/authoring/projects/{project_id}          detail
+  POST   /admin/authoring/projects/{project_id}/analyze  structure + flow (async)
+  PUT    /admin/authoring/projects/{project_id}/structure save edits
+  POST   /admin/authoring/projects/{project_id}/materialize  → staged curriculum
+
+Gate: every endpoint requires the `curriculum:author` permission, which only
+super_admin holds (via its wildcard). product_admin and below get 403.
+
+PR-B will add generate / topic review / regenerate / snapshot / publish here.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from src.admin import authoring_service as svc
+from src.admin.authoring_schemas import (
+    AnalyzeResponse,
+    CreateProjectRequest,
+    CreateProjectResponse,
+    EditStructureRequest,
+    MaterializeResponse,
+    ProjectDetail,
+    ProjectListResponse,
+)
+from src.auth.dependencies import get_current_admin
+from src.core.db import get_db
+from src.core.events import emit_event, write_audit_log
+from src.core.permissions import _has_permission
+from src.utils.logger import get_logger
+
+log = get_logger("authoring")
+router = APIRouter(tags=["authoring"])
+
+_AUTHOR_PERMISSION = "curriculum:author"
+
+
+def _require_author():
+    """Chained dependency: verify admin JWT, then require curriculum:author.
+
+    get_current_admin verifies ADMIN_JWT_SECRET and stamps
+    request.state.jwt_payload; this inner dep enforces the permission. Only
+    super_admin satisfies curriculum:author (wildcard), so the studio is
+    super-admin-only.
+    """
+
+    async def dep(
+        request: Request,
+        admin: Annotated[dict, Depends(get_current_admin)],
+    ) -> dict:
+        role = admin.get("role", "")
+        if not _has_permission(role, _AUTHOR_PERMISSION):
+            log.warning(
+                "authoring_permission_denied role=%s actor_id=%s",
+                role,
+                admin.get("admin_id"),
+            )
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "forbidden",
+                    "detail": (
+                        f"Role '{role}' does not have permission "
+                        f"'{_AUTHOR_PERMISSION}'."
+                    ),
+                    "correlation_id": getattr(request.state, "correlation_id", ""),
+                },
+            )
+        return admin
+
+    return dep
+
+
+def _actor_uuid(admin: dict) -> uuid.UUID | None:
+    raw = admin.get("admin_id")
+    if not raw:
+        return None
+    try:
+        return uuid.UUID(str(raw))
+    except (ValueError, TypeError):
+        return None
+
+
+def _not_found(project_id: str, request: Request) -> HTTPException:
+    return HTTPException(
+        status_code=404,
+        detail={
+            "error": "not_found",
+            "detail": f"Authoring project {project_id!r} not found.",
+            "correlation_id": getattr(request.state, "correlation_id", ""),
+        },
+    )
+
+
+# ── 1. Create ──────────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/admin/authoring/projects",
+    response_model=CreateProjectResponse,
+    status_code=201,
+)
+async def create_project(
+    body: CreateProjectRequest,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> CreateProjectResponse:
+    async with get_db(request) as conn:
+        project = await svc.create_project(
+            conn,
+            title=body.title,
+            grade=body.grade,
+            languages=body.languages,
+            raw_toc=body.raw_toc,
+            created_by=_actor_uuid(admin),
+        )
+    emit_event(
+        "authoring",
+        "project_created",
+        project_id=project["project_id"],
+        grade=body.grade,
+        raw_toc_chars=len(body.raw_toc),
+    )
+    return CreateProjectResponse(
+        project_id=project["project_id"], status=project["status"]
+    )
+
+
+# ── 2. List ──────────────────────────────────────────────────────────────────
+
+
+@router.get("/admin/authoring/projects", response_model=ProjectListResponse)
+async def list_projects(
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> ProjectListResponse:
+    async with get_db(request) as conn:
+        projects, total = await svc.list_projects(conn)
+    return ProjectListResponse(projects=projects, total=total)
+
+
+# ── 3. Detail ──────────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/admin/authoring/projects/{project_id}", response_model=ProjectDetail
+)
+async def get_project(
+    project_id: str,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> ProjectDetail:
+    async with get_db(request) as conn:
+        project = await svc.get_project(conn, project_id)
+    if project is None:
+        raise _not_found(project_id, request)
+    return ProjectDetail(**project)
+
+
+# ── 4. Analyze (async) ──────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/admin/authoring/projects/{project_id}/analyze",
+    response_model=AnalyzeResponse,
+    status_code=202,
+)
+async def analyze_project(
+    project_id: str,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> AnalyzeResponse:
+    async with get_db(request) as conn:
+        project = await svc.get_project(conn, project_id)
+        if project is None:
+            raise _not_found(project_id, request)
+        ok = await svc.mark_analyzing(conn, project_id)
+    if not ok:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "conflict",
+                "detail": (
+                    f"Project is in status {project['status']!r}; analysis can "
+                    "only run from draft/analyzed/structured."
+                ),
+                "correlation_id": getattr(request.state, "correlation_id", ""),
+            },
+        )
+
+    from src.core.celery_app import celery_app as _celery
+
+    job_id = str(uuid.uuid4())
+    _celery.send_task(
+        "src.auth.tasks.run_authoring_analyze_task",
+        args=[project_id],
+        queue="pipeline",
+    )
+    emit_event("authoring", "analyze_dispatched", project_id=project_id, job_id=job_id)
+    return AnalyzeResponse(job_id=job_id, status="analyzing")
+
+
+# ── 5. Save structure edits ─────────────────────────────────────────────────────
+
+
+@router.put(
+    "/admin/authoring/projects/{project_id}/structure",
+    response_model=ProjectDetail,
+)
+async def edit_structure(
+    project_id: str,
+    body: EditStructureRequest,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> ProjectDetail:
+    async with get_db(request) as conn:
+        existing = await svc.get_project(conn, project_id)
+        if existing is None:
+            raise _not_found(project_id, request)
+        updated = await svc.save_structure(
+            conn, project_id, body.structured_toc.model_dump()
+        )
+    if updated is None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "conflict",
+                "detail": (
+                    f"Project is in status {existing['status']!r}; structure can "
+                    "only be edited after analysis (analyzed/structured)."
+                ),
+                "correlation_id": getattr(request.state, "correlation_id", ""),
+            },
+        )
+    return ProjectDetail(**updated)
+
+
+# ── 6. Materialize → staged platform curriculum ─────────────────────────────────
+
+
+@router.post(
+    "/admin/authoring/projects/{project_id}/materialize",
+    response_model=MaterializeResponse,
+    status_code=201,
+)
+async def materialize_project(
+    project_id: str,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> MaterializeResponse:
+    async with get_db(request) as conn:
+        try:
+            result = await svc.materialize(conn, project_id, _actor_uuid(admin))
+        except svc.MaterializeError as exc:
+            if "not found" in str(exc):
+                raise _not_found(project_id, request) from exc
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "conflict",
+                    "detail": str(exc),
+                    "correlation_id": getattr(request.state, "correlation_id", ""),
+                },
+            ) from exc
+
+    emit_event(
+        "authoring",
+        "materialized",
+        project_id=project_id,
+        curriculum_id=result["curriculum_id"],
+        units=result["units_created"],
+    )
+    write_audit_log(
+        event_type="authoring.materialize",
+        actor_type="admin",
+        actor_id=_actor_uuid(admin),
+        target_type="curriculum",
+        target_id=None,
+        metadata={
+            "project_id": project_id,
+            "curriculum_id": result["curriculum_id"],
+            "units": result["units_created"],
+        },
+    )
+    return MaterializeResponse(**result)

--- a/backend/src/admin/authoring_schemas.py
+++ b/backend/src/admin/authoring_schemas.py
@@ -1,0 +1,116 @@
+"""
+backend/src/admin/authoring_schemas.py
+
+Pydantic request/response schemas for the Curriculum Authoring Studio
+(super-admin TOC-driven content authoring).
+
+PR-A scope: intake → analyze → structure → materialize (endpoints 1-6).
+PR-B will add topic generation / regenerate / snapshot / publish schemas.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+_LANGS = {"en", "fr", "es"}
+
+
+# ── Structured TOC tree (mirrors pipeline/toc_structurer.py shapes) ───────────
+
+
+class TopicNode(BaseModel):
+    title: str = Field(min_length=1, max_length=300)
+    subtopics: list[str] = Field(default_factory=list)
+    prerequisites: list[str] = Field(default_factory=list)
+
+
+class SubjectNode(BaseModel):
+    subject_label: str = Field(min_length=1, max_length=200)
+    units: list[TopicNode] = Field(default_factory=list)
+
+    @field_validator("units")
+    @classmethod
+    def _at_least_one_unit(cls, v: list[TopicNode]) -> list[TopicNode]:
+        if not v:
+            raise ValueError("each subject must have at least one unit")
+        return v
+
+
+class StructuredTOC(BaseModel):
+    subjects: list[SubjectNode] = Field(default_factory=list)
+
+    @field_validator("subjects")
+    @classmethod
+    def _at_least_one_subject(cls, v: list[SubjectNode]) -> list[SubjectNode]:
+        if not v:
+            raise ValueError("structured_toc must have at least one subject")
+        return v
+
+
+# ── Requests ──────────────────────────────────────────────────────────────────
+
+
+class CreateProjectRequest(BaseModel):
+    title: str = Field(min_length=1, max_length=300)
+    grade: int | None = Field(default=None, ge=1, le=12)
+    languages: list[str] = Field(default_factory=lambda: ["en"])
+    raw_toc: str = Field(min_length=1, max_length=20000)
+
+    @field_validator("languages")
+    @classmethod
+    def _valid_langs(cls, v: list[str]) -> list[str]:
+        if not v:
+            return ["en"]
+        bad = [lang for lang in v if lang not in _LANGS]
+        if bad:
+            raise ValueError(f"unsupported languages: {bad}; allowed: {sorted(_LANGS)}")
+        return v
+
+
+class EditStructureRequest(BaseModel):
+    structured_toc: StructuredTOC
+
+
+# ── Responses ──────────────────────────────────────────────────────────────────
+
+
+class ProjectSummary(BaseModel):
+    project_id: str
+    title: str
+    grade: int | None = None
+    languages: list[str]
+    status: str
+    curriculum_id: str | None = None
+    visibility: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProjectDetail(ProjectSummary):
+    raw_toc: str | None = None
+    structured_toc: dict | None = None
+    flow_report: dict | None = None
+    analyze_error: str | None = None
+
+
+class ProjectListResponse(BaseModel):
+    projects: list[ProjectSummary]
+    total: int
+
+
+class CreateProjectResponse(BaseModel):
+    project_id: str
+    status: str
+
+
+class AnalyzeResponse(BaseModel):
+    job_id: str
+    status: str  # 'analyzing'
+
+
+class MaterializeResponse(BaseModel):
+    curriculum_id: str
+    status: str  # 'structured'
+    units_created: int

--- a/backend/src/admin/authoring_service.py
+++ b/backend/src/admin/authoring_service.py
@@ -1,0 +1,370 @@
+"""
+backend/src/admin/authoring_service.py
+
+Service layer for the Curriculum Authoring Studio (super-admin).
+
+PR-A scope: project CRUD, TOC analysis (structure + advisory flow), structure
+editing, and materialisation into a *staged* platform curriculum.
+
+Design notes
+------------
+- All DB access takes an asyncpg connection acquired by the router via
+  get_db(request), which stamps app.current_school_id='bypass' for admin
+  requests. That bypass is what lets materialize() write owner_type='platform'
+  rows past the migration-0046 write-guard (pitfall #28).
+- The authoring_* tables are not tenant-scoped (no RLS policy), consistent
+  with pipeline_jobs.
+- The expensive analyze step (LLM calls) runs in a Celery task; run_analysis()
+  is the pure worker body so it is directly unit-testable with a fake provider.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import asyncpg
+
+from src.utils.logger import get_logger
+
+log = get_logger("authoring")
+
+
+# ── Provider factory (patched in tests) ───────────────────────────────────────
+
+
+def _build_authoring_provider():
+    """Build the default LLM provider for authoring analysis/generation.
+
+    Isolated so tests can patch it with a fake provider instead of reaching
+    for a real Anthropic key. Imports are deferred: pipeline.config requires
+    ANTHROPIC_API_KEY at import time, which we don't want at module load.
+    """
+    from pipeline.config import settings as pipeline_settings
+    from pipeline.providers import get_provider
+
+    return get_provider(pipeline_settings.DEFAULT_PROVIDER, pipeline_settings)
+
+
+def _now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def _row_to_summary(row: asyncpg.Record) -> dict:
+    return {
+        "project_id": str(row["project_id"]),
+        "title": row["title"],
+        "grade": row["grade"],
+        "languages": list(row["languages"]),
+        "status": row["status"],
+        "curriculum_id": row["curriculum_id"],
+        "visibility": row["visibility"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def _coerce_json(value: Any) -> dict | None:
+    """asyncpg jsonb codec returns dicts already, but be defensive."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return None
+    return value
+
+
+def _row_to_detail(row: asyncpg.Record) -> dict:
+    detail = _row_to_summary(row)
+    detail.update({
+        "raw_toc": row["raw_toc"],
+        "structured_toc": _coerce_json(row["structured_toc"]),
+        "flow_report": _coerce_json(row["flow_report"]),
+        "analyze_error": row["analyze_error"],
+    })
+    return detail
+
+
+# ── CRUD ───────────────────────────────────────────────────────────────────────
+
+
+async def create_project(
+    conn: asyncpg.Connection,
+    *,
+    title: str,
+    grade: int | None,
+    languages: list[str],
+    raw_toc: str,
+    created_by: uuid.UUID | None,
+) -> dict:
+    row = await conn.fetchrow(
+        """
+        INSERT INTO authoring_projects (title, grade, languages, raw_toc, created_by)
+        VALUES ($1, $2, $3, $4, $5)
+        RETURNING *
+        """,
+        title,
+        grade,
+        languages,
+        raw_toc,
+        created_by,
+    )
+    return _row_to_detail(row)
+
+
+async def list_projects(conn: asyncpg.Connection) -> tuple[list[dict], int]:
+    rows = await conn.fetch(
+        "SELECT * FROM authoring_projects ORDER BY created_at DESC"
+    )
+    return [_row_to_summary(r) for r in rows], len(rows)
+
+
+async def get_project(conn: asyncpg.Connection, project_id: str) -> dict | None:
+    row = await conn.fetchrow(
+        "SELECT * FROM authoring_projects WHERE project_id = $1", project_id
+    )
+    return _row_to_detail(row) if row else None
+
+
+async def mark_analyzing(conn: asyncpg.Connection, project_id: str) -> bool:
+    """Transition draft → analyzing. Returns False if not in an analyzable state."""
+    row = await conn.fetchrow(
+        """
+        UPDATE authoring_projects
+           SET status = 'analyzing', analyze_error = NULL, updated_at = now()
+         WHERE project_id = $1
+           AND status IN ('draft', 'analyzed', 'structured')
+        RETURNING project_id
+        """,
+        project_id,
+    )
+    return row is not None
+
+
+async def save_structure(
+    conn: asyncpg.Connection,
+    project_id: str,
+    structured_toc: dict,
+) -> dict | None:
+    """Persist operator edits to the structured TOC.
+
+    Allowed once the project has been analysed (status analyzed | structured).
+    Returns the updated detail dict, or None if the project is missing / in a
+    wrong state.
+    """
+    row = await conn.fetchrow(
+        """
+        UPDATE authoring_projects
+           SET structured_toc = $2, updated_at = now()
+         WHERE project_id = $1
+           AND status IN ('analyzed', 'structured')
+        RETURNING *
+        """,
+        project_id,
+        structured_toc,
+    )
+    return _row_to_detail(row) if row else None
+
+
+# ── Analyze (Celery worker body) ───────────────────────────────────────────────
+
+
+async def run_analysis(
+    conn: asyncpg.Connection,
+    project_id: str,
+    provider=None,
+) -> None:
+    """Structure the raw TOC and run advisory flow analysis.
+
+    Idempotent-ish: reads raw_toc, writes structured_toc + flow_report and
+    flips status → 'analyzed'. On any structuring failure, records
+    analyze_error and reverts status → 'draft' so the operator can retry.
+
+    Never raises — failures are persisted on the row.
+    """
+    from pipeline.flow_analyzer import analyze_toc_flow
+    from pipeline.toc_structurer import StructureError, structure_toc
+
+    row = await conn.fetchrow(
+        "SELECT raw_toc, grade FROM authoring_projects WHERE project_id = $1",
+        project_id,
+    )
+    if row is None:
+        log.warning("authoring_analyze_missing_project project_id=%s", project_id)
+        return
+
+    if provider is None:
+        provider = _build_authoring_provider()
+
+    raw_toc = row["raw_toc"] or ""
+    grade = row["grade"]
+
+    try:
+        structured = await asyncio.to_thread(structure_toc, raw_toc, grade, provider)
+    except StructureError as exc:
+        log.warning("authoring_structure_failed project_id=%s error=%s", project_id, exc)
+        await conn.execute(
+            """
+            UPDATE authoring_projects
+               SET status = 'draft', analyze_error = $2, updated_at = now()
+             WHERE project_id = $1
+            """,
+            project_id,
+            str(exc),
+        )
+        return
+
+    # Flow analysis is advisory and never raises.
+    report = await asyncio.to_thread(analyze_toc_flow, structured, provider)
+
+    await conn.execute(
+        """
+        UPDATE authoring_projects
+           SET structured_toc = $2, flow_report = $3,
+               status = 'analyzed', analyze_error = NULL, updated_at = now()
+         WHERE project_id = $1
+        """,
+        project_id,
+        structured.model_dump(),
+        report.model_dump(),
+    )
+    log.info(
+        "authoring_analyzed project_id=%s subjects=%d flow_warnings=%d",
+        project_id,
+        len(structured.subjects),
+        len(report.warnings),
+    )
+
+
+# ── Materialize ────────────────────────────────────────────────────────────────
+
+
+_SUBJECT_CODE_RE = re.compile(r"[^A-Z0-9]")
+
+
+def _subject_code(label: str, index: int) -> str:
+    """Derive a short uppercase subject code from a label.
+
+    Falls back to S{index} when the label has no usable alphanumerics, so
+    unit_ids stay unique across subjects.
+    """
+    code = _SUBJECT_CODE_RE.sub("", label.upper())[:6]
+    return code or f"S{index + 1}"
+
+
+class MaterializeError(RuntimeError):
+    """Raised when a project cannot be materialised (wrong state / no TOC)."""
+
+
+async def materialize(
+    conn: asyncpg.Connection,
+    project_id: str,
+    created_by: uuid.UUID | None,
+) -> dict:
+    """Create a staged platform curriculum + units from the structured TOC.
+
+    The curriculum is owner_type='platform', source_type='admin_authored',
+    is_default=FALSE (staged, not in the school catalog yet) and carries no
+    school_id — keeping it out of the school namespace (requirement d).
+
+    Idempotent: if the project already has a curriculum_id, returns it without
+    creating duplicates.
+    """
+    row = await conn.fetchrow(
+        "SELECT title, grade, structured_toc, curriculum_id, status "
+        "FROM authoring_projects WHERE project_id = $1",
+        project_id,
+    )
+    if row is None:
+        raise MaterializeError("project not found")
+
+    structured = _coerce_json(row["structured_toc"])
+    if not structured or not structured.get("subjects"):
+        raise MaterializeError("project has no structured TOC; analyze and edit first")
+
+    # Idempotent re-call.
+    if row["curriculum_id"]:
+        units = await conn.fetchval(
+            "SELECT COUNT(*) FROM curriculum_units WHERE curriculum_id = $1",
+            row["curriculum_id"],
+        )
+        return {
+            "curriculum_id": row["curriculum_id"],
+            "status": row["status"],
+            "units_created": int(units or 0),
+        }
+
+    curriculum_id = f"authored-{project_id}"
+    proj8 = str(project_id).replace("-", "")[:8]
+    year = _now().year
+    grade = row["grade"]
+
+    units_created = 0
+    async with conn.transaction():
+        await conn.execute(
+            """
+            INSERT INTO curricula
+                (curriculum_id, name, grade, year, is_default,
+                 owner_type, owner_id, school_id, source_type, status)
+            VALUES ($1, $2, $3, $4, FALSE,
+                    'platform', NULL, NULL, 'admin_authored', 'active')
+            ON CONFLICT (curriculum_id) DO NOTHING
+            """,
+            curriculum_id,
+            row["title"],
+            grade,
+            year,
+        )
+
+        for s_idx, subject in enumerate(structured["subjects"]):
+            subj_code = _subject_code(subject.get("subject_label", ""), s_idx)
+            for u_idx, unit in enumerate(subject.get("units", []) or []):
+                title = unit.get("title", "")
+                unit_id = f"AUTH-{proj8}-{subj_code}-{u_idx + 1:03d}"
+                subtopics = unit.get("subtopics", []) or []
+                description = "; ".join(subtopics)
+                await conn.execute(
+                    """
+                    INSERT INTO curriculum_units
+                        (unit_id, curriculum_id, subject, title, unit_name,
+                         description, has_lab, sort_order)
+                    VALUES ($1, $2, $3, $4, $5, $6, FALSE, $7)
+                    ON CONFLICT (unit_id, curriculum_id) DO NOTHING
+                    """,
+                    unit_id,
+                    curriculum_id,
+                    subject.get("subject_label", subj_code),
+                    title,
+                    title,  # unit_name mirrors title (pitfall #20)
+                    description,
+                    units_created,
+                )
+                units_created += 1
+
+        await conn.execute(
+            """
+            UPDATE authoring_projects
+               SET curriculum_id = $2, status = 'structured', updated_at = now()
+             WHERE project_id = $1
+            """,
+            project_id,
+            curriculum_id,
+        )
+
+    log.info(
+        "authoring_materialized project_id=%s curriculum_id=%s units=%d",
+        project_id,
+        curriculum_id,
+        units_created,
+    )
+    return {
+        "curriculum_id": curriculum_id,
+        "status": "structured",
+        "units_created": units_created,
+    }

--- a/backend/src/auth/tasks.py
+++ b/backend/src/auth/tasks.py
@@ -2256,3 +2256,45 @@ def generate_scenario_clips_task(
         scenario_id,
         "failed" if any_error else "done",
     )
+
+
+@celery_app.task(name="src.auth.tasks.run_authoring_analyze_task")
+def run_authoring_analyze_task(project_id: str) -> None:
+    """Structure + advisory-flow-analyze an Authoring Studio project's raw TOC.
+
+    Calls src.admin.authoring_service.run_analysis(), which builds the default
+    LLM provider, structures the pasted free-text TOC, runs the advisory flow
+    analysis, and flips the project status draft → analyzed (or back to draft
+    with analyze_error on failure). Never raises out of the worker.
+
+    pipeline imports require the repo root on sys.path (same trick as
+    run_grade_pipeline_task), since authoring_service reaches into
+    pipeline.toc_structurer / pipeline.flow_analyzer / pipeline.providers.
+    """
+    import os as _os
+    import sys as _sys
+
+    _pipeline_parent = _os.path.abspath("/pipeline/..")
+    if _pipeline_parent not in _sys.path:
+        _sys.path.insert(0, _pipeline_parent)
+
+    import asyncpg as _asyncpg
+
+    from src.admin.authoring_service import run_analysis
+
+    async def _go() -> None:
+        conn = await _asyncpg.connect(settings.DATABASE_URL)
+        try:
+            # Platform context — bypass RLS (pitfall #28). authoring_* tables
+            # aren't tenant-scoped, but keep the stamp consistent for safety.
+            await conn.execute(
+                "SELECT set_config('app.current_school_id', 'bypass', false)"
+            )
+            await run_analysis(conn, project_id)
+        finally:
+            await conn.close()
+
+    try:
+        _run_async(_go())
+    except Exception as exc:  # never let the worker crash on a bad TOC
+        log.error("run_authoring_analyze_task_failed project_id=%s error=%s", project_id, exc)

--- a/backend/src/core/app_factory.py
+++ b/backend/src/core/app_factory.py
@@ -235,6 +235,7 @@ def _register_routers(app: FastAPI) -> None:
     # Lazy imports inside this function body avoid circular imports:
     # routers import from src.core.* but never from main.py.
     from src.account.router import router as account_router
+    from src.admin.authoring_router import router as admin_authoring_router
     from src.admin.build_reports import router as ci_reports_router
     from src.admin.curriculum_lifecycle_router import router as admin_curriculum_lifecycle_router
     from src.admin.demo_accounts import router as demo_admin_router
@@ -290,6 +291,7 @@ def _register_routers(app: FastAPI) -> None:
     app.include_router(subscription_router, prefix="/api/v1")
     app.include_router(admin_router, prefix="/api/v1")
     app.include_router(admin_streams_router, prefix="/api/v1")
+    app.include_router(admin_authoring_router, prefix="/api/v1")
     app.include_router(admin_curriculum_lifecycle_router, prefix="/api/v1")
     app.include_router(admin_retention_router, prefix="/api/v1")
     app.include_router(ci_reports_router, prefix="/api/v1")

--- a/backend/tests/test_authoring.py
+++ b/backend/tests/test_authoring.py
@@ -1,0 +1,305 @@
+"""
+Endpoint + service tests for the Curriculum Authoring Studio (PR-A).
+
+Covers the super-admin gate, project creation, analyze dispatch, the
+run_analysis worker body, structure editing, and materialisation into a
+staged platform curriculum.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from main import app
+
+from src.admin import authoring_service as svc
+
+# run_analysis() lazily imports the `pipeline` package (repo root). CI runs
+# pytest from backend/, so ensure repo root is importable before any test runs.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+# ── Fake provider returning structure JSON or flow JSON by prompt marker ──────
+
+
+class _DualFakeProvider:
+    """Branches on the prompt: structurer prompt vs flow-analyzer prompt."""
+
+    STRUCTURED = {
+        "subjects": [{
+            "subject_label": "Physics",
+            "units": [
+                {"title": "Kinematics", "subtopics": ["Speed", "Velocity"],
+                 "prerequisites": []},
+                {"title": "Dynamics", "subtopics": ["Forces"],
+                 "prerequisites": ["Kinematics"]},
+            ],
+        }]
+    }
+    FLOW = {"summary": "Flow looks sound.", "warnings": []}
+
+    def generate(self, prompt: str) -> tuple[str, int, int]:
+        if "pedagogy reviewer" in prompt:
+            return json.dumps(self.FLOW), 50, 60
+        return json.dumps(self.STRUCTURED), 80, 120
+
+
+async def _seed_analyzed_project(
+    *, title: str = "Grade 9 Physics", grade: int | None = 9
+) -> str:
+    """Create + analyse a project on the committed app pool so HTTP endpoints
+    (which use their own pooled connection) can see it."""
+    async with app.state.pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        project = await svc.create_project(
+            conn,
+            title=title,
+            grade=grade,
+            languages=["en"],
+            raw_toc="1. Kinematics\n2. Dynamics",
+            created_by=None,
+        )
+        await svc.run_analysis(conn, project["project_id"], provider=_DualFakeProvider())
+    return project["project_id"]
+
+
+# ── Gate ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_project_requires_super_admin(
+    client: AsyncClient, product_admin_token: str
+) -> None:
+    r = await client.post(
+        "/api/v1/admin/authoring/projects",
+        headers={"Authorization": f"Bearer {product_admin_token}"},
+        json={"title": "G9 Physics", "grade": 9, "languages": ["en"],
+              "raw_toc": "1. Motion\n2. Forces"},
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_project_super_admin_ok(
+    client: AsyncClient, admin_token: str
+) -> None:
+    r = await client.post(
+        "/api/v1/admin/authoring/projects",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"title": "G9 Physics", "grade": 9, "languages": ["en"],
+              "raw_toc": "1. Motion\n2. Forces"},
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["status"] == "draft"
+    assert body["project_id"]
+
+
+@pytest.mark.asyncio
+async def test_create_project_rejects_bad_language(
+    client: AsyncClient, admin_token: str
+) -> None:
+    r = await client.post(
+        "/api/v1/admin/authoring/projects",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"title": "X", "grade": 9, "languages": ["klingon"], "raw_toc": "x"},
+    )
+    assert r.status_code == 422
+
+
+# ── Analyze dispatch ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_analyze_dispatches_and_marks_analyzing(
+    client: AsyncClient, admin_token: str
+) -> None:
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    created = await client.post(
+        "/api/v1/admin/authoring/projects",
+        headers=headers,
+        json={"title": "G9 Physics", "grade": 9, "languages": ["en"],
+              "raw_toc": "1. Kinematics\n2. Dynamics"},
+    )
+    project_id = created.json()["project_id"]
+
+    with patch("src.core.celery_app.celery_app.send_task") as send_task:
+        r = await client.post(
+            f"/api/v1/admin/authoring/projects/{project_id}/analyze", headers=headers
+        )
+    assert r.status_code == 202
+    assert r.json()["status"] == "analyzing"
+    send_task.assert_called_once()
+
+    detail = await client.get(
+        f"/api/v1/admin/authoring/projects/{project_id}", headers=headers
+    )
+    assert detail.json()["status"] == "analyzing"
+
+
+@pytest.mark.asyncio
+async def test_analyze_missing_project_404(
+    client: AsyncClient, admin_token: str
+) -> None:
+    r = await client.post(
+        "/api/v1/admin/authoring/projects/00000000-0000-0000-0000-000000000000/analyze",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 404
+
+
+# ── run_analysis worker body (direct, with fake provider) ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_analysis_structures_and_flows(client: AsyncClient) -> None:
+    # Use a pooled connection (jsonb codec installed) — the raw db_conn fixture
+    # cannot bind dicts to jsonb columns.
+    async with app.state.pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        project = await svc.create_project(
+            conn,
+            title="G9 Physics",
+            grade=9,
+            languages=["en"],
+            raw_toc="1. Kinematics\n2. Dynamics",
+            created_by=None,
+        )
+        await svc.run_analysis(conn, project["project_id"], provider=_DualFakeProvider())
+        detail = await svc.get_project(conn, project["project_id"])
+
+    assert detail["status"] == "analyzed"
+    assert detail["structured_toc"]["subjects"][0]["units"][0]["title"] == "Kinematics"
+    assert detail["flow_report"]["summary"] == "Flow looks sound."
+
+
+@pytest.mark.asyncio
+async def test_run_analysis_records_error_on_bad_toc(client: AsyncClient) -> None:
+    class _BadProvider:
+        def generate(self, prompt: str) -> tuple[str, int, int]:
+            return "this is not json", 1, 1
+
+    async with app.state.pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        project = await svc.create_project(
+            conn, title="X", grade=None, languages=["en"], raw_toc="junk", created_by=None
+        )
+        await svc.run_analysis(conn, project["project_id"], provider=_BadProvider())
+        detail = await svc.get_project(conn, project["project_id"])
+
+    assert detail["status"] == "draft"
+    assert detail["analyze_error"]
+
+
+# ── Structure edit ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_edit_structure_persists(client: AsyncClient, admin_token: str) -> None:
+    project_id = await _seed_analyzed_project()
+    edited = {"subjects": [{"subject_label": "Physics", "units": [
+        {"title": "Kinematics", "subtopics": ["Speed", "Velocity", "Acceleration"],
+         "prerequisites": []},
+    ]}]}
+    r = await client.put(
+        f"/api/v1/admin/authoring/projects/{project_id}/structure",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"structured_toc": edited},
+    )
+    assert r.status_code == 200
+    units = r.json()["structured_toc"]["subjects"][0]["units"]
+    assert units[0]["subtopics"] == ["Speed", "Velocity", "Acceleration"]
+
+
+@pytest.mark.asyncio
+async def test_edit_structure_conflict_when_draft(
+    client: AsyncClient, admin_token: str
+) -> None:
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    created = await client.post(
+        "/api/v1/admin/authoring/projects",
+        headers=headers,
+        json={"title": "X", "grade": 9, "languages": ["en"], "raw_toc": "1. A"},
+    )
+    project_id = created.json()["project_id"]
+    r = await client.put(
+        f"/api/v1/admin/authoring/projects/{project_id}/structure",
+        headers=headers,
+        json={"structured_toc": {"subjects": [
+            {"subject_label": "S", "units": [{"title": "A"}]}]}},
+    )
+    assert r.status_code == 409
+
+
+# ── Materialize ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_materialize_creates_staged_platform_curriculum(
+    client: AsyncClient, admin_token: str, db_conn
+) -> None:
+    project_id = await _seed_analyzed_project()
+    r = await client.post(
+        f"/api/v1/admin/authoring/projects/{project_id}/materialize",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 201
+    curriculum_id = r.json()["curriculum_id"]
+    assert r.json()["units_created"] == 2
+
+    row = await db_conn.fetchrow(
+        "SELECT owner_type, source_type, is_default, school_id "
+        "FROM curricula WHERE curriculum_id = $1",
+        curriculum_id,
+    )
+    assert row["owner_type"] == "platform"
+    assert row["source_type"] == "admin_authored"
+    assert row["is_default"] is False
+    assert row["school_id"] is None
+
+    units = await db_conn.fetch(
+        "SELECT title, unit_name FROM curriculum_units WHERE curriculum_id = $1",
+        curriculum_id,
+    )
+    assert len(units) == 2
+    # pitfall #20 — unit_name mirrors title and is never null
+    assert all(u["unit_name"] == u["title"] for u in units)
+
+
+@pytest.mark.asyncio
+async def test_materialize_is_idempotent(
+    client: AsyncClient, admin_token: str
+) -> None:
+    project_id = await _seed_analyzed_project()
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    first = await client.post(
+        f"/api/v1/admin/authoring/projects/{project_id}/materialize", headers=headers
+    )
+    second = await client.post(
+        f"/api/v1/admin/authoring/projects/{project_id}/materialize", headers=headers
+    )
+    assert first.json()["curriculum_id"] == second.json()["curriculum_id"]
+    assert second.json()["units_created"] == 2
+
+
+@pytest.mark.asyncio
+async def test_materialize_conflict_without_structure(
+    client: AsyncClient, admin_token: str
+) -> None:
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    created = await client.post(
+        "/api/v1/admin/authoring/projects",
+        headers=headers,
+        json={"title": "X", "grade": 9, "languages": ["en"], "raw_toc": "1. A"},
+    )
+    project_id = created.json()["project_id"]
+    r = await client.post(
+        f"/api/v1/admin/authoring/projects/{project_id}/materialize", headers=headers
+    )
+    assert r.status_code == 409

--- a/backend/tests/test_authoring_pipeline.py
+++ b/backend/tests/test_authoring_pipeline.py
@@ -1,0 +1,117 @@
+"""
+Pipeline-layer tests for the Curriculum Authoring Studio (PR-A).
+
+Covers the pure structuring + flow-analysis modules and the deterministic
+(no-LLM) ordering check. No DB, no real provider — fake providers return
+canned JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+# CI runs pytest from backend/; the `pipeline` package lives at repo root.
+# Mirror the sys.path idiom in tests/test_pipeline.py so the imports below
+# resolve in CI and in the local container (where repo root resolves to `/`).
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from pipeline.flow_analyzer import FlowReport, analyze_toc_flow  # noqa: E402
+from pipeline.toc_structurer import StructuredTOC, structure_toc  # noqa: E402
+
+from src.admin.authoring_flow import check_topic_ordering  # noqa: E402
+
+
+class _FakeProvider:
+    """Returns a fixed response string; ignores the prompt."""
+
+    def __init__(self, response: str) -> None:
+        self._response = response
+
+    def generate(self, prompt: str) -> tuple[str, int, int]:
+        return self._response, 100, 200
+
+
+def test_structure_toc_parses_free_text() -> None:
+    response = json.dumps({
+        "subjects": [{
+            "subject_label": "Motion",
+            "units": [
+                {"title": "Speed and velocity", "subtopics": ["Speed", "Velocity"],
+                 "prerequisites": []},
+                {"title": "Acceleration", "subtopics": ["Average", "Instantaneous"],
+                 "prerequisites": ["Speed and velocity"]},
+            ],
+        }]
+    })
+    raw = "Chapter 1 Motion\n 1.1 Speed and velocity\n 1.2 Acceleration"
+    structured = structure_toc(raw, grade=9, provider=_FakeProvider(response))
+
+    assert isinstance(structured, StructuredTOC)
+    assert structured.subjects[0].units[0].title == "Speed and velocity"
+    assert structured.subjects[0].units[0].subtopics == ["Speed", "Velocity"]
+
+
+def test_structure_toc_strips_code_fences() -> None:
+    fenced = "```json\n" + json.dumps({
+        "subjects": [{"subject_label": "Bio",
+                      "units": [{"title": "Cells", "subtopics": [], "prerequisites": []}]}]
+    }) + "\n```"
+    structured = structure_toc("Cells", grade=7, provider=_FakeProvider(fenced))
+    assert structured.subjects[0].units[0].title == "Cells"
+
+
+def test_flow_analyzer_flags_prereq_gap() -> None:
+    response = json.dumps({
+        "summary": "One ordering issue found.",
+        "warnings": [{
+            "kind": "prerequisite_after_use",
+            "unit": "Acceleration",
+            "subject": "Physics",
+            "detail": "Acceleration needs Velocity, taught later.",
+        }],
+    })
+    structured = {
+        "subjects": [{"subject_label": "Physics", "units": [
+            {"title": "Acceleration", "subtopics": [], "prerequisites": ["Velocity"]},
+            {"title": "Velocity", "subtopics": [], "prerequisites": []},
+        ]}]
+    }
+    report: FlowReport = analyze_toc_flow(structured, provider=_FakeProvider(response))
+    assert any(w.kind == "prerequisite_after_use" for w in report.warnings)
+
+
+def test_flow_analyzer_never_raises_on_garbage() -> None:
+    report = analyze_toc_flow({"subjects": []}, provider=_FakeProvider("not json at all"))
+    assert isinstance(report, FlowReport)
+    assert report.warnings == []
+
+
+def test_deterministic_ordering_check_flags_late_prereq() -> None:
+    structured = {"subjects": [{"subject_label": "P", "units": [
+        {"title": "B", "subtopics": [], "prerequisites": ["A"]},
+        {"title": "A", "subtopics": [], "prerequisites": []},
+    ]}]}
+    warnings = check_topic_ordering(structured)
+    assert warnings
+    assert warnings[0]["unit"] == "B"
+    assert warnings[0]["kind"] == "prerequisite_after_use"
+
+
+def test_deterministic_ordering_check_clean_when_in_order() -> None:
+    structured = {"subjects": [{"subject_label": "P", "units": [
+        {"title": "A", "subtopics": [], "prerequisites": []},
+        {"title": "B", "subtopics": [], "prerequisites": ["A"]},
+    ]}]}
+    assert check_topic_ordering(structured) == []
+
+
+def test_deterministic_ordering_check_flags_missing_prereq() -> None:
+    structured = {"subjects": [{"subject_label": "P", "units": [
+        {"title": "A", "subtopics": [], "prerequisites": ["Nonexistent"]},
+    ]}]}
+    warnings = check_topic_ordering(structured)
+    assert any(w["kind"] == "missing_prerequisite" for w in warnings)

--- a/pipeline/flow_analyzer.py
+++ b/pipeline/flow_analyzer.py
@@ -1,0 +1,159 @@
+"""
+pipeline/flow_analyzer.py — advisory pedagogical-flow analysis of a TOC.
+
+After a free-text TOC has been structured (see toc_structurer.py), the
+Authoring Studio runs this LLM pass to surface *advisory* flow problems:
+prerequisites used before they're taught, conceptual gaps, redundant topics,
+and ordering that fights comprehension.
+
+This is advisory only. It never rewrites the curriculum and never blocks the
+operator — it produces a FlowReport the studio renders alongside the editable
+topic table. The operator decides what to act on.
+
+For the cheap, deterministic, no-LLM check that runs on every topic edit, see
+backend/src/admin/authoring_flow.py::check_topic_ordering — this module is the
+richer (paid) analysis run on demand.
+
+Public surface:
+  - FlowWarning / FlowReport     Pydantic models
+  - analyze_toc_flow()           sync; takes an LLMProvider instance
+  - FLOW_PROMPT_TEMPLATE         exposed for tests
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from pydantic import BaseModel, Field, ValidationError
+
+log = logging.getLogger("pipeline.flow_analyzer")
+
+# Closed-ish set of warning kinds the studio UI knows how to render. The LLM is
+# instructed to use these; unknown kinds are kept (forward-compatible) but the
+# UI groups them under "other".
+FLOW_WARNING_KINDS = (
+    "prerequisite_after_use",  # a prereq is taught after the unit that needs it
+    "missing_prerequisite",    # a referenced prereq isn't in the curriculum
+    "conceptual_gap",          # a jump that skips an expected intermediate topic
+    "redundant_topic",         # the same concept is covered twice
+    "ordering",                # general sequencing concern
+)
+
+
+class FlowWarning(BaseModel):
+    """One advisory flow concern."""
+
+    kind: str = Field(min_length=1)
+    unit: str = Field(default="")        # the unit title the warning is about
+    subject: str | None = None
+    detail: str = Field(default="")      # human-readable explanation
+
+
+class FlowReport(BaseModel):
+    """Advisory flow analysis of a structured TOC."""
+
+    warnings: list[FlowWarning] = Field(default_factory=list)
+    summary: str = Field(default="")
+
+
+FLOW_PROMPT_TEMPLATE = """\
+You are a curriculum pedagogy reviewer. Below is a structured table of
+contents (subjects → units → subtopics, with optional prerequisites).
+Analyse the LEARNING FLOW and report concerns.
+
+Structured TOC (JSON):
+{structured_json}
+
+Look for:
+- prerequisite_after_use: a unit relies on a concept that is taught in a
+  LATER unit (or lists a prerequisite that appears after it).
+- missing_prerequisite: a unit lists or clearly needs a prerequisite that is
+  nowhere in the curriculum.
+- conceptual_gap: the sequence jumps over an expected intermediate concept.
+- redundant_topic: two units cover essentially the same concept.
+- ordering: any other sequencing issue that would hurt comprehension.
+
+Return ONLY a JSON object (no prose, no markdown fences):
+{{
+  "summary": "one or two sentences on overall flow health",
+  "warnings": [
+    {{"kind": "<one of the kinds above>", "unit": "<unit title>",
+      "subject": "<subject label or null>", "detail": "<why it matters>"}}
+  ]
+}}
+If the flow is sound, return an empty "warnings" array with a brief positive
+summary. Do not invent problems.
+"""
+
+
+def _strip_code_fences(text: str) -> str:
+    t = text.strip()
+    if t.startswith("```"):
+        first_nl = t.find("\n")
+        if first_nl != -1:
+            t = t[first_nl + 1 :]
+        if t.rstrip().endswith("```"):
+            t = t.rstrip()[:-3]
+    return t.strip()
+
+
+def _to_plain(structured: Any) -> dict:
+    """Accept a StructuredTOC, a pydantic model, or a plain dict."""
+    if hasattr(structured, "model_dump"):
+        return structured.model_dump()
+    return structured
+
+
+def analyze_toc_flow(
+    structured: Any,
+    provider,
+    settings=None,
+) -> FlowReport:
+    """Run the advisory LLM flow analysis over a structured TOC.
+
+    Args:
+        structured: StructuredTOC | dict — the structured table of contents.
+        provider:   An LLMProvider instance.
+        settings:   Unused when ``provider`` is supplied; kept for symmetry.
+
+    Returns:
+        FlowReport. Never raises on bad LLM output — a malformed response
+        yields an empty report with a diagnostic summary, because flow
+        analysis is advisory and must not break the authoring workflow.
+    """
+    plain = _to_plain(structured)
+    prompt = FLOW_PROMPT_TEMPLATE.format(
+        structured_json=json.dumps(plain, ensure_ascii=False, indent=2),
+    )
+
+    try:
+        text, _in_tok, _out_tok = provider.generate(prompt)
+    except Exception as exc:  # provider SDKs raise their own error types
+        log.warning("flow_analyzer: provider failed: %s", exc)
+        return FlowReport(summary="flow analysis unavailable (provider error)")
+
+    cleaned = _strip_code_fences(text)
+    if not cleaned:
+        return FlowReport(summary="flow analysis unavailable (empty response)")
+
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        log.warning("flow_analyzer: bad JSON: %s", exc)
+        return FlowReport(summary="flow analysis unavailable (unparseable response)")
+
+    if not isinstance(parsed, dict):
+        return FlowReport(summary="flow analysis unavailable (unexpected shape)")
+
+    warnings: list[FlowWarning] = []
+    for i, item in enumerate(parsed.get("warnings", []) or []):
+        if not isinstance(item, dict):
+            continue
+        try:
+            warnings.append(FlowWarning(**item))
+        except ValidationError as exc:
+            log.warning("flow_analyzer: warning %d failed validation: %s", i, exc)
+
+    return FlowReport(warnings=warnings, summary=str(parsed.get("summary", "")))

--- a/pipeline/toc_structurer.py
+++ b/pipeline/toc_structurer.py
@@ -1,0 +1,167 @@
+"""
+pipeline/toc_structurer.py — free-text TOC → structured curriculum tree.
+
+The super-admin Curriculum Authoring Studio (Epic: Authoring Studio) lets an
+operator paste a rough, free-text table of contents (a textbook index, a
+syllabus outline, a bullet list). This module turns that into the canonical
+structured shape the rest of the platform speaks:
+
+    {
+      "subjects": [
+        {"subject_label": "Physics",
+         "units": [
+           {"title": "Kinematics",
+            "subtopics": ["Speed", "Velocity", "Acceleration"],
+            "prerequisites": []},
+           ...
+         ]}
+      ]
+    }
+
+The LLM's job is *extraction + light normalisation* — group loose lines into
+subjects → units → subtopics and surface obvious prerequisite hints. It must
+not invent units the operator didn't write; the operator edits the result in
+the studio table afterwards.
+
+Public surface:
+  - TopicNode / SubjectNode / StructuredTOC   Pydantic models
+  - StructureError                            raised on unrecoverable parse failure
+  - structure_toc()                           sync; takes an LLMProvider instance
+  - STRUCTURE_PROMPT_TEMPLATE                  exposed for tests
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from pydantic import BaseModel, Field, ValidationError
+
+log = logging.getLogger("pipeline.toc_structurer")
+
+
+class TopicNode(BaseModel):
+    """One unit/topic within a subject."""
+
+    title: str = Field(min_length=1, max_length=300)
+    subtopics: list[str] = Field(default_factory=list)
+    prerequisites: list[str] = Field(default_factory=list)
+
+
+class SubjectNode(BaseModel):
+    """A subject grouping a list of units."""
+
+    subject_label: str = Field(min_length=1, max_length=200)
+    units: list[TopicNode] = Field(default_factory=list)
+
+
+class StructuredTOC(BaseModel):
+    """The full structured table of contents."""
+
+    subjects: list[SubjectNode] = Field(default_factory=list)
+
+
+class StructureError(RuntimeError):
+    """Raised when the LLM output cannot be parsed into a StructuredTOC."""
+
+
+STRUCTURE_PROMPT_TEMPLATE = """\
+You are a curriculum architect. An operator has pasted a rough, free-text
+table of contents for educational material{grade_clause}. Turn it into a
+clean structured tree.
+
+Raw table of contents:
+\"\"\"
+{raw_toc}
+\"\"\"
+
+Rules:
+- Group lines into subjects → units → subtopics, following the operator's
+  evident intent. A "subject" is a broad area (e.g. Physics); a "unit" is a
+  chapter/topic (e.g. Kinematics); "subtopics" are the finer points listed
+  under it.
+- If the paste covers a single subject with no explicit subject heading,
+  infer ONE reasonable subject_label and put every unit under it.
+- Populate "prerequisites" ONLY when the source text makes a dependency
+  explicit, or when a unit unmistakably requires an earlier unit's concept.
+  Reference prerequisites by the exact unit "title" you assigned. When in
+  doubt, leave prerequisites empty — do not guess.
+- Do NOT invent units, subtopics, or subjects that are not implied by the
+  source. Do NOT drop content the operator wrote.
+
+Return ONLY a JSON object (no prose, no markdown fences) of this exact shape:
+{{
+  "subjects": [
+    {{
+      "subject_label": "string",
+      "units": [
+        {{"title": "string", "subtopics": ["string", ...], "prerequisites": ["string", ...]}}
+      ]
+    }}
+  ]
+}}
+"""
+
+
+def _strip_code_fences(text: str) -> str:
+    t = text.strip()
+    if t.startswith("```"):
+        first_nl = t.find("\n")
+        if first_nl != -1:
+            t = t[first_nl + 1 :]
+        if t.rstrip().endswith("```"):
+            t = t.rstrip()[:-3]
+    return t.strip()
+
+
+def structure_toc(
+    raw_toc: str,
+    grade: int | None,
+    provider,
+    settings=None,
+) -> StructuredTOC:
+    """Structure a free-text TOC into a StructuredTOC via the given provider.
+
+    Args:
+        raw_toc:  The operator's pasted free text.
+        grade:    Optional grade (1-12) — included in the prompt for context.
+        provider: An LLMProvider instance (``.generate(prompt) -> (text, in, out)``).
+        settings: Unused when ``provider`` is supplied; kept for call symmetry.
+
+    Returns:
+        StructuredTOC with at least one subject.
+
+    Raises:
+        StructureError: the LLM returned something that is not a parseable,
+            non-empty StructuredTOC. The caller (analyze task) records this on
+            the project so the operator can re-run.
+    """
+    grade_clause = f" for grade {grade}" if grade else ""
+    prompt = STRUCTURE_PROMPT_TEMPLATE.format(
+        grade_clause=grade_clause,
+        raw_toc=raw_toc,
+    )
+
+    try:
+        text, _in_tok, _out_tok = provider.generate(prompt)
+    except Exception as exc:  # provider SDKs raise their own error types
+        raise StructureError(f"provider call failed: {exc}") from exc
+
+    cleaned = _strip_code_fences(text)
+    if not cleaned:
+        raise StructureError("empty LLM response")
+
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        raise StructureError(f"bad JSON from LLM: {exc}") from exc
+
+    try:
+        structured = StructuredTOC(**parsed)
+    except (ValidationError, TypeError) as exc:
+        raise StructureError(f"schema validation failed: {exc}") from exc
+
+    if not structured.subjects or not any(s.units for s in structured.subjects):
+        raise StructureError("structured TOC has no subjects/units")
+
+    return structured

--- a/web/lib/api/types.gen.ts
+++ b/web/lib/api/types.gen.ts
@@ -1986,6 +1986,92 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/authoring/projects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Projects */
+        get: operations["list_projects_api_v1_admin_authoring_projects_get"];
+        put?: never;
+        /** Create Project */
+        post: operations["create_project_api_v1_admin_authoring_projects_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/authoring/projects/{project_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Project */
+        get: operations["get_project_api_v1_admin_authoring_projects__project_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/authoring/projects/{project_id}/analyze": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Analyze Project */
+        post: operations["analyze_project_api_v1_admin_authoring_projects__project_id__analyze_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/authoring/projects/{project_id}/structure": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Edit Structure */
+        put: operations["edit_structure_api_v1_admin_authoring_projects__project_id__structure_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/authoring/projects/{project_id}/materialize": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Materialize Project */
+        post: operations["materialize_project_api_v1_admin_authoring_projects__project_id__materialize_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/curricula/{curriculum_id}/usage": {
         parameters: {
             query?: never;
@@ -5919,6 +6005,13 @@ export interface components {
              */
             updated_at: string;
         };
+        /** AnalyzeResponse */
+        AnalyzeResponse: {
+            /** Job Id */
+            job_id: string;
+            /** Status */
+            status: string;
+        };
         /** AnnotateRequest */
         AnnotateRequest: {
             /** Unit Id */
@@ -6631,6 +6724,24 @@ export interface components {
              */
             payouts_enabled: boolean;
         };
+        /** CreateProjectRequest */
+        CreateProjectRequest: {
+            /** Title */
+            title: string;
+            /** Grade */
+            grade?: number | null;
+            /** Languages */
+            languages?: string[];
+            /** Raw Toc */
+            raw_toc: string;
+        };
+        /** CreateProjectResponse */
+        CreateProjectResponse: {
+            /** Project Id */
+            project_id: string;
+            /** Status */
+            status: string;
+        };
         /** CreditsBundleCheckoutRequest */
         CreditsBundleCheckoutRequest: {
             /** Bundle Size */
@@ -7226,6 +7337,10 @@ export interface components {
             /** Description */
             description: string;
         };
+        /** EditStructureRequest */
+        EditStructureRequest: {
+            structured_toc: components["schemas"]["StructuredTOC"];
+        };
         /** EndSessionRequest */
         EndSessionRequest: {
             /** Score */
@@ -7766,6 +7881,15 @@ export interface components {
             /** Seen At */
             seen_at?: string | null;
         };
+        /** MaterializeResponse */
+        MaterializeResponse: {
+            /** Curriculum Id */
+            curriculum_id: string;
+            /** Status */
+            status: string;
+            /** Units Created */
+            units_created: number;
+        };
         /** NextUnit */
         NextUnit: {
             /** Unit Id */
@@ -8047,6 +8171,79 @@ export interface components {
             needs_retry_count: number;
             /** Subjects */
             subjects: components["schemas"]["SubjectProgressMap"][];
+        };
+        /** ProjectDetail */
+        ProjectDetail: {
+            /** Project Id */
+            project_id: string;
+            /** Title */
+            title: string;
+            /** Grade */
+            grade?: number | null;
+            /** Languages */
+            languages: string[];
+            /** Status */
+            status: string;
+            /** Curriculum Id */
+            curriculum_id?: string | null;
+            /** Visibility */
+            visibility: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Raw Toc */
+            raw_toc?: string | null;
+            /** Structured Toc */
+            structured_toc?: {
+                [key: string]: unknown;
+            } | null;
+            /** Flow Report */
+            flow_report?: {
+                [key: string]: unknown;
+            } | null;
+            /** Analyze Error */
+            analyze_error?: string | null;
+        };
+        /** ProjectListResponse */
+        ProjectListResponse: {
+            /** Projects */
+            projects: components["schemas"]["ProjectSummary"][];
+            /** Total */
+            total: number;
+        };
+        /** ProjectSummary */
+        ProjectSummary: {
+            /** Project Id */
+            project_id: string;
+            /** Title */
+            title: string;
+            /** Grade */
+            grade?: number | null;
+            /** Languages */
+            languages: string[];
+            /** Status */
+            status: string;
+            /** Curriculum Id */
+            curriculum_id?: string | null;
+            /** Visibility */
+            visibility: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
         };
         /** PromoteTeacherResponse */
         PromoteTeacherResponse: {
@@ -9129,6 +9326,11 @@ export interface components {
             /** Description */
             description?: string | null;
         };
+        /** StructuredTOC */
+        StructuredTOC: {
+            /** Subjects */
+            subjects?: components["schemas"]["SubjectNode"][];
+        };
         /** StruggleItem */
         StruggleItem: {
             /** Unit Id */
@@ -9315,6 +9517,13 @@ export interface components {
             name: string;
             /** Units */
             units: components["schemas"]["Unit"][];
+        };
+        /** SubjectNode */
+        SubjectNode: {
+            /** Subject Label */
+            subject_label: string;
+            /** Units */
+            units?: components["schemas"]["TopicNode"][];
         };
         /** SubjectProgress */
         SubjectProgress: {
@@ -9632,6 +9841,15 @@ export interface components {
              */
             student_id: string;
             student: components["schemas"]["StudentPublic"];
+        };
+        /** TopicNode */
+        TopicNode: {
+            /** Title */
+            title: string;
+            /** Subtopics */
+            subtopics?: string[];
+            /** Prerequisites */
+            prerequisites?: string[];
         };
         /** TrendsReport */
         TrendsReport: {
@@ -13159,6 +13377,187 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["StreamMergeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_projects_api_v1_admin_authoring_projects_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectListResponse"];
+                };
+            };
+        };
+    };
+    create_project_api_v1_admin_authoring_projects_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateProjectRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateProjectResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_project_api_v1_admin_authoring_projects__project_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analyze_project_api_v1_admin_authoring_projects__project_id__analyze_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnalyzeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    edit_structure_api_v1_admin_authoring_projects__project_id__structure_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EditStructureRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    materialize_project_api_v1_admin_authoring_projects__project_id__materialize_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MaterializeResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -4686,6 +4686,274 @@
         }
       }
     },
+    "/api/v1/admin/authoring/projects": {
+      "get": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "List Projects",
+        "operationId": "list_projects_api_v1_admin_authoring_projects_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectListResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "Create Project",
+        "operationId": "create_project_api_v1_admin_authoring_projects_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateProjectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateProjectResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/admin/authoring/projects/{project_id}": {
+      "get": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "Get Project",
+        "operationId": "get_project_api_v1_admin_authoring_projects__project_id__get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectDetail"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/authoring/projects/{project_id}/analyze": {
+      "post": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "Analyze Project",
+        "operationId": "analyze_project_api_v1_admin_authoring_projects__project_id__analyze_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnalyzeResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/authoring/projects/{project_id}/structure": {
+      "put": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "Edit Structure",
+        "operationId": "edit_structure_api_v1_admin_authoring_projects__project_id__structure_put",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditStructureRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectDetail"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/authoring/projects/{project_id}/materialize": {
+      "post": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "Materialize Project",
+        "operationId": "materialize_project_api_v1_admin_authoring_projects__project_id__materialize_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaterializeResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/admin/curricula/{curriculum_id}/usage": {
       "get": {
         "summary": "Get Curriculum Usage",
@@ -15571,6 +15839,24 @@
         ],
         "title": "AlertSettingsResponse"
       },
+      "AnalyzeResponse": {
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "title": "Job Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "job_id",
+          "status"
+        ],
+        "title": "AnalyzeResponse"
+      },
       "AnnotateRequest": {
         "properties": {
           "unit_id": {
@@ -17486,6 +17772,66 @@
         ],
         "title": "ConnectStatusResponse"
       },
+      "CreateProjectRequest": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 300,
+            "minLength": 1,
+            "title": "Title"
+          },
+          "grade": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 12.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grade"
+          },
+          "languages": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Languages"
+          },
+          "raw_toc": {
+            "type": "string",
+            "maxLength": 20000,
+            "minLength": 1,
+            "title": "Raw Toc"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "raw_toc"
+        ],
+        "title": "CreateProjectRequest"
+      },
+      "CreateProjectResponse": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "project_id",
+          "status"
+        ],
+        "title": "CreateProjectResponse"
+      },
       "CreditsBundleCheckoutRequest": {
         "properties": {
           "bundle_size": {
@@ -19097,6 +19443,18 @@
         ],
         "title": "EarningsItem"
       },
+      "EditStructureRequest": {
+        "properties": {
+          "structured_toc": {
+            "$ref": "#/components/schemas/StructuredTOC"
+          }
+        },
+        "type": "object",
+        "required": [
+          "structured_toc"
+        ],
+        "title": "EditStructureRequest"
+      },
       "EndSessionRequest": {
         "properties": {
           "score": {
@@ -20509,6 +20867,29 @@
         ],
         "title": "MarkSeenResponse"
       },
+      "MaterializeResponse": {
+        "properties": {
+          "curriculum_id": {
+            "type": "string",
+            "title": "Curriculum Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "units_created": {
+            "type": "integer",
+            "title": "Units Created"
+          }
+        },
+        "type": "object",
+        "required": [
+          "curriculum_id",
+          "status",
+          "units_created"
+        ],
+        "title": "MaterializeResponse"
+      },
       "NextUnit": {
         "properties": {
           "unit_id": {
@@ -21232,6 +21613,213 @@
           "subjects"
         ],
         "title": "ProgressMapResponse"
+      },
+      "ProjectDetail": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "grade": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grade"
+          },
+          "languages": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Languages"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "curriculum_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Curriculum Id"
+          },
+          "visibility": {
+            "type": "string",
+            "title": "Visibility"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "raw_toc": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Raw Toc"
+          },
+          "structured_toc": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Structured Toc"
+          },
+          "flow_report": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Flow Report"
+          },
+          "analyze_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Analyze Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "project_id",
+          "title",
+          "languages",
+          "status",
+          "visibility",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ProjectDetail"
+      },
+      "ProjectListResponse": {
+        "properties": {
+          "projects": {
+            "items": {
+              "$ref": "#/components/schemas/ProjectSummary"
+            },
+            "type": "array",
+            "title": "Projects"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "projects",
+          "total"
+        ],
+        "title": "ProjectListResponse"
+      },
+      "ProjectSummary": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "grade": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grade"
+          },
+          "languages": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Languages"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "curriculum_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Curriculum Id"
+          },
+          "visibility": {
+            "type": "string",
+            "title": "Visibility"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "project_id",
+          "title",
+          "languages",
+          "status",
+          "visibility",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ProjectSummary"
       },
       "PromoteTeacherResponse": {
         "properties": {
@@ -24145,6 +24733,19 @@
         "type": "object",
         "title": "StreamUpdateRequest"
       },
+      "StructuredTOC": {
+        "properties": {
+          "subjects": {
+            "items": {
+              "$ref": "#/components/schemas/SubjectNode"
+            },
+            "type": "array",
+            "title": "Subjects"
+          }
+        },
+        "type": "object",
+        "title": "StructuredTOC"
+      },
       "StruggleItem": {
         "properties": {
           "unit_id": {
@@ -24651,6 +25252,28 @@
           "units"
         ],
         "title": "Subject"
+      },
+      "SubjectNode": {
+        "properties": {
+          "subject_label": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Subject Label"
+          },
+          "units": {
+            "items": {
+              "$ref": "#/components/schemas/TopicNode"
+            },
+            "type": "array",
+            "title": "Units"
+          }
+        },
+        "type": "object",
+        "required": [
+          "subject_label"
+        ],
+        "title": "SubjectNode"
       },
       "SubjectProgress": {
         "properties": {
@@ -25406,6 +26029,35 @@
         ],
         "title": "TokenExchangeResponse",
         "description": "Response for POST /auth/exchange"
+      },
+      "TopicNode": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 300,
+            "minLength": 1,
+            "title": "Title"
+          },
+          "subtopics": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Subtopics"
+          },
+          "prerequisites": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Prerequisites"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "TopicNode"
       },
       "TrendsReport": {
         "properties": {


### PR DESCRIPTION
## What

PR-A of 2 for the **Curriculum Authoring Studio** — a super-admin tool that turns a pasted free-text table of contents into platform curriculum content. This PR covers intake → analyze → structure → materialize. (PR-B — generate/review/regenerate/snapshot/publish — stacks on this branch.)

A super-admin pastes a free-text TOC; the system structures it (LLM) + runs an advisory flow analysis, lets the admin edit the structured tree, and materialises it as a **staged platform curriculum** (`owner_type='platform'`, `source_type='admin_authored'`, `is_default=FALSE`, no `school_id`) — kept out of the school namespace until publish.

## Why

Requested super-admin capability to author content from a TOC, with editorial review of structure and flow before generation. Reuses existing machinery (Phase D `subjects/units` shape, the platform-curriculum write-guard, provider abstraction) rather than reinventing it.

## Endpoints (super_admin-gated via new `curriculum:author` permission; `product_admin` and below → 403)

`/api/v1/admin/authoring/`:
- `POST /projects` — create from pasted free-text TOC
- `GET /projects` · `GET /projects/{id}`
- `POST /projects/{id}/analyze` — Celery: structure + advisory flow (202)
- `PUT /projects/{id}/structure` — save operator edits
- `POST /projects/{id}/materialize` — → staged platform curriculum

## Data / migration

`0060_curriculum_authoring_studio`: `authoring_projects`, `authoring_topic_versions`, `authoring_active_versions`, `authoring_snapshots` (platform/admin-scoped, no tenant RLS — like `pipeline_jobs`); extends `curricula.source_type` CHECK with `admin_authored`. Downgrade deletes `admin_authored` curricula before reverting the CHECK; full down/up cycle verified.

## Alternatives considered

- Extending Phase D (school-scoped) curriculum definitions — rejected: this is a distinct platform-tier entity with an AI structuring step and post-analysis editability.

## Risk

Low/additive. New tables + endpoints; no changes to existing serving paths. The flow-analyzer is advisory only (never rewrites/blocks).

## Test plan

- 19 tests (7 pipeline: structurer/flow-analyzer/deterministic ordering; 12 endpoint/service: gate, analyze worker, structure edit, materialize staged-platform invariants + idempotency).
- Migration 0060 up **and** down cycle verified with committed `admin_authored` rows.
- ruff + bandit clean; OpenAPI + TS types regenerated; full suite collects with no import regression.

> ⚠️ Generation/analysis paths are tested with **fake** providers — not yet run against a real LLM. PR-B adds a recommendation to smoke-test the flow-analyzer prompt with a live key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)