### PR TITLE
feat(authoring): Curriculum Authoring Studio — PR-B (generate → review → regenerate → snapshot → publish)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,18 +292,36 @@ All admin routes live under `/admin/` and require a valid `sb_admin_token` JWT c
 | `/admin/feedback` | Student feedback list |
 | `/admin/audit` | Audit log |
 
-**Curriculum Authoring Studio (super-admin only, API surface — PR-A, no web UI yet):**
+**Curriculum Authoring Studio (super-admin only, API surface — PR-A + PR-B, no web UI yet):**
 Gated by the `curriculum:author` permission, which only `super_admin` holds (via its
 `{"*"}` wildcard); `product_admin` and below get 403. Endpoints under
 `/api/v1/admin/authoring/` (`backend/src/admin/authoring_router.py`):
-`POST /projects` (create from pasted free-text TOC) · `GET /projects` · `GET /projects/{id}` ·
-`POST /projects/{id}/analyze` (Celery: structure + advisory flow, 202) ·
-`PUT /projects/{id}/structure` (save edits) ·
-`POST /projects/{id}/materialize` (→ staged platform curriculum, `owner_type='platform'`,
-`source_type='admin_authored'`, `is_default=FALSE`, no `school_id`). TOC structuring +
-flow analysis live in `pipeline/toc_structurer.py` + `pipeline/flow_analyzer.py`; the cheap
-no-LLM ordering check is `backend/src/admin/authoring_flow.py`. PR-B adds
-generate/review/regenerate/snapshot/publish + Mermaid prompt emphasis.
+- **PR-A — intake → structure:** `POST /projects` (create from pasted free-text TOC) ·
+  `GET /projects` · `GET /projects/{id}` · `POST /projects/{id}/analyze` (Celery: structure +
+  advisory flow, 202) · `PUT /projects/{id}/structure` (save edits) ·
+  `POST /projects/{id}/materialize` (→ staged platform curriculum, `owner_type='platform'`,
+  `source_type='admin_authored'`, `is_default=FALSE`, no `school_id`).
+- **PR-B — generate → review → publish:** `POST /projects/{id}/generate` (Celery, all topics,
+  202) · `GET /projects/{id}/topics/{unit_id}?content_type=&history=` (active or full history) ·
+  `POST .../topics/{unit_id}/regenerate` (sync, append-only version with reason + deterministic
+  flow recheck; unlimited) · `POST .../topics/{unit_id}/accept` ·
+  `POST /projects/{id}/snapshots` + `GET …` + `POST …/{snapshot_id}/restore` (manifest snapshots:
+  per-topic append-only versions + whole-curriculum pointer rollback) ·
+  `POST /projects/{id}/flow-recheck` (Celery, full LLM re-analysis of current TOC, 202) ·
+  `POST /projects/{id}/publish` (`{visibility: private|catalog}`: gates on all active topics
+  accepted, writes accepted bodies to the content store + `content_subject_versions`, sets
+  `curricula.is_default = (visibility=='catalog')`).
+
+Content model: generated content lives in `authoring_topic_versions` (append-only) with
+`authoring_active_versions` pointing at the live version; `authoring_snapshots` hold manifest
+snapshots. TOC structuring + flow analysis: `pipeline/toc_structurer.py` +
+`pipeline/flow_analyzer.py`; per-topic generation + regenerate: `backend/src/admin/authoring_generation.py`;
+cheap no-LLM ordering check: `backend/src/admin/authoring_flow.py`. Generation uses the shared
+prompt builders with `diagram_emphasis=True` (Mermaid diagrams + richer prose — counters
+"too terse"); `web/components/content/MermaidDiagram.tsx` renders fenced ```mermaid blocks in
+`SBMarkdown`. State machine: `draft → analyzing → analyzed → structured → generating → generated
+→ published`. Celery tasks (raw asyncpg connections) register the jsonb codec before binding
+dict payloads (else asyncpg rejects them — "expected str, got dict").
 
 ---
 

--- a/backend/src/admin/authoring_generation.py
+++ b/backend/src/admin/authoring_generation.py
@@ -1,0 +1,454 @@
+"""
+backend/src/admin/authoring_generation.py
+
+Per-topic content generation, append-only versioning, and regenerate-with-reason
+for the Curriculum Authoring Studio (PR-B).
+
+Content model
+-------------
+Generated content lives in authoring_topic_versions (append-only) with
+authoring_active_versions pointing at the live version per
+(project_id, unit_id, lang, content_type). This is the studio working copy;
+publish() (authoring_service) writes the *accepted* versions out to the content
+store + content_subject_versions so students/admin-review can see them.
+
+Generation uses the shared pipeline prompt builders with diagram_emphasis=True
+for lessons + tutorials (Mermaid diagrams, richer prose — counters the "too
+terse" feedback). Each response is schema-validated before it is stored.
+
+The expensive full-curriculum generate() runs in a Celery task; regenerate of a
+single topic runs synchronously on the request (one LLM call) so the operator
+gets the new version + flow recheck back immediately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import UTC, datetime
+
+import asyncpg
+
+from src.admin.authoring_flow import check_topic_ordering
+from src.admin.authoring_service import _build_authoring_provider, _coerce_json
+from src.utils.logger import get_logger
+
+log = get_logger("authoring")
+
+# Quiz sets generated per unit; lesson + tutorial always; experiment only when
+# the unit is flagged has_lab.
+QUIZ_SETS = 3
+BASE_CONTENT_TYPES = ("lesson", "tutorial", "quiz_set_1", "quiz_set_2", "quiz_set_3")
+
+
+def _strip_code_fences(text: str) -> str:
+    t = text.strip()
+    if t.startswith("```"):
+        first_nl = t.find("\n")
+        if first_nl != -1:
+            t = t[first_nl + 1 :]
+        if t.rstrip().endswith("```"):
+            t = t.rstrip()[:-3]
+    return t.strip()
+
+
+class GenerationError(RuntimeError):
+    """Raised when a single content_type cannot be generated/validated."""
+
+
+def _build_prompt(content_type: str, *, unit_id: str, subject: str, topic: str,
+                  grade: int, lang: str) -> str:
+    """Build the prompt for a content_type, with diagram emphasis on prose types."""
+    from pipeline.prompts import (
+        build_experiment_prompt,
+        build_lesson_prompt,
+        build_quiz_prompt,
+        build_tutorial_prompt,
+    )
+
+    g = grade or 8
+    if content_type == "lesson":
+        return build_lesson_prompt(unit_id, subject, topic, g, lang, diagram_emphasis=True)
+    if content_type == "tutorial":
+        return build_tutorial_prompt(unit_id, subject, topic, g, lang, diagram_emphasis=True)
+    if content_type.startswith("quiz_set_"):
+        set_number = int(content_type.rsplit("_", 1)[1])
+        return build_quiz_prompt(unit_id, subject, topic, g, lang, set_number, QUIZ_SETS)
+    if content_type == "experiment":
+        return build_experiment_prompt(unit_id, subject, topic, g, lang)
+    raise GenerationError(f"unknown content_type {content_type!r}")
+
+
+def _validate(content_type: str, body: dict) -> None:
+    from pipeline.schemas import (
+        validate_experiment,
+        validate_lesson,
+        validate_quiz,
+        validate_tutorial,
+    )
+
+    if content_type == "lesson":
+        validate_lesson(body)
+    elif content_type == "tutorial":
+        validate_tutorial(body)
+    elif content_type.startswith("quiz_set_"):
+        validate_quiz(body)
+    elif content_type == "experiment":
+        validate_experiment(body)
+
+
+def generate_one(
+    provider,
+    *,
+    content_type: str,
+    unit_id: str,
+    subject: str,
+    topic: str,
+    grade: int,
+    lang: str,
+) -> tuple[dict, int]:
+    """Generate + validate one content_type. Returns (body, total_tokens).
+
+    Raises GenerationError on a provider error, unparseable JSON, or schema
+    validation failure — the caller decides whether to skip or surface it.
+    """
+    prompt = _build_prompt(
+        content_type, unit_id=unit_id, subject=subject, topic=topic, grade=grade, lang=lang
+    )
+    try:
+        text, in_tok, out_tok = provider.generate(prompt)
+    except Exception as exc:  # provider SDKs raise their own error types
+        raise GenerationError(f"provider failed for {content_type}: {exc}") from exc
+
+    try:
+        body = json.loads(_strip_code_fences(text))
+    except json.JSONDecodeError as exc:
+        raise GenerationError(f"bad JSON for {content_type}: {exc}") from exc
+
+    try:
+        _validate(content_type, body)
+    except Exception as exc:  # jsonschema.ValidationError
+        raise GenerationError(f"schema validation failed for {content_type}: {exc}") from exc
+
+    return body, int(in_tok) + int(out_tok)
+
+
+# ── Append-only version + active pointer helpers ──────────────────────────────
+
+
+async def next_version_number(
+    conn: asyncpg.Connection, project_id: str, unit_id: str, lang: str, content_type: str
+) -> int:
+    row = await conn.fetchval(
+        """
+        SELECT COALESCE(MAX(version_number), 0)
+          FROM authoring_topic_versions
+         WHERE project_id = $1 AND unit_id = $2 AND lang = $3 AND content_type = $4
+        """,
+        project_id, unit_id, lang, content_type,
+    )
+    return int(row or 0) + 1
+
+
+async def append_topic_version(
+    conn: asyncpg.Connection,
+    *,
+    project_id: str,
+    unit_id: str,
+    lang: str,
+    content_type: str,
+    body: dict,
+    regen_reason: str | None = None,
+    flow_recheck: list | None = None,
+    ai_model: str | None = None,
+    tokens_used: int | None = None,
+    created_by: uuid.UUID | None = None,
+    set_active: bool = True,
+) -> dict:
+    """Insert a new append-only version and (optionally) point active at it."""
+    version_number = await next_version_number(conn, project_id, unit_id, lang, content_type)
+    row = await conn.fetchrow(
+        """
+        INSERT INTO authoring_topic_versions
+            (project_id, unit_id, lang, content_type, body, version_number,
+             regen_reason, flow_recheck, ai_model, tokens_used, created_by)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        RETURNING topic_version_id, version_number, review_status, created_at
+        """,
+        project_id, unit_id, lang, content_type, body, version_number,
+        regen_reason, flow_recheck, ai_model, tokens_used, created_by,
+    )
+    topic_version_id = row["topic_version_id"]
+    if set_active:
+        await set_active_version(conn, project_id, unit_id, lang, content_type, topic_version_id)
+    return {
+        "topic_version_id": str(topic_version_id),
+        "version_number": row["version_number"],
+        "review_status": row["review_status"],
+        "created_at": row["created_at"],
+    }
+
+
+async def set_active_version(
+    conn: asyncpg.Connection,
+    project_id: str,
+    unit_id: str,
+    lang: str,
+    content_type: str,
+    topic_version_id,
+) -> None:
+    await conn.execute(
+        """
+        INSERT INTO authoring_active_versions
+            (project_id, unit_id, lang, content_type, topic_version_id)
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (project_id, unit_id, lang, content_type)
+        DO UPDATE SET topic_version_id = EXCLUDED.topic_version_id,
+                      activated_at = now()
+        """,
+        project_id, unit_id, lang, content_type, topic_version_id,
+    )
+
+
+def _version_row_to_dict(row: asyncpg.Record) -> dict:
+    return {
+        "topic_version_id": str(row["topic_version_id"]),
+        "unit_id": row["unit_id"],
+        "lang": row["lang"],
+        "content_type": row["content_type"],
+        "version_number": row["version_number"],
+        "body": _coerce_json(row["body"]),
+        "regen_reason": row["regen_reason"],
+        "flow_recheck": _coerce_json(row["flow_recheck"]),
+        "review_status": row["review_status"],
+        "created_at": row["created_at"],
+        "is_active": row["is_active"],
+    }
+
+
+async def get_active_topic(
+    conn: asyncpg.Connection, project_id: str, unit_id: str, content_type: str, lang: str
+) -> dict | None:
+    row = await conn.fetchrow(
+        """
+        SELECT tv.*, (av.topic_version_id = tv.topic_version_id) AS is_active
+          FROM authoring_active_versions av
+          JOIN authoring_topic_versions tv ON tv.topic_version_id = av.topic_version_id
+         WHERE av.project_id = $1 AND av.unit_id = $2
+           AND av.content_type = $3 AND av.lang = $4
+        """,
+        project_id, unit_id, content_type, lang,
+    )
+    return _version_row_to_dict(row) if row else None
+
+
+async def get_topic_history(
+    conn: asyncpg.Connection, project_id: str, unit_id: str, content_type: str, lang: str
+) -> list[dict]:
+    rows = await conn.fetch(
+        """
+        SELECT tv.*,
+               (av.topic_version_id = tv.topic_version_id) AS is_active
+          FROM authoring_topic_versions tv
+          LEFT JOIN authoring_active_versions av
+                 ON av.project_id = tv.project_id AND av.unit_id = tv.unit_id
+                AND av.lang = tv.lang AND av.content_type = tv.content_type
+         WHERE tv.project_id = $1 AND tv.unit_id = $2
+           AND tv.content_type = $3 AND tv.lang = $4
+         ORDER BY tv.version_number DESC
+        """,
+        project_id, unit_id, content_type, lang,
+    )
+    return [_version_row_to_dict(r) for r in rows]
+
+
+# ── Generation worker bodies ──────────────────────────────────────────────────
+
+
+def _now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+async def generate_topics(
+    conn: asyncpg.Connection,
+    project_id: str,
+    *,
+    langs: list[str] | None = None,
+    force: bool = False,
+    provider=None,
+) -> dict:
+    """Generate content for every unit in a materialised project.
+
+    For each unit × lang × content_type, generates + validates content and
+    stores it as version 1 (or skips if a version already exists and not
+    force). Flips status generating → generated. Returns a summary count.
+    Never raises on a single-topic failure — failures are counted.
+    """
+    proj = await conn.fetchrow(
+        "SELECT grade, curriculum_id, status FROM authoring_projects WHERE project_id = $1",
+        project_id,
+    )
+    if proj is None or not proj["curriculum_id"]:
+        log.warning("authoring_generate_not_materialized project_id=%s", project_id)
+        return {"generated": 0, "failed": 0, "skipped": 0}
+
+    langs = langs or ["en"]
+    if provider is None:
+        provider = _build_authoring_provider()
+    model = getattr(provider, "model", None)
+
+    units = await conn.fetch(
+        "SELECT unit_id, subject, title, has_lab FROM curriculum_units "
+        "WHERE curriculum_id = $1 ORDER BY sort_order",
+        proj["curriculum_id"],
+    )
+
+    await conn.execute(
+        "UPDATE authoring_projects SET status = 'generating', updated_at = now() "
+        "WHERE project_id = $1",
+        project_id,
+    )
+
+    generated = failed = skipped = 0
+    for unit in units:
+        content_types = list(BASE_CONTENT_TYPES)
+        if unit["has_lab"]:
+            content_types.append("experiment")
+        for lang in langs:
+            for content_type in content_types:
+                if not force:
+                    existing = await conn.fetchval(
+                        "SELECT 1 FROM authoring_active_versions "
+                        "WHERE project_id=$1 AND unit_id=$2 AND lang=$3 AND content_type=$4",
+                        project_id, unit["unit_id"], lang, content_type,
+                    )
+                    if existing:
+                        skipped += 1
+                        continue
+                try:
+                    body, tokens = await asyncio.to_thread(
+                        generate_one,
+                        provider,
+                        content_type=content_type,
+                        unit_id=unit["unit_id"],
+                        subject=unit["subject"],
+                        topic=unit["title"],
+                        grade=proj["grade"],
+                        lang=lang,
+                    )
+                except GenerationError as exc:
+                    failed += 1
+                    log.warning(
+                        "authoring_generate_topic_failed project_id=%s unit=%s type=%s err=%s",
+                        project_id, unit["unit_id"], content_type, exc,
+                    )
+                    continue
+                await append_topic_version(
+                    conn,
+                    project_id=project_id,
+                    unit_id=unit["unit_id"],
+                    lang=lang,
+                    content_type=content_type,
+                    body=body,
+                    ai_model=model,
+                    tokens_used=tokens,
+                )
+                generated += 1
+
+    await conn.execute(
+        "UPDATE authoring_projects SET status = 'generated', updated_at = now() "
+        "WHERE project_id = $1",
+        project_id,
+    )
+    log.info(
+        "authoring_generated project_id=%s generated=%d failed=%d skipped=%d",
+        project_id, generated, failed, skipped,
+    )
+    return {"generated": generated, "failed": failed, "skipped": skipped}
+
+
+async def regenerate_topic(
+    conn: asyncpg.Connection,
+    project_id: str,
+    unit_id: str,
+    *,
+    content_type: str,
+    reason: str,
+    lang: str = "en",
+    provider=None,
+    created_by: uuid.UUID | None = None,
+) -> dict:
+    """Regenerate a single topic's content with a reason (unlimited).
+
+    Appends a new version, runs the cheap deterministic flow recheck over the
+    current structured TOC (requirement f), stores it on the version, and points
+    active at the new version. Returns the new version summary + flow_recheck.
+    """
+    proj = await conn.fetchrow(
+        "SELECT grade, structured_toc FROM authoring_projects WHERE project_id = $1",
+        project_id,
+    )
+    if proj is None:
+        raise GenerationError("project not found")
+    unit = await conn.fetchrow(
+        "SELECT cu.subject, cu.title FROM authoring_projects ap "
+        "JOIN curriculum_units cu ON cu.curriculum_id = ap.curriculum_id "
+        "WHERE ap.project_id = $1 AND cu.unit_id = $2",
+        project_id, unit_id,
+    )
+    if unit is None:
+        raise GenerationError("unit not found for project")
+
+    if provider is None:
+        provider = _build_authoring_provider()
+    model = getattr(provider, "model", None)
+
+    body, tokens = await asyncio.to_thread(
+        generate_one,
+        provider,
+        content_type=content_type,
+        unit_id=unit_id,
+        subject=unit["subject"],
+        topic=unit["title"],
+        grade=proj["grade"],
+        lang=lang,
+    )
+
+    # Cheap, deterministic flow recheck on the current structured TOC.
+    flow_warnings = check_topic_ordering(_coerce_json(proj["structured_toc"]) or {})
+
+    result = await append_topic_version(
+        conn,
+        project_id=project_id,
+        unit_id=unit_id,
+        lang=lang,
+        content_type=content_type,
+        body=body,
+        regen_reason=reason,
+        flow_recheck=flow_warnings,
+        ai_model=model,
+        tokens_used=tokens,
+        created_by=created_by,
+    )
+    result["flow_recheck"] = flow_warnings
+    return result
+
+
+async def accept_topic(
+    conn: asyncpg.Connection, project_id: str, unit_id: str, content_type: str, lang: str
+) -> bool:
+    """Mark the active version of a topic as accepted. False if no active version."""
+    row = await conn.fetchrow(
+        """
+        UPDATE authoring_topic_versions tv
+           SET review_status = 'accepted'
+          FROM authoring_active_versions av
+         WHERE av.topic_version_id = tv.topic_version_id
+           AND av.project_id = $1 AND av.unit_id = $2
+           AND av.content_type = $3 AND av.lang = $4
+        RETURNING tv.topic_version_id
+        """,
+        project_id, unit_id, content_type, lang,
+    )
+    return row is not None

--- a/backend/src/admin/authoring_router.py
+++ b/backend/src/admin/authoring_router.py
@@ -14,7 +14,19 @@ PR-A endpoints (intake → analyze → structure → materialize):
 Gate: every endpoint requires the `curriculum:author` permission, which only
 super_admin holds (via its wildcard). product_admin and below get 403.
 
-PR-B will add generate / topic review / regenerate / snapshot / publish here.
+PR-B endpoints (generate → review → regenerate → snapshot → publish):
+  POST   /admin/authoring/projects/{id}/generate                      generate all (async)
+  GET    /admin/authoring/projects/{id}/topics/{unit_id}              view active / ?history=1
+  POST   /admin/authoring/projects/{id}/topics/{unit_id}/regenerate   regenerate-with-reason
+  POST   /admin/authoring/projects/{id}/topics/{unit_id}/accept       accept active version
+  POST   /admin/authoring/projects/{id}/snapshots                     create manifest snapshot
+  GET    /admin/authoring/projects/{id}/snapshots                     list snapshots
+  POST   /admin/authoring/projects/{id}/snapshots/{snapshot_id}/restore  rollback
+  POST   /admin/authoring/projects/{id}/flow-recheck                  full LLM re-analysis (async)
+  POST   /admin/authoring/projects/{id}/publish                       private | catalog
+
+Gate: every endpoint requires the `curriculum:author` permission, which only
+super_admin holds (via its wildcard). product_admin and below get 403.
 """
 
 from __future__ import annotations
@@ -24,15 +36,31 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
+from src.admin import authoring_generation as gen
 from src.admin import authoring_service as svc
 from src.admin.authoring_schemas import (
+    AcceptRequest,
+    AcceptResponse,
     AnalyzeResponse,
     CreateProjectRequest,
     CreateProjectResponse,
     EditStructureRequest,
+    FlowRecheckResponse,
+    GenerateRequest,
+    GenerateResponse,
     MaterializeResponse,
     ProjectDetail,
     ProjectListResponse,
+    PublishRequest,
+    PublishResponse,
+    RegenerateRequest,
+    RegenerateResponse,
+    RestoreResponse,
+    SnapshotCreateRequest,
+    SnapshotItem,
+    SnapshotListResponse,
+    TopicHistoryResponse,
+    TopicVersion,
 )
 from src.auth.dependencies import get_current_admin
 from src.core.db import get_db
@@ -294,3 +322,319 @@ async def materialize_project(
         },
     )
     return MaterializeResponse(**result)
+
+
+# ── 7. Generate all topics (async) ──────────────────────────────────────────────
+
+
+@router.post(
+    "/admin/authoring/projects/{project_id}/generate",
+    response_model=GenerateResponse,
+    status_code=202,
+)
+async def generate_project(
+    project_id: str,
+    body: GenerateRequest,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> GenerateResponse:
+    async with get_db(request) as conn:
+        project = await svc.get_project(conn, project_id)
+        if project is None:
+            raise _not_found(project_id, request)
+        if not project["curriculum_id"]:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "conflict",
+                    "detail": "Project must be materialized before generation.",
+                    "correlation_id": getattr(request.state, "correlation_id", ""),
+                },
+            )
+        if project["status"] == "generating":
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "conflict",
+                    "detail": "Generation is already running for this project.",
+                    "correlation_id": getattr(request.state, "correlation_id", ""),
+                },
+            )
+
+    from src.core.celery_app import celery_app as _celery
+
+    job_id = str(uuid.uuid4())
+    _celery.send_task(
+        "src.auth.tasks.run_authoring_generate_task",
+        args=[project_id, body.langs, body.force],
+        queue="pipeline",
+    )
+    emit_event("authoring", "generate_dispatched", project_id=project_id, job_id=job_id)
+    return GenerateResponse(job_id=job_id, status="generating")
+
+
+# ── 8. View topic content (active or history) ───────────────────────────────────
+
+
+@router.get(
+    "/admin/authoring/projects/{project_id}/topics/{unit_id}",
+    response_model=TopicVersion | TopicHistoryResponse,
+)
+async def get_topic(
+    project_id: str,
+    unit_id: str,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+    content_type: str = "lesson",
+    lang: str = "en",
+    history: int = 0,
+) -> TopicVersion | TopicHistoryResponse:
+    async with get_db(request) as conn:
+        if history:
+            versions = await gen.get_topic_history(conn, project_id, unit_id, content_type, lang)
+            return TopicHistoryResponse(versions=[TopicVersion(**v) for v in versions])
+        active = await gen.get_active_topic(conn, project_id, unit_id, content_type, lang)
+    if active is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": "not_found",
+                "detail": f"No {content_type!r} content for unit {unit_id!r}.",
+                "correlation_id": getattr(request.state, "correlation_id", ""),
+            },
+        )
+    return TopicVersion(**active)
+
+
+# ── 9. Regenerate a topic with a reason (unlimited) ─────────────────────────────
+
+
+@router.post(
+    "/admin/authoring/projects/{project_id}/topics/{unit_id}/regenerate",
+    response_model=RegenerateResponse,
+)
+async def regenerate_topic(
+    project_id: str,
+    unit_id: str,
+    body: RegenerateRequest,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> RegenerateResponse:
+    async with get_db(request) as conn:
+        try:
+            result = await gen.regenerate_topic(
+                conn,
+                project_id,
+                unit_id,
+                content_type=body.content_type,
+                reason=body.reason,
+                lang=body.lang,
+                created_by=_actor_uuid(admin),
+            )
+        except gen.GenerationError as exc:
+            detail = str(exc)
+            status = 404 if "not found" in detail else 422
+            raise HTTPException(
+                status_code=status,
+                detail={
+                    "error": "regeneration_failed",
+                    "detail": detail,
+                    "correlation_id": getattr(request.state, "correlation_id", ""),
+                },
+            ) from exc
+    emit_event(
+        "authoring",
+        "topic_regenerated",
+        project_id=project_id,
+        unit_id=unit_id,
+        content_type=body.content_type,
+        reason_chars=len(body.reason),
+        version_number=result["version_number"],
+    )
+    return RegenerateResponse(
+        topic_version_id=result["topic_version_id"],
+        version_number=result["version_number"],
+        review_status=result["review_status"],
+        flow_recheck=result["flow_recheck"],
+    )
+
+
+# ── 10. Accept a topic's active version ─────────────────────────────────────────
+
+
+@router.post(
+    "/admin/authoring/projects/{project_id}/topics/{unit_id}/accept",
+    response_model=AcceptResponse,
+)
+async def accept_topic(
+    project_id: str,
+    unit_id: str,
+    body: AcceptRequest,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> AcceptResponse:
+    async with get_db(request) as conn:
+        ok = await gen.accept_topic(conn, project_id, unit_id, body.content_type, body.lang)
+    if not ok:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": "not_found",
+                "detail": f"No active {body.content_type!r} version for unit {unit_id!r}.",
+                "correlation_id": getattr(request.state, "correlation_id", ""),
+            },
+        )
+    return AcceptResponse(review_status="accepted")
+
+
+# ── 11. Create snapshot ──────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/admin/authoring/projects/{project_id}/snapshots",
+    response_model=SnapshotItem,
+    status_code=201,
+)
+async def create_snapshot(
+    project_id: str,
+    body: SnapshotCreateRequest,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> SnapshotItem:
+    async with get_db(request) as conn:
+        project = await svc.get_project(conn, project_id)
+        if project is None:
+            raise _not_found(project_id, request)
+        snap = await svc.create_snapshot(
+            conn, project_id, label=body.label, created_by=_actor_uuid(admin)
+        )
+    emit_event("authoring", "snapshot_created", project_id=project_id,
+               snapshot_number=snap["snapshot_number"])
+    return SnapshotItem(**snap)
+
+
+# ── 12. List snapshots ──────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/admin/authoring/projects/{project_id}/snapshots",
+    response_model=SnapshotListResponse,
+)
+async def list_snapshots(
+    project_id: str,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> SnapshotListResponse:
+    async with get_db(request) as conn:
+        snaps = await svc.list_snapshots(conn, project_id)
+    return SnapshotListResponse(snapshots=[SnapshotItem(**s) for s in snaps])
+
+
+# ── 13. Restore snapshot ─────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/admin/authoring/projects/{project_id}/snapshots/{snapshot_id}/restore",
+    response_model=RestoreResponse,
+)
+async def restore_snapshot(
+    project_id: str,
+    snapshot_id: str,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> RestoreResponse:
+    async with get_db(request) as conn:
+        ok = await svc.restore_snapshot(conn, project_id, snapshot_id)
+    if not ok:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": "not_found",
+                "detail": f"Snapshot {snapshot_id!r} not found for this project.",
+                "correlation_id": getattr(request.state, "correlation_id", ""),
+            },
+        )
+    write_audit_log(
+        event_type="authoring.restore",
+        actor_type="admin",
+        actor_id=_actor_uuid(admin),
+        target_type="authoring_project",
+        target_id=None,
+        metadata={"project_id": project_id, "snapshot_id": snapshot_id},
+    )
+    return RestoreResponse(restored=True)
+
+
+# ── 14. On-demand full flow re-analysis (async) ─────────────────────────────────
+
+
+@router.post(
+    "/admin/authoring/projects/{project_id}/flow-recheck",
+    response_model=FlowRecheckResponse,
+    status_code=202,
+)
+async def flow_recheck(
+    project_id: str,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> FlowRecheckResponse:
+    async with get_db(request) as conn:
+        project = await svc.get_project(conn, project_id)
+    if project is None:
+        raise _not_found(project_id, request)
+
+    from src.core.celery_app import celery_app as _celery
+
+    job_id = str(uuid.uuid4())
+    _celery.send_task(
+        "src.auth.tasks.run_authoring_flow_recheck_task",
+        args=[project_id],
+        queue="pipeline",
+    )
+    emit_event("authoring", "flow_recheck_dispatched", project_id=project_id, job_id=job_id)
+    return FlowRecheckResponse(job_id=job_id, status="analyzing")
+
+
+# ── 15. Publish ──────────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/admin/authoring/projects/{project_id}/publish",
+    response_model=PublishResponse,
+)
+async def publish_project(
+    project_id: str,
+    body: PublishRequest,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> PublishResponse:
+    storage = request.app.state.storage
+    async with get_db(request) as conn:
+        try:
+            result = await svc.publish(conn, storage, project_id, visibility=body.visibility)
+        except svc.PublishError as exc:
+            detail = str(exc)
+            status = 404 if "not found" in detail else 409
+            raise HTTPException(
+                status_code=status,
+                detail={
+                    "error": "publish_failed",
+                    "detail": detail,
+                    "correlation_id": getattr(request.state, "correlation_id", ""),
+                },
+            ) from exc
+    emit_event("authoring", "published", project_id=project_id,
+               curriculum_id=result["curriculum_id"], visibility=body.visibility)
+    write_audit_log(
+        event_type="authoring.publish",
+        actor_type="admin",
+        actor_id=_actor_uuid(admin),
+        target_type="curriculum",
+        target_id=None,
+        metadata={
+            "project_id": project_id,
+            "curriculum_id": result["curriculum_id"],
+            "visibility": body.visibility,
+        },
+    )
+    return PublishResponse(**result)

--- a/backend/src/admin/authoring_schemas.py
+++ b/backend/src/admin/authoring_schemas.py
@@ -114,3 +114,115 @@ class MaterializeResponse(BaseModel):
     curriculum_id: str
     status: str  # 'structured'
     units_created: int
+
+
+# ── PR-B: generate / review / regenerate / snapshot / publish ─────────────────
+
+_CONTENT_TYPES = {
+    "lesson", "tutorial", "quiz_set_1", "quiz_set_2", "quiz_set_3", "experiment",
+}
+
+
+class GenerateRequest(BaseModel):
+    langs: str = "en"  # comma-separated, e.g. "en,fr"
+    force: bool = False
+
+
+class GenerateResponse(BaseModel):
+    job_id: str
+    status: str  # 'generating'
+
+
+class TopicVersion(BaseModel):
+    topic_version_id: str
+    unit_id: str
+    lang: str
+    content_type: str
+    version_number: int
+    body: dict | None = None
+    regen_reason: str | None = None
+    flow_recheck: list | None = None
+    review_status: str
+    created_at: datetime
+    is_active: bool = False
+
+
+class TopicHistoryResponse(BaseModel):
+    versions: list[TopicVersion]
+
+
+class RegenerateRequest(BaseModel):
+    content_type: str
+    reason: str = Field(min_length=1, max_length=1000)
+    lang: str = "en"
+
+    @field_validator("content_type")
+    @classmethod
+    def _valid_content_type(cls, v: str) -> str:
+        if v not in _CONTENT_TYPES:
+            raise ValueError(f"content_type must be one of {sorted(_CONTENT_TYPES)}")
+        return v
+
+
+class RegenerateResponse(BaseModel):
+    topic_version_id: str
+    version_number: int
+    review_status: str
+    flow_recheck: list
+
+
+class AcceptRequest(BaseModel):
+    content_type: str
+    lang: str = "en"
+
+    @field_validator("content_type")
+    @classmethod
+    def _valid_content_type(cls, v: str) -> str:
+        if v not in _CONTENT_TYPES:
+            raise ValueError(f"content_type must be one of {sorted(_CONTENT_TYPES)}")
+        return v
+
+
+class AcceptResponse(BaseModel):
+    review_status: str
+
+
+class SnapshotCreateRequest(BaseModel):
+    label: str | None = None
+
+
+class SnapshotItem(BaseModel):
+    snapshot_id: str
+    snapshot_number: int
+    label: str | None = None
+    created_at: datetime
+
+
+class SnapshotListResponse(BaseModel):
+    snapshots: list[SnapshotItem]
+
+
+class RestoreResponse(BaseModel):
+    restored: bool
+
+
+class FlowRecheckResponse(BaseModel):
+    job_id: str
+    status: str
+
+
+class PublishRequest(BaseModel):
+    visibility: str = "private"
+
+    @field_validator("visibility")
+    @classmethod
+    def _valid_visibility(cls, v: str) -> str:
+        if v not in ("private", "catalog"):
+            raise ValueError("visibility must be 'private' or 'catalog'")
+        return v
+
+
+class PublishResponse(BaseModel):
+    curriculum_id: str
+    visibility: str
+    files_written: int

--- a/backend/src/admin/authoring_service.py
+++ b/backend/src/admin/authoring_service.py
@@ -368,3 +368,278 @@ async def materialize(
         "status": "structured",
         "units_created": units_created,
     }
+
+
+# ── Snapshots (whole-curriculum manifest) ─────────────────────────────────────
+
+
+def _manifest_key(unit_id: str, content_type: str, lang: str) -> str:
+    return f"{unit_id}::{content_type}::{lang}"
+
+
+async def create_snapshot(
+    conn: asyncpg.Connection,
+    project_id: str,
+    *,
+    label: str | None,
+    created_by: uuid.UUID | None,
+) -> dict:
+    """Capture the current active-version pointers + structured TOC as a snapshot.
+
+    The manifest references topic_version_ids (no content copy) so a restore is
+    a cheap pointer rewrite — the chosen per-topic-history + manifest model
+    (requirement g).
+    """
+    actives = await conn.fetch(
+        "SELECT unit_id, content_type, lang, topic_version_id "
+        "FROM authoring_active_versions WHERE project_id = $1",
+        project_id,
+    )
+    manifest = {
+        "versions": {
+            _manifest_key(r["unit_id"], r["content_type"], r["lang"]): str(r["topic_version_id"])
+            for r in actives
+        },
+        "structured_toc": _coerce_json(
+            await conn.fetchval(
+                "SELECT structured_toc FROM authoring_projects WHERE project_id = $1",
+                project_id,
+            )
+        ),
+    }
+    snapshot_number = int(
+        await conn.fetchval(
+            "SELECT COALESCE(MAX(snapshot_number), 0) FROM authoring_snapshots "
+            "WHERE project_id = $1",
+            project_id,
+        ) or 0
+    ) + 1
+
+    row = await conn.fetchrow(
+        """
+        INSERT INTO authoring_snapshots (project_id, snapshot_number, manifest, label, created_by)
+        VALUES ($1, $2, $3, $4, $5)
+        RETURNING snapshot_id, snapshot_number, created_at
+        """,
+        project_id, snapshot_number, manifest, label, created_by,
+    )
+    await conn.execute(
+        "UPDATE authoring_projects SET current_snapshot_id = $2, updated_at = now() "
+        "WHERE project_id = $1",
+        project_id, row["snapshot_id"],
+    )
+    return {
+        "snapshot_id": str(row["snapshot_id"]),
+        "snapshot_number": row["snapshot_number"],
+        "label": label,
+        "created_at": row["created_at"],
+    }
+
+
+async def list_snapshots(conn: asyncpg.Connection, project_id: str) -> list[dict]:
+    rows = await conn.fetch(
+        "SELECT snapshot_id, snapshot_number, label, created_at FROM authoring_snapshots "
+        "WHERE project_id = $1 ORDER BY snapshot_number DESC",
+        project_id,
+    )
+    return [
+        {
+            "snapshot_id": str(r["snapshot_id"]),
+            "snapshot_number": r["snapshot_number"],
+            "label": r["label"],
+            "created_at": r["created_at"],
+        }
+        for r in rows
+    ]
+
+
+async def restore_snapshot(conn: asyncpg.Connection, project_id: str, snapshot_id: str) -> bool:
+    """Rewrite active-version pointers from a snapshot's manifest.
+
+    Returns False if the snapshot doesn't belong to the project. Restores the
+    whole curriculum to the snapshot's point in time without copying content.
+    """
+    manifest = _coerce_json(
+        await conn.fetchval(
+            "SELECT manifest FROM authoring_snapshots "
+            "WHERE snapshot_id = $1 AND project_id = $2",
+            snapshot_id, project_id,
+        )
+    )
+    if manifest is None:
+        return False
+
+    versions = (manifest or {}).get("versions", {})
+    async with conn.transaction():
+        for key, topic_version_id in versions.items():
+            unit_id, content_type, lang = key.split("::")
+            await conn.execute(
+                """
+                INSERT INTO authoring_active_versions
+                    (project_id, unit_id, lang, content_type, topic_version_id)
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (project_id, unit_id, lang, content_type)
+                DO UPDATE SET topic_version_id = EXCLUDED.topic_version_id,
+                              activated_at = now()
+                """,
+                project_id, unit_id, lang, content_type, uuid.UUID(topic_version_id),
+            )
+        await conn.execute(
+            "UPDATE authoring_projects SET current_snapshot_id = $2, updated_at = now() "
+            "WHERE project_id = $1",
+            project_id, uuid.UUID(snapshot_id),
+        )
+    return True
+
+
+# ── Publish ────────────────────────────────────────────────────────────────────
+
+
+class PublishError(RuntimeError):
+    """Raised when a project cannot be published (wrong state / unaccepted topics)."""
+
+
+# content_type → content-store filename stem (filename = f"{stem}_{lang}.json").
+_CONTENT_FILENAMES = {
+    "lesson": "lesson",
+    "tutorial": "tutorial",
+    "quiz_set_1": "quiz_set_1",
+    "quiz_set_2": "quiz_set_2",
+    "quiz_set_3": "quiz_set_3",
+    "experiment": "experiment",
+}
+
+
+async def publish(
+    conn: asyncpg.Connection,
+    storage,
+    project_id: str,
+    *,
+    visibility: str,
+) -> dict:
+    """Publish an authored curriculum.
+
+    Requires status='generated' and every active topic version accepted. Writes
+    accepted bodies to the content store, creates content_subject_versions rows
+    (status='published') per subject, sets curricula.is_default = (visibility ==
+    'catalog'), and flips the project to status='published'.
+    """
+    proj = await conn.fetchrow(
+        "SELECT curriculum_id, status FROM authoring_projects WHERE project_id = $1",
+        project_id,
+    )
+    if proj is None:
+        raise PublishError("project not found")
+    if not proj["curriculum_id"]:
+        raise PublishError("project has not been materialized")
+    if proj["status"] not in ("generated", "published"):
+        raise PublishError(
+            f"project is in status {proj['status']!r}; generate content before publishing"
+        )
+
+    curriculum_id = proj["curriculum_id"]
+
+    # Gate: every active topic version must be accepted.
+    actives = await conn.fetch(
+        """
+        SELECT tv.unit_id, tv.lang, tv.content_type, tv.body, tv.review_status
+          FROM authoring_active_versions av
+          JOIN authoring_topic_versions tv ON tv.topic_version_id = av.topic_version_id
+         WHERE av.project_id = $1
+        """,
+        project_id,
+    )
+    if not actives:
+        raise PublishError("nothing to publish — generate content first")
+    unaccepted = [a for a in actives if a["review_status"] != "accepted"]
+    if unaccepted:
+        raise PublishError(
+            f"{len(unaccepted)} topic version(s) are not accepted; accept all before publishing"
+        )
+
+    # Write accepted bodies to the content store.
+    for a in actives:
+        stem = _CONTENT_FILENAMES.get(a["content_type"])
+        if not stem:
+            continue
+        path = f"curricula/{curriculum_id}/{a['unit_id']}/{stem}_{a['lang']}.json"
+        body = _coerce_json(a["body"]) or {}
+        await storage.write(path, json.dumps(body, ensure_ascii=False).encode("utf-8"))
+
+    # content_subject_versions per distinct subject (status published).
+    subjects = await conn.fetch(
+        "SELECT DISTINCT subject FROM curriculum_units WHERE curriculum_id = $1",
+        curriculum_id,
+    )
+    pipeline_run_id = f"authoring-{project_id}"
+    for s in subjects:
+        subject = s["subject"]
+        next_version = int(
+            await conn.fetchval(
+                "SELECT COALESCE(MAX(version_number), 0) FROM content_subject_versions "
+                "WHERE curriculum_id = $1 AND subject = $2",
+                curriculum_id, subject,
+            ) or 0
+        ) + 1
+        await conn.execute(
+            """
+            INSERT INTO content_subject_versions
+                (curriculum_id, subject, subject_name, version_number, status,
+                 alex_warnings_count, provider, generated_at, published_at, pipeline_run_id)
+            VALUES ($1, $2, $3, $4, 'published', 0, 'anthropic', NOW(), NOW(), $5)
+            ON CONFLICT (curriculum_id, subject, version_number) DO UPDATE
+                SET status = 'published', published_at = NOW()
+            """,
+            curriculum_id, subject, subject, next_version, pipeline_run_id,
+        )
+
+    is_catalog = visibility == "catalog"
+    await conn.execute(
+        "UPDATE curricula SET is_default = $2 WHERE curriculum_id = $1",
+        curriculum_id, is_catalog,
+    )
+    await conn.execute(
+        "UPDATE authoring_projects SET visibility = $2, status = 'published', updated_at = now() "
+        "WHERE project_id = $1",
+        project_id, visibility,
+    )
+
+    log.info(
+        "authoring_published project_id=%s curriculum_id=%s visibility=%s files=%d",
+        project_id, curriculum_id, visibility, len(actives),
+    )
+    return {
+        "curriculum_id": curriculum_id,
+        "visibility": visibility,
+        "files_written": len(actives),
+    }
+
+
+# ── On-demand full flow re-analysis (Celery worker body) ──────────────────────
+
+
+async def run_flow_recheck(conn: asyncpg.Connection, project_id: str, provider=None) -> None:
+    """Re-run the advisory LLM flow analysis over the CURRENT structured TOC.
+
+    Unlike run_analysis (which re-structures raw_toc), this preserves operator
+    edits and only refreshes flow_report. Never raises.
+    """
+    from pipeline.flow_analyzer import analyze_toc_flow
+
+    structured = _coerce_json(
+        await conn.fetchval(
+            "SELECT structured_toc FROM authoring_projects WHERE project_id = $1",
+            project_id,
+        )
+    )
+    if not structured:
+        return
+    if provider is None:
+        provider = _build_authoring_provider()
+    report = await asyncio.to_thread(analyze_toc_flow, structured, provider)
+    await conn.execute(
+        "UPDATE authoring_projects SET flow_report = $2, updated_at = now() "
+        "WHERE project_id = $1",
+        project_id,
+        report.model_dump(),
+    )

--- a/backend/src/auth/tasks.py
+++ b/backend/src/auth/tasks.py
@@ -2285,6 +2285,12 @@ def run_authoring_analyze_task(project_id: str) -> None:
     async def _go() -> None:
         conn = await _asyncpg.connect(settings.DATABASE_URL)
         try:
+            # jsonb columns (structured_toc, flow_report) are bound as dicts;
+            # register the same codec the app pool uses or asyncpg rejects them
+            # ("expected str, got dict").
+            await conn.set_type_codec(
+                "jsonb", encoder=json.dumps, decoder=json.loads, schema="pg_catalog"
+            )
             # Platform context — bypass RLS (pitfall #28). authoring_* tables
             # aren't tenant-scoped, but keep the stamp consistent for safety.
             await conn.execute(
@@ -2298,3 +2304,75 @@ def run_authoring_analyze_task(project_id: str) -> None:
         _run_async(_go())
     except Exception as exc:  # never let the worker crash on a bad TOC
         log.error("run_authoring_analyze_task_failed project_id=%s error=%s", project_id, exc)
+
+
+@celery_app.task(name="src.auth.tasks.run_authoring_generate_task")
+def run_authoring_generate_task(project_id: str, langs: str = "en", force: bool = False) -> None:
+    """Generate content for every unit in a materialised Authoring Studio project.
+
+    Calls src.admin.authoring_generation.generate_topics(); flips the project
+    status generating → generated. Never raises out of the worker.
+    """
+    import os as _os
+    import sys as _sys
+
+    _pipeline_parent = _os.path.abspath("/pipeline/..")
+    if _pipeline_parent not in _sys.path:
+        _sys.path.insert(0, _pipeline_parent)
+
+    import asyncpg as _asyncpg
+
+    from src.admin.authoring_generation import generate_topics
+
+    async def _go() -> None:
+        conn = await _asyncpg.connect(settings.DATABASE_URL)
+        try:
+            await conn.set_type_codec(
+                "jsonb", encoder=json.dumps, decoder=json.loads, schema="pg_catalog"
+            )
+            await conn.execute(
+                "SELECT set_config('app.current_school_id', 'bypass', false)"
+            )
+            await generate_topics(
+                conn, project_id, langs=[lang for lang in langs.split(",") if lang], force=force
+            )
+        finally:
+            await conn.close()
+
+    try:
+        _run_async(_go())
+    except Exception as exc:  # worker must survive a generation failure
+        log.error("run_authoring_generate_task_failed project_id=%s error=%s", project_id, exc)
+
+
+@celery_app.task(name="src.auth.tasks.run_authoring_flow_recheck_task")
+def run_authoring_flow_recheck_task(project_id: str) -> None:
+    """Re-run advisory flow analysis on an Authoring Studio project's current TOC."""
+    import os as _os
+    import sys as _sys
+
+    _pipeline_parent = _os.path.abspath("/pipeline/..")
+    if _pipeline_parent not in _sys.path:
+        _sys.path.insert(0, _pipeline_parent)
+
+    import asyncpg as _asyncpg
+
+    from src.admin.authoring_service import run_flow_recheck
+
+    async def _go() -> None:
+        conn = await _asyncpg.connect(settings.DATABASE_URL)
+        try:
+            await conn.set_type_codec(
+                "jsonb", encoder=json.dumps, decoder=json.loads, schema="pg_catalog"
+            )
+            await conn.execute(
+                "SELECT set_config('app.current_school_id', 'bypass', false)"
+            )
+            await run_flow_recheck(conn, project_id)
+        finally:
+            await conn.close()
+
+    try:
+        _run_async(_go())
+    except Exception as exc:  # worker must survive an analysis failure
+        log.error("run_authoring_flow_recheck_task_failed project_id=%s error=%s", project_id, exc)

--- a/backend/tests/test_authoring_pipeline.py
+++ b/backend/tests/test_authoring_pipeline.py
@@ -20,6 +20,7 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 from pipeline.flow_analyzer import FlowReport, analyze_toc_flow  # noqa: E402
+from pipeline.prompts import build_lesson_prompt, build_tutorial_prompt  # noqa: E402
 from pipeline.toc_structurer import StructuredTOC, structure_toc  # noqa: E402
 
 from src.admin.authoring_flow import check_topic_ordering  # noqa: E402
@@ -115,3 +116,19 @@ def test_deterministic_ordering_check_flags_missing_prereq() -> None:
     ]}]}
     warnings = check_topic_ordering(structured)
     assert any(w["kind"] == "missing_prerequisite" for w in warnings)
+
+
+def test_lesson_prompt_diagram_emphasis_requests_mermaid() -> None:
+    on = build_lesson_prompt("U1", "Natural Sciences", "Photosynthesis", 9, "en",
+                             diagram_emphasis=True)
+    off = build_lesson_prompt("U1", "Natural Sciences", "Photosynthesis", 9, "en")
+    assert "mermaid" in on.lower()
+    assert "mermaid" not in off.lower()
+
+
+def test_tutorial_prompt_diagram_emphasis_requests_mermaid() -> None:
+    on = build_tutorial_prompt("U1", "Mathematics", "Quadratics", 10, "en",
+                               diagram_emphasis=True)
+    off = build_tutorial_prompt("U1", "Mathematics", "Quadratics", 10, "en")
+    assert "mermaid" in on.lower()
+    assert "mermaid" not in off.lower()

--- a/backend/tests/test_authoring_pr_b.py
+++ b/backend/tests/test_authoring_pr_b.py
@@ -1,0 +1,365 @@
+"""
+Endpoint + service tests for the Curriculum Authoring Studio — PR-B
+(generate → review → regenerate-with-reason → snapshot/restore → publish).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from main import app
+
+from src.admin import authoring_generation as gen
+from src.admin import authoring_service as svc
+
+# run_analysis / generation lazily import the `pipeline` package (repo root).
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# ── A fake provider that answers every authoring prompt type ──────────────────
+
+
+def _valid_lesson() -> dict:
+    return {
+        "unit_id": "U", "subject": "Physics", "topic": "Motion",
+        "synopsis": "A short but valid synopsis of the lesson.",
+        "sections": [
+            {"heading": "Introduction", "body": "Intro body with a diagram.\n\n"
+             "```mermaid\ngraph TD; A-->B;\n```"},
+            {"heading": "Core Concepts", "body": "Core concepts body text here."},
+        ],
+        "key_points": ["kp one", "kp two"],
+        "learning_objectives": ["Explain motion", "Calculate speed"],
+        "reading_level": "Grade 9", "estimated_duration_minutes": 40,
+        "language": "en", "generated_at": "2026-01-01T00:00:00Z",
+        "model": "fake-model", "content_version": 1,
+    }
+
+
+def _valid_quiz(set_number: int = 1) -> dict:
+    q = {
+        "question_id": "q1", "question_text": "What is speed?",
+        "question_type": "multiple_choice",
+        "options": [
+            {"option_id": "A", "text": "distance/time"},
+            {"option_id": "B", "text": "time/distance"},
+            {"option_id": "C", "text": "mass"},
+            {"option_id": "D", "text": "force"},
+        ],
+        "correct_option": "A", "explanation": "Speed is distance over time.",
+        "difficulty": "easy",
+    }
+    return {
+        "unit_id": "U", "set_number": set_number, "language": "en",
+        "questions": [{**q, "question_id": f"q{i + 1}"} for i in range(8)],
+        "total_questions": 8, "estimated_duration_minutes": 10, "passing_score": 6,
+        "generated_at": "2026-01-01T00:00:00Z", "model": "fake-model", "content_version": 1,
+    }
+
+
+def _valid_tutorial() -> dict:
+    return {
+        "unit_id": "U", "language": "en", "title": "Motion tutorial",
+        "sections": [{
+            "section_id": "s1", "title": "Step 1",
+            "content": "Section content that is long enough.",
+            "examples": ["example one"], "practice_question": "Try this problem.",
+        }],
+        "common_mistakes": ["mixing up speed and velocity"],
+        "generated_at": "2026-01-01T00:00:00Z", "model": "fake-model", "content_version": 1,
+    }
+
+
+class _FakeProvider:
+    """Answers structurer / flow / lesson / quiz / tutorial prompts."""
+
+    model = "fake-model"
+
+    def generate(self, prompt: str) -> tuple[str, int, int]:
+        if "pedagogy reviewer" in prompt:
+            return json.dumps({"summary": "ok", "warnings": []}), 10, 10
+        if "curriculum architect" in prompt:
+            return json.dumps({"subjects": [{"subject_label": "Physics", "units": [
+                {"title": "Motion", "subtopics": ["Speed"], "prerequisites": []}]}]}), 10, 10
+        if "creating a quiz" in prompt:
+            set_number = 1
+            for n in (1, 2, 3):
+                if f"set {n} of" in prompt:
+                    set_number = n
+            return json.dumps(_valid_quiz(set_number)), 10, 10
+        if "worked tutorial" in prompt:
+            return json.dumps(_valid_tutorial()), 10, 10
+        return json.dumps(_valid_lesson()), 10, 10
+
+
+async def _seed_generated_project(*, units: int = 1) -> str:
+    """Create → analyze → materialize → generate, committed on the app pool."""
+    subjects = [{
+        "subject_label": "Physics",
+        "units": [
+            {"title": f"Topic {i + 1}", "subtopics": ["a"], "prerequisites": []}
+            for i in range(units)
+        ],
+    }]
+    async with app.state.pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        project = await svc.create_project(
+            conn, title="G9 Physics", grade=9, languages=["en"],
+            raw_toc="1. Motion", created_by=None,
+        )
+        pid = project["project_id"]
+        # Set the structured TOC directly (skip the analyze round-trip).
+        await conn.execute(
+            "UPDATE authoring_projects SET structured_toc=$2, status='analyzed' WHERE project_id=$1",
+            pid, {"subjects": subjects},
+        )
+        await svc.materialize(conn, pid, None)
+        await gen.generate_topics(conn, pid, langs=["en"], provider=_FakeProvider())
+    return pid
+
+
+def _first_unit_id(pid: str) -> str:
+    # Deterministic from materialize: AUTH-{proj8}-PHYSIC-001
+    return f"AUTH-{pid.replace('-', '')[:8]}-PHYSIC-001"
+
+
+# ── Generate ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_generate_topics_service_creates_active_versions(client: AsyncClient) -> None:
+    pid = await _seed_generated_project()
+    async with app.state.pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        status = await conn.fetchval(
+            "SELECT status FROM authoring_projects WHERE project_id=$1", pid
+        )
+        n_active = await conn.fetchval(
+            "SELECT COUNT(*) FROM authoring_active_versions WHERE project_id=$1", pid
+        )
+    assert status == "generated"
+    assert n_active == 5  # lesson + tutorial + 3 quiz sets
+
+
+@pytest.mark.asyncio
+async def test_generate_endpoint_dispatches(client: AsyncClient, admin_token: str) -> None:
+    pid = await _seed_generated_project()
+    with patch("src.core.celery_app.celery_app.send_task") as send_task:
+        r = await client.post(
+            f"/api/v1/admin/authoring/projects/{pid}/generate",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"langs": "en", "force": True},
+        )
+    assert r.status_code == 202
+    assert r.json()["status"] == "generating"
+    send_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_generate_requires_materialized(client: AsyncClient, admin_token: str) -> None:
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    created = await client.post(
+        "/api/v1/admin/authoring/projects", headers=headers,
+        json={"title": "X", "grade": 9, "languages": ["en"], "raw_toc": "1. A"},
+    )
+    pid = created.json()["project_id"]
+    r = await client.post(
+        f"/api/v1/admin/authoring/projects/{pid}/generate", headers=headers, json={}
+    )
+    assert r.status_code == 409
+
+
+# ── View / regenerate / accept ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_view_topic_returns_active(client: AsyncClient, admin_token: str) -> None:
+    pid = await _seed_generated_project()
+    unit_id = _first_unit_id(pid)
+    r = await client.get(
+        f"/api/v1/admin/authoring/projects/{pid}/topics/{unit_id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        params={"content_type": "lesson"},
+    )
+    assert r.status_code == 200
+    assert r.json()["version_number"] == 1
+    assert r.json()["body"]["sections"]
+
+
+@pytest.mark.asyncio
+async def test_regenerate_is_append_only_unlimited_with_flow_recheck(
+    client: AsyncClient, admin_token: str
+) -> None:
+    pid = await _seed_generated_project()
+    unit_id = _first_unit_id(pid)
+    headers = {"Authorization": f"Bearer {admin_token}"}
+
+    with patch.object(gen, "_build_authoring_provider", return_value=_FakeProvider()):
+        for i in range(3):  # unlimited
+            r = await client.post(
+                f"/api/v1/admin/authoring/projects/{pid}/topics/{unit_id}/regenerate",
+                headers=headers,
+                json={"content_type": "lesson", "reason": f"too terse, expand ({i})"},
+            )
+            assert r.status_code == 200
+            assert "flow_recheck" in r.json()
+
+    hist = await client.get(
+        f"/api/v1/admin/authoring/projects/{pid}/topics/{unit_id}",
+        headers=headers, params={"content_type": "lesson", "history": 1},
+    )
+    versions = hist.json()["versions"]
+    assert [v["version_number"] for v in versions] == [4, 3, 2, 1]
+    assert versions[0]["is_active"] is True
+    assert versions[0]["regen_reason"].startswith("too terse")
+
+
+@pytest.mark.asyncio
+async def test_regenerate_requires_reason(client: AsyncClient, admin_token: str) -> None:
+    pid = await _seed_generated_project()
+    unit_id = _first_unit_id(pid)
+    r = await client.post(
+        f"/api/v1/admin/authoring/projects/{pid}/topics/{unit_id}/regenerate",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"content_type": "lesson", "reason": ""},
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_accept_topic(client: AsyncClient, admin_token: str) -> None:
+    pid = await _seed_generated_project()
+    unit_id = _first_unit_id(pid)
+    r = await client.post(
+        f"/api/v1/admin/authoring/projects/{pid}/topics/{unit_id}/accept",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"content_type": "lesson"},
+    )
+    assert r.status_code == 200
+    assert r.json()["review_status"] == "accepted"
+
+
+# ── Snapshot / restore ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_snapshot_and_restore_round_trip(client: AsyncClient, admin_token: str) -> None:
+    pid = await _seed_generated_project()
+    unit_id = _first_unit_id(pid)
+    headers = {"Authorization": f"Bearer {admin_token}"}
+
+    snap = await client.post(
+        f"/api/v1/admin/authoring/projects/{pid}/snapshots",
+        headers=headers, json={"label": "before edits"},
+    )
+    assert snap.status_code == 201
+    snapshot_id = snap.json()["snapshot_id"]
+
+    # Mutate the lesson topic (new active version 2).
+    with patch.object(gen, "_build_authoring_provider", return_value=_FakeProvider()):
+        await client.post(
+            f"/api/v1/admin/authoring/projects/{pid}/topics/{unit_id}/regenerate",
+            headers=headers, json={"content_type": "lesson", "reason": "rewrite"},
+        )
+    mutated = await client.get(
+        f"/api/v1/admin/authoring/projects/{pid}/topics/{unit_id}",
+        headers=headers, params={"content_type": "lesson"},
+    )
+    assert mutated.json()["version_number"] == 2
+
+    # Restore → active lesson back to version 1.
+    rest = await client.post(
+        f"/api/v1/admin/authoring/projects/{pid}/snapshots/{snapshot_id}/restore",
+        headers=headers,
+    )
+    assert rest.status_code == 200
+    after = await client.get(
+        f"/api/v1/admin/authoring/projects/{pid}/topics/{unit_id}",
+        headers=headers, params={"content_type": "lesson"},
+    )
+    assert after.json()["version_number"] == 1
+
+
+# ── Publish ──────────────────────────────────────────────────────────────────
+
+
+async def _accept_all(pid: str) -> None:
+    async with app.state.pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        await conn.execute(
+            """
+            UPDATE authoring_topic_versions tv SET review_status='accepted'
+              FROM authoring_active_versions av
+             WHERE av.topic_version_id = tv.topic_version_id AND av.project_id = $1
+            """,
+            pid,
+        )
+
+
+@pytest.mark.asyncio
+async def test_publish_requires_all_accepted(client: AsyncClient, admin_token: str) -> None:
+    pid = await _seed_generated_project()
+    r = await client.post(
+        f"/api/v1/admin/authoring/projects/{pid}/publish",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"visibility": "private"},
+    )
+    assert r.status_code == 409  # topics still pending
+
+
+@pytest.mark.asyncio
+async def test_publish_catalog_sets_is_default(
+    client: AsyncClient, admin_token: str
+) -> None:
+    pid = await _seed_generated_project()
+    await _accept_all(pid)
+    r = await client.post(
+        f"/api/v1/admin/authoring/projects/{pid}/publish",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"visibility": "catalog"},
+    )
+    assert r.status_code == 200
+    curriculum_id = r.json()["curriculum_id"]
+    assert r.json()["files_written"] == 5
+
+    async with app.state.pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        is_default = await conn.fetchval(
+            "SELECT is_default FROM curricula WHERE curriculum_id=$1", curriculum_id
+        )
+        status = await conn.fetchval(
+            "SELECT status FROM authoring_projects WHERE project_id=$1", pid
+        )
+        csv_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM content_subject_versions WHERE curriculum_id=$1", curriculum_id
+        )
+    assert is_default is True
+    assert status == "published"
+    assert csv_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_publish_private_keeps_is_default_false(
+    client: AsyncClient, admin_token: str
+) -> None:
+    pid = await _seed_generated_project()
+    await _accept_all(pid)
+    r = await client.post(
+        f"/api/v1/admin/authoring/projects/{pid}/publish",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"visibility": "private"},
+    )
+    assert r.status_code == 200
+    async with app.state.pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        is_default = await conn.fetchval(
+            "SELECT is_default FROM curricula WHERE curriculum_id=$1", r.json()["curriculum_id"]
+        )
+    assert is_default is False

--- a/pipeline/prompts.py
+++ b/pipeline/prompts.py
@@ -243,14 +243,44 @@ def _subject_guidelines(subject: str) -> str:
     return ""
 
 
+# Visual-emphasis block — opt-in via diagram_emphasis=True. Used by the
+# Curriculum Authoring Studio (Epic: Authoring Studio) to counter "too terse"
+# feedback: it asks the model to embed Mermaid diagrams for processes,
+# hierarchies, cycles, and relationships, and to expand explanations. Kept
+# OFF by default so existing platform builds are byte-for-byte unchanged.
+_DIAGRAM_EMPHASIS = """
+VISUAL EMPHASIS (authoring mode — make the content richer, not terse):
+- Where a concept involves a process, sequence, hierarchy, cycle, life-cycle,
+  or relationship between parts, embed a Mermaid diagram in a fenced
+  ```mermaid code block INSIDE the relevant section body. Choose the right
+  diagram type (flowchart `graph TD`, `sequenceDiagram`, `classDiagram`, or
+  `stateDiagram-v2`). Keep node labels short and in plain language.
+- Add a diagram only when it genuinely aids comprehension — never for
+  prose-only content, and prefer one clear diagram over several.
+- Expand every explanation with concrete, worked detail. Do not leave a
+  section terse or summary-only.
+"""
+
+
+def _diagram_block(emphasis: bool) -> str:
+    """Return the visual-emphasis directive when enabled, else ''."""
+    return _DIAGRAM_EMPHASIS if emphasis else ""
+
+
 def build_lesson_prompt(
     unit_id: str,
     subject: str,
     topic: str,
     grade: int,
     lang: str,
+    diagram_emphasis: bool = False,
 ) -> str:
-    """Return the prompt for generating a lesson JSON document."""
+    """Return the prompt for generating a lesson JSON document.
+
+    diagram_emphasis: when True, ask the model to embed Mermaid diagrams and
+    expand explanations (Authoring Studio). OFF by default so platform builds
+    are unchanged.
+    """
     grade_desc = _grade_descriptor(grade)
     lang_instruction = f"Write all content in {lang.upper()} language." if lang != "en" else "Write all content in English."
 
@@ -265,6 +295,7 @@ You MUST respond with ONLY valid JSON — no markdown fences, no extra text, no 
 
 {_FORMATTING_GUIDELINES}
 {_subject_guidelines(subject)}
+{_diagram_block(diagram_emphasis)}
 The JSON must exactly match this schema:
 
 {{
@@ -385,8 +416,13 @@ def build_tutorial_prompt(
     topic: str,
     grade: int,
     lang: str,
+    diagram_emphasis: bool = False,
 ) -> str:
-    """Return the prompt for generating a tutorial (step-by-step walkthrough) JSON document."""
+    """Return the prompt for generating a tutorial (step-by-step walkthrough) JSON document.
+
+    diagram_emphasis: when True, ask the model to embed Mermaid diagrams and
+    expand explanations (Authoring Studio). OFF by default.
+    """
     grade_desc = _grade_descriptor(grade)
     lang_instruction = f"Write all content in {lang.upper()} language." if lang != "en" else "Write all content in English."
 
@@ -401,6 +437,7 @@ You MUST respond with ONLY valid JSON — no markdown fences, no extra text, no 
 
 {_FORMATTING_GUIDELINES}
 {_subject_guidelines(subject)}
+{_diagram_block(diagram_emphasis)}
 The JSON must exactly match this schema:
 
 {{

--- a/web/components/content/Markdown.tsx
+++ b/web/components/content/Markdown.tsx
@@ -5,6 +5,7 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import { cn } from "@/lib/utils";
+import { MermaidDiagram } from "@/components/content/MermaidDiagram";
 
 /**
  * SBMarkdown — the canonical prose renderer for AI-generated content.
@@ -85,6 +86,11 @@ export function SBMarkdown({
             </td>
           ),
           code: ({ children, className: cname }) => {
+            // Mermaid fenced blocks render as diagrams, not raw code (Authoring
+            // Studio diagram_emphasis output).
+            if (cname?.includes("language-mermaid")) {
+              return <MermaidDiagram chart={String(children).trim()} />;
+            }
             const isBlock = cname?.includes("language-");
             if (isBlock) {
               return (

--- a/web/components/content/MermaidDiagram.tsx
+++ b/web/components/content/MermaidDiagram.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+/**
+ * web/components/content/MermaidDiagram.tsx
+ *
+ * Renders a fenced ```mermaid code block (flowchart / sequence / class /
+ * state diagram) as an inline SVG. Used by SBMarkdown so Authoring Studio
+ * content (and any content the pipeline emits with diagram_emphasis) renders
+ * diagrams instead of raw code.
+ *
+ * Mermaid is imported dynamically — it touches `window` and cannot be
+ * imported during SSR. The wrapper div carries data-testid="mermaid-diagram"
+ * and renders immediately; the SVG fills in asynchronously. On a render
+ * error we show a short note (never the raw source) so a malformed diagram
+ * doesn't dump code at the reader.
+ */
+
+import { useEffect, useId, useRef, useState } from "react";
+
+export function MermaidDiagram({ chart }: { chart: string }) {
+  const id = useId().replace(/:/g, "");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function render() {
+      try {
+        const mermaid = (await import("mermaid")).default;
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: "default",
+          securityLevel: "strict",
+          themeVariables: {
+            // Keep colours accessible — contrast ≥ 4.5:1 (WCAG AA).
+            primaryColor: "#e0e7ff",
+            primaryTextColor: "#1e1b4b",
+            primaryBorderColor: "#6366f1",
+            lineColor: "#6366f1",
+          },
+        });
+        const { svg } = await mermaid.render(`mmd-${id}`, chart);
+        if (cancelled || !containerRef.current) return;
+        containerRef.current.innerHTML = svg;
+        const svgEl = containerRef.current.querySelector("svg");
+        if (svgEl) {
+          svgEl.setAttribute("width", "100%");
+          svgEl.removeAttribute("height");
+          svgEl.style.maxWidth = "100%";
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Diagram could not be rendered");
+        }
+      }
+    }
+
+    render();
+    return () => {
+      cancelled = true;
+    };
+  }, [chart, id]);
+
+  return (
+    <div
+      data-testid="mermaid-diagram"
+      className="my-3 flex justify-center overflow-x-auto rounded-md bg-gray-50 p-3"
+    >
+      {error ? (
+        <span className="text-sm text-gray-400 italic">Diagram unavailable</span>
+      ) : (
+        <div ref={containerRef} className="w-full" />
+      )}
+    </div>
+  );
+}

--- a/web/lib/api/types.gen.ts
+++ b/web/lib/api/types.gen.ts
@@ -2072,6 +2072,143 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/authoring/projects/{project_id}/generate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Generate Project */
+        post: operations["generate_project_api_v1_admin_authoring_projects__project_id__generate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/authoring/projects/{project_id}/topics/{unit_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Topic */
+        get: operations["get_topic_api_v1_admin_authoring_projects__project_id__topics__unit_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/authoring/projects/{project_id}/topics/{unit_id}/regenerate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Regenerate Topic */
+        post: operations["regenerate_topic_api_v1_admin_authoring_projects__project_id__topics__unit_id__regenerate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/authoring/projects/{project_id}/topics/{unit_id}/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Accept Topic */
+        post: operations["accept_topic_api_v1_admin_authoring_projects__project_id__topics__unit_id__accept_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/authoring/projects/{project_id}/snapshots": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Snapshots */
+        get: operations["list_snapshots_api_v1_admin_authoring_projects__project_id__snapshots_get"];
+        put?: never;
+        /** Create Snapshot */
+        post: operations["create_snapshot_api_v1_admin_authoring_projects__project_id__snapshots_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/authoring/projects/{project_id}/snapshots/{snapshot_id}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Restore Snapshot */
+        post: operations["restore_snapshot_api_v1_admin_authoring_projects__project_id__snapshots__snapshot_id__restore_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/authoring/projects/{project_id}/flow-recheck": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Flow Recheck */
+        post: operations["flow_recheck_api_v1_admin_authoring_projects__project_id__flow_recheck_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/authoring/projects/{project_id}/publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Publish Project */
+        post: operations["publish_project_api_v1_admin_authoring_projects__project_id__publish_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/curricula/{curriculum_id}/usage": {
         parameters: {
             query?: never;
@@ -5600,6 +5737,21 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** AcceptRequest */
+        AcceptRequest: {
+            /** Content Type */
+            content_type: string;
+            /**
+             * Lang
+             * @default en
+             */
+            lang: string;
+        };
+        /** AcceptResponse */
+        AcceptResponse: {
+            /** Review Status */
+            review_status: string;
+        };
         /**
          * AccountStatusUpdate
          * @description PATCH /account/students/{id}/status
@@ -7591,6 +7743,13 @@ export interface components {
              */
             submitted_at: string;
         };
+        /** FlowRecheckResponse */
+        FlowRecheckResponse: {
+            /** Job Id */
+            job_id: string;
+            /** Status */
+            status: string;
+        };
         /**
          * ForgotPasswordRequest
          * @description POST /auth/forgot-password
@@ -7616,6 +7775,26 @@ export interface components {
             job_id: string;
             /** Scenario Id */
             scenario_id: string;
+        };
+        /** GenerateRequest */
+        GenerateRequest: {
+            /**
+             * Langs
+             * @default en
+             */
+            langs: string;
+            /**
+             * Force
+             * @default false
+             */
+            force: boolean;
+        };
+        /** GenerateResponse */
+        GenerateResponse: {
+            /** Job Id */
+            job_id: string;
+            /** Status */
+            status: string;
         };
         /** GeoBlockAddRequest */
         GeoBlockAddRequest: {
@@ -8312,17 +8491,13 @@ export interface components {
             /** Role */
             role: string;
         };
-        /** PublishResponse */
-        PublishResponse: {
-            /** Version Id */
-            version_id: string;
-            /** Status */
-            status: string;
+        /** PublishRequest */
+        PublishRequest: {
             /**
-             * Published At
-             * Format: date-time
+             * Visibility
+             * @default private
              */
-            published_at: string;
+            visibility: string;
         };
         /** QuizOption */
         QuizOption: {
@@ -8449,6 +8624,29 @@ export interface components {
         RefreshRequest: {
             /** Refresh Token */
             refresh_token: string;
+        };
+        /** RegenerateRequest */
+        RegenerateRequest: {
+            /** Content Type */
+            content_type: string;
+            /** Reason */
+            reason: string;
+            /**
+             * Lang
+             * @default en
+             */
+            lang: string;
+        };
+        /** RegenerateResponse */
+        RegenerateResponse: {
+            /** Topic Version Id */
+            topic_version_id: string;
+            /** Version Number */
+            version_number: number;
+            /** Review Status */
+            review_status: string;
+            /** Flow Recheck */
+            flow_recheck: unknown[];
         };
         /** RegisterTokenRequest */
         RegisterTokenRequest: {
@@ -8588,6 +8786,11 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
+        };
+        /** RestoreResponse */
+        RestoreResponse: {
+            /** Restored */
+            restored: boolean;
         };
         /** RetentionDashboard */
         RetentionDashboard: {
@@ -9200,6 +9403,30 @@ export interface components {
             version_id: string;
             /** Reason */
             reason: string;
+        };
+        /** SnapshotCreateRequest */
+        SnapshotCreateRequest: {
+            /** Label */
+            label?: string | null;
+        };
+        /** SnapshotItem */
+        SnapshotItem: {
+            /** Snapshot Id */
+            snapshot_id: string;
+            /** Snapshot Number */
+            snapshot_number: number;
+            /** Label */
+            label?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+        };
+        /** SnapshotListResponse */
+        SnapshotListResponse: {
+            /** Snapshots */
+            snapshots: components["schemas"]["SnapshotItem"][];
         };
         /** StartSessionRequest */
         StartSessionRequest: {
@@ -9842,6 +10069,11 @@ export interface components {
             student_id: string;
             student: components["schemas"]["StudentPublic"];
         };
+        /** TopicHistoryResponse */
+        TopicHistoryResponse: {
+            /** Versions */
+            versions: components["schemas"]["TopicVersion"][];
+        };
         /** TopicNode */
         TopicNode: {
             /** Title */
@@ -9850,6 +10082,39 @@ export interface components {
             subtopics?: string[];
             /** Prerequisites */
             prerequisites?: string[];
+        };
+        /** TopicVersion */
+        TopicVersion: {
+            /** Topic Version Id */
+            topic_version_id: string;
+            /** Unit Id */
+            unit_id: string;
+            /** Lang */
+            lang: string;
+            /** Content Type */
+            content_type: string;
+            /** Version Number */
+            version_number: number;
+            /** Body */
+            body?: {
+                [key: string]: unknown;
+            } | null;
+            /** Regen Reason */
+            regen_reason?: string | null;
+            /** Flow Recheck */
+            flow_recheck?: unknown[] | null;
+            /** Review Status */
+            review_status: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Is Active
+             * @default false
+             */
+            is_active: boolean;
         };
         /** TrendsReport */
         TrendsReport: {
@@ -10222,6 +10487,15 @@ export interface components {
             /** Duration */
             duration?: string | null;
         };
+        /** PublishResponse */
+        src__admin__authoring_schemas__PublishResponse: {
+            /** Curriculum Id */
+            curriculum_id: string;
+            /** Visibility */
+            visibility: string;
+            /** Files Written */
+            files_written: number;
+        };
         /** ArchiveResponse */
         src__admin__curriculum_lifecycle_router__ArchiveResponse: {
             /** Curriculum Id */
@@ -10254,6 +10528,18 @@ export interface components {
             inappropriate_count: number;
             /** Other Count */
             other_count: number;
+        };
+        /** PublishResponse */
+        src__admin__schemas__PublishResponse: {
+            /** Version Id */
+            version_id: string;
+            /** Status */
+            status: string;
+            /**
+             * Published At
+             * Format: date-time
+             */
+            published_at: string;
         };
         /** RejectRequest */
         src__admin__schemas__RejectRequest: {
@@ -12680,7 +12966,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PublishResponse"];
+                    "application/json": components["schemas"]["src__admin__schemas__PublishResponse"];
                 };
             };
             /** @description Validation Error */
@@ -13558,6 +13844,313 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MaterializeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_project_api_v1_admin_authoring_projects__project_id__generate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GenerateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenerateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_topic_api_v1_admin_authoring_projects__project_id__topics__unit_id__get: {
+        parameters: {
+            query?: {
+                content_type?: string;
+                lang?: string;
+                history?: number;
+            };
+            header?: never;
+            path: {
+                project_id: string;
+                unit_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopicVersion"] | components["schemas"]["TopicHistoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    regenerate_topic_api_v1_admin_authoring_projects__project_id__topics__unit_id__regenerate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                unit_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RegenerateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegenerateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    accept_topic_api_v1_admin_authoring_projects__project_id__topics__unit_id__accept_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                unit_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AcceptRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AcceptResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_snapshots_api_v1_admin_authoring_projects__project_id__snapshots_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SnapshotListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_snapshot_api_v1_admin_authoring_projects__project_id__snapshots_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SnapshotCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SnapshotItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    restore_snapshot_api_v1_admin_authoring_projects__project_id__snapshots__snapshot_id__restore_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                snapshot_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RestoreResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    flow_recheck_api_v1_admin_authoring_projects__project_id__flow_recheck_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FlowRecheckResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    publish_project_api_v1_admin_authoring_projects__project_id__publish_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PublishRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["src__admin__authoring_schemas__PublishResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -3517,7 +3517,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublishResponse"
+                  "$ref": "#/components/schemas/src__admin__schemas__PublishResponse"
                 }
               }
             }
@@ -4937,6 +4937,551 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MaterializeResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/authoring/projects/{project_id}/generate": {
+      "post": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "Generate Project",
+        "operationId": "generate_project_api_v1_admin_authoring_projects__project_id__generate_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/authoring/projects/{project_id}/topics/{unit_id}": {
+      "get": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "Get Topic",
+        "operationId": "get_topic_api_v1_admin_authoring_projects__project_id__topics__unit_id__get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Unit Id"
+            }
+          },
+          {
+            "name": "content_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "lesson",
+              "title": "Content Type"
+            }
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "en",
+              "title": "Lang"
+            }
+          },
+          {
+            "name": "history",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "History"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/TopicVersion"
+                    },
+                    {
+                      "$ref": "#/components/schemas/TopicHistoryResponse"
+                    }
+                  ],
+                  "title": "Response Get Topic Api V1 Admin Authoring Projects  Project Id  Topics  Unit Id  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/authoring/projects/{project_id}/topics/{unit_id}/regenerate": {
+      "post": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "Regenerate Topic",
+        "operationId": "regenerate_topic_api_v1_admin_authoring_projects__project_id__topics__unit_id__regenerate_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Unit Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegenerateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegenerateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/authoring/projects/{project_id}/topics/{unit_id}/accept": {
+      "post": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "Accept Topic",
+        "operationId": "accept_topic_api_v1_admin_authoring_projects__project_id__topics__unit_id__accept_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Unit Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcceptRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/authoring/projects/{project_id}/snapshots": {
+      "post": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "Create Snapshot",
+        "operationId": "create_snapshot_api_v1_admin_authoring_projects__project_id__snapshots_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SnapshotCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnapshotItem"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "List Snapshots",
+        "operationId": "list_snapshots_api_v1_admin_authoring_projects__project_id__snapshots_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnapshotListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/authoring/projects/{project_id}/snapshots/{snapshot_id}/restore": {
+      "post": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "Restore Snapshot",
+        "operationId": "restore_snapshot_api_v1_admin_authoring_projects__project_id__snapshots__snapshot_id__restore_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "snapshot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Snapshot Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/authoring/projects/{project_id}/flow-recheck": {
+      "post": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "Flow Recheck",
+        "operationId": "flow_recheck_api_v1_admin_authoring_projects__project_id__flow_recheck_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlowRecheckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/authoring/projects/{project_id}/publish": {
+      "post": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "Publish Project",
+        "operationId": "publish_project_api_v1_admin_authoring_projects__project_id__publish_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublishRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/src__admin__authoring_schemas__PublishResponse"
                 }
               }
             }
@@ -14850,6 +15395,37 @@
   },
   "components": {
     "schemas": {
+      "AcceptRequest": {
+        "properties": {
+          "content_type": {
+            "type": "string",
+            "title": "Content Type"
+          },
+          "lang": {
+            "type": "string",
+            "title": "Lang",
+            "default": "en"
+          }
+        },
+        "type": "object",
+        "required": [
+          "content_type"
+        ],
+        "title": "AcceptRequest"
+      },
+      "AcceptResponse": {
+        "properties": {
+          "review_status": {
+            "type": "string",
+            "title": "Review Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "review_status"
+        ],
+        "title": "AcceptResponse"
+      },
       "AccountStatusUpdate": {
         "properties": {
           "status": {
@@ -20164,6 +20740,24 @@
         ],
         "title": "FeedbackSubmitResponse"
       },
+      "FlowRecheckResponse": {
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "title": "Job Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "job_id",
+          "status"
+        ],
+        "title": "FlowRecheckResponse"
+      },
       "ForgotPasswordRequest": {
         "properties": {
           "email": {
@@ -20209,6 +20803,40 @@
           "scenario_id"
         ],
         "title": "GenerateClipsResponse"
+      },
+      "GenerateRequest": {
+        "properties": {
+          "langs": {
+            "type": "string",
+            "title": "Langs",
+            "default": "en"
+          },
+          "force": {
+            "type": "boolean",
+            "title": "Force",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "GenerateRequest"
+      },
+      "GenerateResponse": {
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "title": "Job Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "job_id",
+          "status"
+        ],
+        "title": "GenerateResponse"
       },
       "GeoBlockAddRequest": {
         "properties": {
@@ -21971,29 +22599,16 @@
         ],
         "title": "ProvisionTeacherResponse"
       },
-      "PublishResponse": {
+      "PublishRequest": {
         "properties": {
-          "version_id": {
+          "visibility": {
             "type": "string",
-            "title": "Version Id"
-          },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Published At"
+            "title": "Visibility",
+            "default": "private"
           }
         },
         "type": "object",
-        "required": [
-          "version_id",
-          "status",
-          "published_at"
-        ],
-        "title": "PublishResponse"
+        "title": "PublishRequest"
       },
       "QuizOption": {
         "properties": {
@@ -22339,6 +22954,60 @@
         ],
         "title": "RefreshRequest",
         "description": "POST /auth/refresh"
+      },
+      "RegenerateRequest": {
+        "properties": {
+          "content_type": {
+            "type": "string",
+            "title": "Content Type"
+          },
+          "reason": {
+            "type": "string",
+            "maxLength": 1000,
+            "minLength": 1,
+            "title": "Reason"
+          },
+          "lang": {
+            "type": "string",
+            "title": "Lang",
+            "default": "en"
+          }
+        },
+        "type": "object",
+        "required": [
+          "content_type",
+          "reason"
+        ],
+        "title": "RegenerateRequest"
+      },
+      "RegenerateResponse": {
+        "properties": {
+          "topic_version_id": {
+            "type": "string",
+            "title": "Topic Version Id"
+          },
+          "version_number": {
+            "type": "integer",
+            "title": "Version Number"
+          },
+          "review_status": {
+            "type": "string",
+            "title": "Review Status"
+          },
+          "flow_recheck": {
+            "items": {},
+            "type": "array",
+            "title": "Flow Recheck"
+          }
+        },
+        "type": "object",
+        "required": [
+          "topic_version_id",
+          "version_number",
+          "review_status",
+          "flow_recheck"
+        ],
+        "title": "RegenerateResponse"
       },
       "RegisterTokenRequest": {
         "properties": {
@@ -22718,6 +23387,19 @@
           "updated_at"
         ],
         "title": "RestoreRequestResponse"
+      },
+      "RestoreResponse": {
+        "properties": {
+          "restored": {
+            "type": "boolean",
+            "title": "Restored"
+          }
+        },
+        "type": "object",
+        "required": [
+          "restored"
+        ],
+        "title": "RestoreResponse"
       },
       "RetentionDashboard": {
         "properties": {
@@ -24376,6 +25058,74 @@
         ],
         "title": "SkippedVersion"
       },
+      "SnapshotCreateRequest": {
+        "properties": {
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          }
+        },
+        "type": "object",
+        "title": "SnapshotCreateRequest"
+      },
+      "SnapshotItem": {
+        "properties": {
+          "snapshot_id": {
+            "type": "string",
+            "title": "Snapshot Id"
+          },
+          "snapshot_number": {
+            "type": "integer",
+            "title": "Snapshot Number"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "snapshot_id",
+          "snapshot_number",
+          "created_at"
+        ],
+        "title": "SnapshotItem"
+      },
+      "SnapshotListResponse": {
+        "properties": {
+          "snapshots": {
+            "items": {
+              "$ref": "#/components/schemas/SnapshotItem"
+            },
+            "type": "array",
+            "title": "Snapshots"
+          }
+        },
+        "type": "object",
+        "required": [
+          "snapshots"
+        ],
+        "title": "SnapshotListResponse"
+      },
       "StartSessionRequest": {
         "properties": {
           "unit_id": {
@@ -26030,6 +26780,22 @@
         "title": "TokenExchangeResponse",
         "description": "Response for POST /auth/exchange"
       },
+      "TopicHistoryResponse": {
+        "properties": {
+          "versions": {
+            "items": {
+              "$ref": "#/components/schemas/TopicVersion"
+            },
+            "type": "array",
+            "title": "Versions"
+          }
+        },
+        "type": "object",
+        "required": [
+          "versions"
+        ],
+        "title": "TopicHistoryResponse"
+      },
       "TopicNode": {
         "properties": {
           "title": {
@@ -26058,6 +26824,90 @@
           "title"
         ],
         "title": "TopicNode"
+      },
+      "TopicVersion": {
+        "properties": {
+          "topic_version_id": {
+            "type": "string",
+            "title": "Topic Version Id"
+          },
+          "unit_id": {
+            "type": "string",
+            "title": "Unit Id"
+          },
+          "lang": {
+            "type": "string",
+            "title": "Lang"
+          },
+          "content_type": {
+            "type": "string",
+            "title": "Content Type"
+          },
+          "version_number": {
+            "type": "integer",
+            "title": "Version Number"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body"
+          },
+          "regen_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Regen Reason"
+          },
+          "flow_recheck": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Flow Recheck"
+          },
+          "review_status": {
+            "type": "string",
+            "title": "Review Status"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "topic_version_id",
+          "unit_id",
+          "lang",
+          "content_type",
+          "version_number",
+          "review_status",
+          "created_at"
+        ],
+        "title": "TopicVersion"
       },
       "TrendsReport": {
         "properties": {
@@ -27069,6 +27919,29 @@
         ],
         "title": "_VisualItemIn"
       },
+      "src__admin__authoring_schemas__PublishResponse": {
+        "properties": {
+          "curriculum_id": {
+            "type": "string",
+            "title": "Curriculum Id"
+          },
+          "visibility": {
+            "type": "string",
+            "title": "Visibility"
+          },
+          "files_written": {
+            "type": "integer",
+            "title": "Files Written"
+          }
+        },
+        "type": "object",
+        "required": [
+          "curriculum_id",
+          "visibility",
+          "files_written"
+        ],
+        "title": "PublishResponse"
+      },
       "src__admin__curriculum_lifecycle_router__ArchiveResponse": {
         "properties": {
           "curriculum_id": {
@@ -27170,6 +28043,30 @@
           "other_count"
         ],
         "title": "FeedbackReportItem"
+      },
+      "src__admin__schemas__PublishResponse": {
+        "properties": {
+          "version_id": {
+            "type": "string",
+            "title": "Version Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Published At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "version_id",
+          "status",
+          "published_at"
+        ],
+        "title": "PublishResponse"
       },
       "src__admin__schemas__RejectRequest": {
         "properties": {

--- a/web/tests/unit/markdown-mermaid.test.tsx
+++ b/web/tests/unit/markdown-mermaid.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Unit test — SBMarkdown renders ```mermaid fenced blocks as a diagram
+ * container (Authoring Studio diagram_emphasis output), not as raw code.
+ *
+ * Run with:
+ *   npm test -- markdown-mermaid
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SBMarkdown } from "@/components/content/Markdown";
+
+// Mermaid is dynamically imported by MermaidDiagram; stub it so the test is
+// deterministic in jsdom (real mermaid needs a full browser layout engine).
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn().mockResolvedValue({ svg: "<svg aria-hidden='true'></svg>" }),
+  },
+}));
+
+describe("SBMarkdown mermaid rendering", () => {
+  it("routes a mermaid fenced block to the diagram container, not <pre><code>", async () => {
+    const md = "```mermaid\ngraph TD; A-->B;\n```";
+    render(<SBMarkdown>{md}</SBMarkdown>);
+
+    expect(await screen.findByTestId("mermaid-diagram")).toBeInTheDocument();
+    // The raw diagram source must not be shown as code text.
+    expect(screen.queryByText("graph TD; A-->B;")).not.toBeInTheDocument();
+  });
+
+  it("still renders a non-mermaid fenced block as code", () => {
+    const md = "```python\nprint('hi')\n```";
+    render(<SBMarkdown>{md}</SBMarkdown>);
+    expect(screen.queryByTestId("mermaid-diagram")).not.toBeInTheDocument();
+    expect(screen.getByText("print('hi')")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

PR-B of 2 — completes the **Curriculum Authoring Studio**. Stacked on #383 (base = `feat/authoring-studio-pr-a`); review/merge that first.

After PR-A materialises a staged platform curriculum, this PR generates per-topic content, supports **unlimited regenerate-with-reason** with a deterministic flow recheck, whole-curriculum **manifest snapshots/restore**, and **publish** (private | school catalog).

## Why

Closes the authoring loop: generate content → review/accept per topic → regenerate terse/weak topics with a reason → version everything → publish. Addresses the "too terse" feedback via Mermaid-diagram prompt emphasis + richer prose.

## Endpoints (super_admin-gated)

`/api/v1/admin/authoring/`:
- `POST /projects/{id}/generate` — Celery, all topics (202)
- `GET /projects/{id}/topics/{unit_id}?content_type=&history=` — active version or full append-only history
- `POST …/topics/{unit_id}/regenerate` — **sync, unlimited**; append-only version with reason + deterministic flow recheck
- `POST …/topics/{unit_id}/accept`
- `POST /projects/{id}/snapshots` · `GET …` · `POST …/{snapshot_id}/restore` — manifest snapshots (per-topic append-only + whole-curriculum pointer rollback, no content copy)
- `POST /projects/{id}/flow-recheck` — Celery, full LLM re-analysis of the current TOC (202)
- `POST /projects/{id}/publish` — `{visibility: private|catalog}`; gates on all active topics accepted, writes accepted bodies to the content store + `content_subject_versions`, sets `curricula.is_default = (visibility=='catalog')`

## Content model

Generated content lives in `authoring_topic_versions` (append-only) with `authoring_active_versions` as the live pointer; `authoring_snapshots` hold manifests. Generation: `backend/src/admin/authoring_generation.py`. Mermaid: `diagram_emphasis=True` on the lesson/tutorial prompt builders (off by default — platform builds unchanged); `web/components/content/MermaidDiagram.tsx` renders fenced ` ```mermaid ` blocks in `SBMarkdown`.

State machine: `draft → analyzing → analyzed → structured → generating → generated → published`.

## Notable fixes / decisions

- **Latent bug fixed:** the Celery tasks (PR-A analyze + new generate/flow-recheck) use raw asyncpg connections; they now register the jsonb codec before binding dict payloads (else asyncpg rejects them — "expected str, got dict").
- **Simplification:** published `content_subject_versions.provider` is `'anthropic'` (the CHECK only allows anthropic/openai/google/school_upload). Revisit if multi-provider authoring is needed.

## Risk

Generation/regenerate/flow paths are exercised with **fake** providers only — never run against a real LLM. **Recommend a live-key smoke run of the flow-analyzer + Mermaid emphasis before relying on output quality.**

## Test plan

- +13 backend tests (11 PR-B endpoint/service incl. generate, unlimited append-only regenerate + flow recheck, accept, snapshot/restore round-trip, publish catalog→`is_default`; 2 prompt-emphasis) + 2 web vitest (SBMarkdown mermaid routing).
- Migration 0060 down/up cycle re-verified with committed `admin_authored` + `content_subject_versions` data.
- ruff + bandit + web format/lint/typecheck clean; OpenAPI + TS types regenerated; full suite collects 1084, no import regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)