### PR TITLE
chore(ci): ratchet per-module coverage floors to current actuals (#387)

### DIFF
--- a/backend/scripts/check_coverage_thresholds.py
+++ b/backend/scripts/check_coverage_thresholds.py
@@ -16,13 +16,21 @@ Exit codes:
   0 — all thresholds met
   1 — one or more thresholds not met (details printed to stdout)
 
-Thresholds (per-module, aggregated over all .py files under that prefix):
-  src/auth/                90%  — token flows, COPPA, suspension paths
-  src/subscription/        90%  — Stripe webhook, plan transitions
-  src/school/subscription  90%  — school billing, SCA handling
-  src/content/             85%  — content serving, entitlement edge cases
-  src/progress/            80%
-  everything else          80%
+Thresholds (per-module, aggregated over all .py files under that prefix).
+
+These are RATCHET FLOORS, not aspirational targets — each is set a couple of
+points below current measured coverage so the gate prevents regression while
+passing today. Raise them toward the TARGET as coverage improves; never lower
+a floor without a deliberate decision. See issue #387 for the back-story (the
+original 85-90% targets were aspirational and the gate had been silently red).
+
+  module                    floor   (target)  — notes
+  src/auth/                  45%     (90%)  — token flows, COPPA, suspension paths
+  src/subscription/          70%     (90%)  — Stripe webhook, plan transitions
+  src/school/subscription    64%     (90%)  — school billing, SCA handling
+  src/content/               60%     (85%)  — content serving, entitlement edges
+  src/progress/              80%     (80%)  — already meets target
+  everything else            77%     (80%)
 """
 from __future__ import annotations
 
@@ -32,14 +40,16 @@ from collections import defaultdict
 from pathlib import Path
 
 # Longest-prefix-wins matching.  Key must NOT include a trailing slash.
+# Ratchet floors (see module docstring + issue #387). Raise toward the bracketed
+# target as coverage improves; do not lower without a deliberate decision.
 THRESHOLDS: dict[str, int] = {
-    "src/auth": 90,
-    "src/subscription": 90,
-    "src/school/subscription": 90,
-    "src/content": 85,
-    "src/progress": 80,
+    "src/auth": 45,  # target 90 — actual ~48%
+    "src/subscription": 70,  # target 90 — actual ~73%
+    "src/school/subscription": 64,  # target 90 — actual ~67%
+    "src/content": 60,  # target 85 — actual ~63%
+    "src/progress": 80,  # meets target (actual ~86%)
 }
-DEFAULT_THRESHOLD = 80
+DEFAULT_THRESHOLD = 77  # "everything else" — actual ~79%; target 80
 
 
 def _bucket(filepath: str) -> str:

--- a/backend/tests/test_check_coverage_thresholds.py
+++ b/backend/tests/test_check_coverage_thresholds.py
@@ -11,12 +11,9 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
-
 # Add the scripts directory to sys.path so we can import it directly.
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 from check_coverage_thresholds import DEFAULT_THRESHOLD, THRESHOLDS, _bucket, main
-
 
 # ── _bucket() routing ─────────────────────────────────────────────────────────
 
@@ -101,8 +98,9 @@ def test_auth_below_threshold_returns_1(tmp_path: Path):
     report = _make_report(
         tmp_path,
         {
-            "src/auth/router.py": (89, 100),   # 89% < 90
-        },
+            # 1 point below the auth floor (dynamic so this survives ratchets).
+            "src/auth/router.py": (THRESHOLDS["src/auth"] - 1, 100),
+},
     )
     assert main(str(report)) == 1
 
@@ -111,8 +109,8 @@ def test_subscription_below_threshold_returns_1(tmp_path: Path):
     report = _make_report(
         tmp_path,
         {
-            "src/subscription/router.py": (85, 100),  # 85% < 90
-        },
+            "src/subscription/router.py": (THRESHOLDS["src/subscription"] - 1, 100),
+},
     )
     assert main(str(report)) == 1
 
@@ -121,8 +119,11 @@ def test_school_subscription_below_threshold_returns_1(tmp_path: Path):
     report = _make_report(
         tmp_path,
         {
-            "src/school/subscription_service.py": (89, 100),  # 89% < 90
-        },
+            "src/school/subscription_service.py": (
+                THRESHOLDS["src/school/subscription"] - 1,
+                100,
+            ),
+},
     )
     assert main(str(report)) == 1
 
@@ -131,8 +132,8 @@ def test_content_below_threshold_returns_1(tmp_path: Path):
     report = _make_report(
         tmp_path,
         {
-            "src/content/router.py": (84, 100),  # 84% < 85
-        },
+            "src/content/router.py": (THRESHOLDS["src/content"] - 1, 100),
+},
     )
     assert main(str(report)) == 1
 
@@ -141,8 +142,8 @@ def test_default_module_below_threshold_returns_1(tmp_path: Path):
     report = _make_report(
         tmp_path,
         {
-            "src/analytics/router.py": (79, 100),  # 79% < 80
-        },
+            "src/analytics/router.py": (DEFAULT_THRESHOLD - 1, 100),
+},
     )
     assert main(str(report)) == 1
 
@@ -177,15 +178,15 @@ def test_aggregate_across_multiple_files_in_module(tmp_path: Path):
 
 def test_aggregate_below_threshold_despite_one_perfect_file(tmp_path: Path):
     """
-    One 100% file cannot mask a very low companion — aggregate must still fail.
-    100 + 79 = 179/200 = 89.5% < 90% auth threshold.
+    One 100% file cannot mask a large untested companion — the aggregate must
+    still fail. 100/500 = 20%, well below the auth floor.
     """
     report = _make_report(
         tmp_path,
         {
             "src/auth/router.py": (100, 100),  # 100%
-            "src/auth/service.py": (79, 100),  # 79%
-            # aggregate = 179/200 = 89.5% < 90
+            "src/auth/service.py": (0, 400),  # 0% over a big file
+            # aggregate = 100/500 = 20% < auth floor
         },
     )
     assert main(str(report)) == 1


### PR DESCRIPTION
## What

Lowers the per-module coverage thresholds in `backend/scripts/check_coverage_thresholds.py` from aspirational targets to **ratchet floors** set a couple points below current measured coverage, so the `Backend — Tests › Check per-module coverage thresholds` gate passes while still catching regressions.

| Module | Actual | Floor (was) | Target (kept in docs) |
|---|---:|---:|---:|
| src/auth | ~48% | **45** (90) | 90 |
| src/subscription | ~73% | **70** (90) | 90 |
| src/school/subscription | ~67% | **64** (90) | 90 |
| src/content | ~63% | **60** (85) | 85 |
| everything else | ~79% | **77** (80) | 80 |
| src/progress | ~86% | 80 (unchanged) | 80 |

No passing module was loosened. Overall coverage is **74.0%** (1082 passed, 2 skipped locally on `main`).

## Why

The gate used 85–90% targets that actual coverage never reached, so CI was silently red on it (only visible once the unrelated test failures were fixed in #386). This unblocks green CI now; the bracketed targets stay documented so floors get raised as coverage improves. Implements option 2 from #387.

## Largest debt (for future ratcheting)

`src/auth/tasks.py` 19% (Celery tasks — the main driver of `src/auth` at 48%), `src/backup/{storage,tasks}.py` 0–7%, `src/content/{service,router}.py` 46–53%, `src/core/storage.py` 52%.

Refs #387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)