### PR TITLE
feat(authoring): super-admin web UI for the Curriculum Authoring Studio

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,8 +291,10 @@ All admin routes live under `/admin/` and require a valid `sb_admin_token` JWT c
 | `/admin/demo-teacher-accounts` | Manage demo teacher accounts |
 | `/admin/feedback` | Student feedback list |
 | `/admin/audit` | Audit log |
+| `/admin/authoring` | Authoring Studio — project list + create (super_admin only) |
+| `/admin/authoring/[projectId]` | Authoring workspace — analyze · edit structure · materialize · generate · per-topic review/regenerate/accept · snapshots/restore · publish |
 
-**Curriculum Authoring Studio (super-admin only, API surface — PR-A + PR-B, no web UI yet):**
+**Curriculum Authoring Studio (super-admin only — backend API + web UI):**
 Gated by the `curriculum:author` permission, which only `super_admin` holds (via its
 `{"*"}` wildcard); `product_admin` and below get 403. Endpoints under
 `/api/v1/admin/authoring/` (`backend/src/admin/authoring_router.py`):
@@ -322,6 +324,12 @@ prompt builders with `diagram_emphasis=True` (Mermaid diagrams + richer prose �
 `SBMarkdown`. State machine: `draft → analyzing → analyzed → structured → generating → generated
 → published`. Celery tasks (raw asyncpg connections) register the jsonb codec before binding
 dict payloads (else asyncpg rejects them — "expected str, got dict").
+
+Web UI (super_admin nav item "Authoring Studio"): `web/app/(admin)/admin/authoring/page.tsx`
+(list + create), `web/app/(admin)/admin/authoring/[projectId]/page.tsx` (staged workspace),
+`web/components/authoring/*` (StatusBadge, StructuredTocEditor, TopicReviewPanel), API client
+`web/lib/api/authoring.ts`. A `GET …/projects/{id}/topics` endpoint backs the topic list. The
+topic review panel renders lesson/tutorial via `<SBMarkdown>` so Mermaid diagrams render.
 
 ---
 

--- a/backend/src/admin/authoring_generation.py
+++ b/backend/src/admin/authoring_generation.py
@@ -488,3 +488,66 @@ async def accept_topic(
         lang,
     )
     return row is not None
+
+
+async def list_topics(conn: asyncpg.Connection, project_id: str) -> dict | None:
+    """List the materialised units of a project with per-content-type status.
+
+    The UI needs to enumerate topics (PR-B only exposed single-topic GET).
+    Returns None if the project doesn't exist; an empty topics list if it
+    hasn't been materialised yet.
+    """
+    proj = await conn.fetchrow(
+        "SELECT grade, curriculum_id, status FROM authoring_projects WHERE project_id = $1",
+        project_id,
+    )
+    if proj is None:
+        return None
+    if not proj["curriculum_id"]:
+        return {"curriculum_id": None, "status": proj["status"], "topics": [], "total": 0}
+
+    units = await conn.fetch(
+        "SELECT unit_id, subject, title FROM curriculum_units "
+        "WHERE curriculum_id = $1 ORDER BY sort_order",
+        proj["curriculum_id"],
+    )
+    actives = await conn.fetch(
+        """
+        SELECT av.unit_id, av.content_type, av.lang,
+               tv.version_number, tv.review_status
+          FROM authoring_active_versions av
+          JOIN authoring_topic_versions tv ON tv.topic_version_id = av.topic_version_id
+         WHERE av.project_id = $1
+        """,
+        project_id,
+    )
+    by_unit: dict[str, list[dict]] = {}
+    for a in actives:
+        by_unit.setdefault(a["unit_id"], []).append(
+            {
+                "content_type": a["content_type"],
+                "lang": a["lang"],
+                "version_number": a["version_number"],
+                "review_status": a["review_status"],
+            }
+        )
+
+    topics = []
+    for u in units:
+        contents = sorted(by_unit.get(u["unit_id"], []), key=lambda c: c["content_type"])
+        topics.append(
+            {
+                "unit_id": u["unit_id"],
+                "title": u["title"],
+                "subject": u["subject"],
+                "contents": contents,
+                "content_count": len(contents),
+                "accepted_count": sum(1 for c in contents if c["review_status"] == "accepted"),
+            }
+        )
+    return {
+        "curriculum_id": proj["curriculum_id"],
+        "status": proj["status"],
+        "topics": topics,
+        "total": len(topics),
+    }

--- a/backend/src/admin/authoring_router.py
+++ b/backend/src/admin/authoring_router.py
@@ -60,6 +60,7 @@ from src.admin.authoring_schemas import (
     SnapshotItem,
     SnapshotListResponse,
     TopicHistoryResponse,
+    TopicListResponse,
     TopicVersion,
 )
 from src.auth.dependencies import get_current_admin
@@ -638,3 +639,22 @@ async def publish_project(
         },
     )
     return PublishResponse(**result)
+
+
+# ── 16. List topics (materialised units + per-content-type status) ──────────────
+
+
+@router.get(
+    "/admin/authoring/projects/{project_id}/topics",
+    response_model=TopicListResponse,
+)
+async def list_topics(
+    project_id: str,
+    request: Request,
+    admin: Annotated[dict, Depends(_require_author())],
+) -> TopicListResponse:
+    async with get_db(request) as conn:
+        result = await gen.list_topics(conn, project_id)
+    if result is None:
+        raise _not_found(project_id, request)
+    return TopicListResponse(**result)

--- a/backend/src/admin/authoring_schemas.py
+++ b/backend/src/admin/authoring_schemas.py
@@ -156,6 +156,29 @@ class TopicHistoryResponse(BaseModel):
     versions: list[TopicVersion]
 
 
+class TopicContentStatus(BaseModel):
+    content_type: str
+    lang: str
+    version_number: int
+    review_status: str
+
+
+class TopicListItem(BaseModel):
+    unit_id: str
+    title: str
+    subject: str
+    contents: list[TopicContentStatus]
+    content_count: int
+    accepted_count: int
+
+
+class TopicListResponse(BaseModel):
+    curriculum_id: str | None = None
+    status: str | None = None
+    topics: list[TopicListItem]
+    total: int
+
+
 class RegenerateRequest(BaseModel):
     content_type: str
     reason: str = Field(min_length=1, max_length=1000)

--- a/backend/tests/test_authoring_pr_b.py
+++ b/backend/tests/test_authoring_pr_b.py
@@ -363,3 +363,33 @@ async def test_publish_private_keeps_is_default_false(
             "SELECT is_default FROM curricula WHERE curriculum_id=$1", r.json()["curriculum_id"]
         )
     assert is_default is False
+
+
+@pytest.mark.asyncio
+async def test_list_topics(client: AsyncClient, admin_token: str) -> None:
+    pid = await _seed_generated_project()
+    r = await client.get(
+        f"/api/v1/admin/authoring/projects/{pid}/topics",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 1
+    topic = body["topics"][0]
+    assert topic["unit_id"] == _first_unit_id(pid)
+    assert topic["content_count"] == 5  # lesson + tutorial + 3 quiz sets
+    assert {c["content_type"] for c in topic["contents"]} >= {"lesson", "tutorial"}
+
+
+@pytest.mark.asyncio
+async def test_list_topics_unmaterialized_is_empty(client: AsyncClient, admin_token: str) -> None:
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    created = await client.post(
+        "/api/v1/admin/authoring/projects",
+        headers=headers,
+        json={"title": "X", "grade": 9, "languages": ["en"], "raw_toc": "1. A"},
+    )
+    pid = created.json()["project_id"]
+    r = await client.get(f"/api/v1/admin/authoring/projects/{pid}/topics", headers=headers)
+    assert r.status_code == 200
+    assert r.json() == {"curriculum_id": None, "status": "draft", "topics": [], "total": 0}

--- a/web/app/(admin)/admin/authoring/[projectId]/page.tsx
+++ b/web/app/(admin)/admin/authoring/[projectId]/page.tsx
@@ -8,12 +8,12 @@ import {
   Boxes,
   Camera,
   Check,
+  Loader2,
   RotateCcw,
   Sparkles,
   Wand2,
   Workflow,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
 import { StatusBadge } from "@/components/authoring/StatusBadge";
 import { StructuredTocEditor } from "@/components/authoring/StructuredTocEditor";
 import { TopicReviewPanel } from "@/components/authoring/TopicReviewPanel";
@@ -168,7 +168,11 @@ export default function AuthoringWorkspacePage({
           onClick={() => analyzeMut.mutate()}
           className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
         >
-          <Wand2 className="h-4 w-4" />
+          {project.status === "analyzing" || analyzeMut.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Wand2 className="h-4 w-4" />
+          )}
           {project.status === "analyzing"
             ? "Analyzing…"
             : project.structured_toc
@@ -247,15 +251,21 @@ export default function AuthoringWorkspacePage({
               onClick={() => generateMut.mutate()}
               className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
             >
-              {project.status === "generating"
-                ? "Generating…"
-                : topics.some((t) => t.content_count > 0)
-                  ? "Regenerate all"
-                  : "Generate all topics"}
+              {project.status === "generating" || generateMut.isPending ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" /> Generating…
+                </>
+              ) : topics.some((t) => t.content_count > 0) ? (
+                "Regenerate all"
+              ) : (
+                "Generate all topics"
+              )}
             </button>
             {project.status === "generating" && (
-              <span className="text-xs text-gray-500">
-                Generating content — this can take a few minutes.
+              <span className="inline-flex items-center gap-1.5 text-xs text-indigo-600">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Generating content — this can take a few minutes. The list updates
+                automatically.
               </span>
             )}
           </div>
@@ -285,15 +295,19 @@ export default function AuthoringWorkspacePage({
                           : "—"}
                       </td>
                       <td className="px-3 py-2">
-                        <span
-                          className={cn(
-                            t.content_count > 0 && t.accepted_count === t.content_count
-                              ? "text-emerald-600"
-                              : "text-gray-500",
-                          )}
-                        >
-                          {t.accepted_count}/{t.content_count}
-                        </span>
+                        {t.content_count === 0 ? (
+                          <span className="inline-flex items-center rounded-full bg-gray-200 px-2.5 py-0.5 text-xs font-semibold text-gray-600">
+                            Not generated
+                          </span>
+                        ) : t.accepted_count === t.content_count ? (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-600 px-2.5 py-0.5 text-xs font-semibold text-white">
+                            <Check className="h-3 w-3" /> Accepted
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center rounded-full bg-amber-500 px-2.5 py-0.5 text-xs font-semibold text-white">
+                            {t.accepted_count}/{t.content_count} accepted
+                          </span>
+                        )}
                       </td>
                       <td className="px-3 py-2 text-right">
                         {t.content_count > 0 && (

--- a/web/app/(admin)/admin/authoring/[projectId]/page.tsx
+++ b/web/app/(admin)/admin/authoring/[projectId]/page.tsx
@@ -1,0 +1,396 @@
+"use client";
+
+import { use, useState } from "react";
+import Link from "next/link";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowLeft,
+  Boxes,
+  Camera,
+  RotateCcw,
+  Sparkles,
+  Wand2,
+  Workflow,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { StatusBadge } from "@/components/authoring/StatusBadge";
+import { StructuredTocEditor } from "@/components/authoring/StructuredTocEditor";
+import { TopicReviewPanel } from "@/components/authoring/TopicReviewPanel";
+import {
+  analyzeProject,
+  createSnapshot,
+  flowRecheck,
+  generate,
+  getProject,
+  listSnapshots,
+  listTopics,
+  materialize,
+  publishProject,
+  restoreSnapshot,
+  saveStructure,
+  type StructuredTOC,
+  type TopicListItem,
+} from "@/lib/api/authoring";
+
+const POLLING = new Set(["analyzing", "generating"]);
+
+export default function AuthoringWorkspacePage({
+  params,
+}: {
+  params: Promise<{ projectId: string }>;
+}) {
+  const { projectId } = use(params);
+  const queryClient = useQueryClient();
+  const [selectedTopic, setSelectedTopic] = useState<TopicListItem | null>(null);
+
+  const { data: project, isLoading } = useQuery({
+    queryKey: ["admin", "authoring", projectId],
+    queryFn: () => getProject(projectId),
+    refetchInterval: (q) =>
+      POLLING.has((q.state.data?.status as string) ?? "") ? 2500 : false,
+  });
+
+  const { data: topicData } = useQuery({
+    queryKey: ["admin", "authoring", projectId, "topics"],
+    queryFn: () => listTopics(projectId),
+    enabled: !!project?.curriculum_id,
+    refetchInterval: project?.status === "generating" ? 3000 : false,
+  });
+
+  const { data: snapshots } = useQuery({
+    queryKey: ["admin", "authoring", projectId, "snapshots"],
+    queryFn: () => listSnapshots(projectId),
+    enabled: !!project,
+  });
+
+  const invalidate = (...extra: string[]) =>
+    void queryClient.invalidateQueries({
+      queryKey: ["admin", "authoring", projectId, ...extra],
+    });
+  const invalidateAll = () => {
+    invalidate();
+    invalidate("topics");
+    invalidate("snapshots");
+  };
+
+  const analyzeMut = useMutation({
+    mutationFn: () => analyzeProject(projectId),
+    onSuccess: () => invalidate(),
+  });
+  const saveStructMut = useMutation({
+    mutationFn: (toc: StructuredTOC) => saveStructure(projectId, toc),
+    onSuccess: () => invalidate(),
+  });
+  const materializeMut = useMutation({
+    mutationFn: () => materialize(projectId),
+    onSuccess: invalidateAll,
+  });
+  const generateMut = useMutation({
+    mutationFn: () => generate(projectId),
+    onSuccess: () => invalidate(),
+  });
+  const snapshotMut = useMutation({
+    mutationFn: () => createSnapshot(projectId),
+    onSuccess: () => invalidate("snapshots"),
+  });
+  const restoreMut = useMutation({
+    mutationFn: (sid: string) => restoreSnapshot(projectId, sid),
+    onSuccess: invalidateAll,
+  });
+  const recheckMut = useMutation({
+    mutationFn: () => flowRecheck(projectId),
+    onSuccess: () => invalidate(),
+  });
+  const publishMut = useMutation({
+    mutationFn: (v: "private" | "catalog") => publishProject(projectId, v),
+    onSuccess: invalidateAll,
+  });
+
+  if (isLoading || !project) {
+    return (
+      <div className="mx-auto max-w-5xl p-8">
+        <div className="h-40 animate-pulse rounded-xl bg-gray-100" />
+      </div>
+    );
+  }
+
+  const topics = topicData?.topics ?? [];
+  const allAccepted =
+    topics.length > 0 &&
+    topics.every((t) => t.content_count > 0 && t.accepted_count === t.content_count);
+  const flow = project.flow_report;
+
+  return (
+    <div className="mx-auto max-w-5xl p-8">
+      <Link
+        href="/admin/authoring"
+        className="mb-3 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+      >
+        <ArrowLeft className="h-4 w-4" /> All projects
+      </Link>
+
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">{project.title}</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Grade {project.grade ?? "—"} · {project.languages.join(", ")} ·{" "}
+            <StatusBadge status={project.status} /> · {project.visibility}
+          </p>
+        </div>
+      </div>
+
+      {/* ── Stage 1: TOC + analyze ─────────────────────────────────────── */}
+      <Section title="1 · Table of contents" icon={<Sparkles className="h-4 w-4" />}>
+        <pre className="mb-3 max-h-48 overflow-auto rounded-lg bg-gray-50 p-3 font-mono text-xs text-gray-700">
+          {project.raw_toc}
+        </pre>
+        <button
+          disabled={analyzeMut.isPending || project.status === "analyzing"}
+          onClick={() => analyzeMut.mutate()}
+          className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+        >
+          <Wand2 className="h-4 w-4" />
+          {project.status === "analyzing"
+            ? "Analyzing…"
+            : project.structured_toc
+              ? "Re-analyze"
+              : "Analyze TOC"}
+        </button>
+        {project.analyze_error && (
+          <p className="mt-2 text-sm text-red-600">
+            Analysis error: {project.analyze_error}
+          </p>
+        )}
+      </Section>
+
+      {/* ── Flow report ────────────────────────────────────────────────── */}
+      {flow && (flow.summary || flow.warnings.length > 0) && (
+        <Section title="Flow analysis (advisory)" icon={<Workflow className="h-4 w-4" />}>
+          {flow.summary && <p className="mb-2 text-sm text-gray-600">{flow.summary}</p>}
+          {flow.warnings.length === 0 ? (
+            <p className="text-sm text-emerald-600">No flow issues found.</p>
+          ) : (
+            <ul className="space-y-1 text-sm">
+              {flow.warnings.map((w, i) => (
+                <li key={i} className="rounded-md bg-amber-50 px-3 py-1.5 text-amber-800">
+                  <span className="font-medium">{w.kind}</span>
+                  {w.unit ? ` · ${w.unit}` : ""} — {w.detail}
+                </li>
+              ))}
+            </ul>
+          )}
+          <button
+            disabled={recheckMut.isPending}
+            onClick={() => recheckMut.mutate()}
+            className="mt-2 text-xs font-medium text-indigo-600 hover:underline disabled:opacity-50"
+          >
+            Re-run full flow analysis
+          </button>
+        </Section>
+      )}
+
+      {/* ── Stage 2: structured TOC editor + materialize ───────────────── */}
+      {project.structured_toc && (
+        <Section title="2 · Structure & edit topics" icon={<Boxes className="h-4 w-4" />}>
+          <StructuredTocEditor
+            value={project.structured_toc}
+            saving={saveStructMut.isPending}
+            onSave={(toc) => saveStructMut.mutate(toc)}
+          />
+          {!project.curriculum_id && (
+            <div className="mt-4 border-t border-gray-100 pt-4">
+              <button
+                disabled={materializeMut.isPending}
+                onClick={() => materializeMut.mutate()}
+                className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+              >
+                {materializeMut.isPending
+                  ? "Saving to library…"
+                  : "Save to library (materialize)"}
+              </button>
+              <p className="mt-1 text-xs text-gray-500">
+                Creates a staged platform curriculum, separate from school content.
+              </p>
+            </div>
+          )}
+        </Section>
+      )}
+
+      {/* ── Stage 3: generate + topic review ───────────────────────────── */}
+      {project.curriculum_id && (
+        <Section
+          title="3 · Generate & review content"
+          icon={<Sparkles className="h-4 w-4" />}
+        >
+          <div className="mb-3 flex items-center gap-3">
+            <button
+              disabled={generateMut.isPending || project.status === "generating"}
+              onClick={() => generateMut.mutate()}
+              className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {project.status === "generating"
+                ? "Generating…"
+                : topics.some((t) => t.content_count > 0)
+                  ? "Regenerate all"
+                  : "Generate all topics"}
+            </button>
+            {project.status === "generating" && (
+              <span className="text-xs text-gray-500">
+                Generating content — this can take a few minutes.
+              </span>
+            )}
+          </div>
+
+          {topics.length === 0 ? (
+            <p className="text-sm text-gray-400">
+              No topics yet — generate content above.
+            </p>
+          ) : (
+            <div className="overflow-hidden rounded-xl border border-gray-200">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50 text-xs text-gray-500">
+                  <tr>
+                    <th className="px-3 py-2 text-left font-medium">Topic</th>
+                    <th className="px-3 py-2 text-left font-medium">Content</th>
+                    <th className="px-3 py-2 text-left font-medium">Accepted</th>
+                    <th className="w-20" />
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {topics.map((t) => (
+                    <tr key={t.unit_id} className="hover:bg-gray-50">
+                      <td className="px-3 py-2 font-medium text-gray-900">{t.title}</td>
+                      <td className="px-3 py-2 text-gray-600">
+                        {t.content_count > 0
+                          ? t.contents.map((c) => c.content_type).join(", ")
+                          : "—"}
+                      </td>
+                      <td className="px-3 py-2">
+                        <span
+                          className={cn(
+                            t.content_count > 0 && t.accepted_count === t.content_count
+                              ? "text-emerald-600"
+                              : "text-gray-500",
+                          )}
+                        >
+                          {t.accepted_count}/{t.content_count}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 text-right">
+                        {t.content_count > 0 && (
+                          <button
+                            onClick={() => setSelectedTopic(t)}
+                            className="text-xs font-medium text-indigo-600 hover:underline"
+                          >
+                            Review
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Section>
+      )}
+
+      {/* ── Snapshots + publish ─────────────────────────────────────────── */}
+      {project.curriculum_id && (
+        <Section title="4 · Versions & publish" icon={<Camera className="h-4 w-4" />}>
+          <div className="mb-4 flex items-center gap-3">
+            <button
+              disabled={snapshotMut.isPending}
+              onClick={() => snapshotMut.mutate()}
+              className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              <Camera className="h-4 w-4" /> Snapshot now
+            </button>
+            <span className="text-xs text-gray-500">
+              {snapshots?.length ?? 0} snapshot(s)
+            </span>
+          </div>
+          {snapshots && snapshots.length > 0 && (
+            <ul className="mb-4 space-y-1 text-sm">
+              {snapshots.map((s) => (
+                <li key={s.snapshot_id} className="flex items-center gap-3">
+                  <span className="font-mono text-xs text-gray-500">
+                    #{s.snapshot_number}
+                  </span>
+                  <span className="text-gray-700">{s.label ?? "(no label)"}</span>
+                  <span className="text-xs text-gray-400">
+                    {new Date(s.created_at).toLocaleString()}
+                  </span>
+                  <button
+                    disabled={restoreMut.isPending}
+                    onClick={() => restoreMut.mutate(s.snapshot_id)}
+                    className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:underline disabled:opacity-50"
+                  >
+                    <RotateCcw className="h-3 w-3" /> Restore
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className="border-t border-gray-100 pt-4">
+            {!allAccepted && (
+              <p className="mb-2 text-xs text-amber-600">
+                Accept every topic&apos;s content before publishing.
+              </p>
+            )}
+            <div className="flex items-center gap-2">
+              <button
+                disabled={!allAccepted || publishMut.isPending}
+                onClick={() => publishMut.mutate("private")}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+              >
+                Publish (private)
+              </button>
+              <button
+                disabled={!allAccepted || publishMut.isPending}
+                onClick={() => publishMut.mutate("catalog")}
+                className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+              >
+                Publish to school catalog
+              </button>
+            </div>
+            {project.status === "published" && (
+              <p className="mt-2 text-sm text-emerald-600">
+                Published ({project.visibility}). Curriculum: {project.curriculum_id}
+              </p>
+            )}
+          </div>
+        </Section>
+      )}
+
+      {selectedTopic && (
+        <TopicReviewPanel
+          projectId={projectId}
+          topic={selectedTopic}
+          onClose={() => setSelectedTopic(null)}
+          onChanged={() => invalidate("topics")}
+        />
+      )}
+    </div>
+  );
+}
+
+function Section({
+  title,
+  icon,
+  children,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mb-6 rounded-xl border border-gray-200 bg-white p-5">
+      <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold tracking-wide text-gray-500 uppercase">
+        {icon} {title}
+      </h2>
+      {children}
+    </section>
+  );
+}

--- a/web/app/(admin)/admin/authoring/[projectId]/page.tsx
+++ b/web/app/(admin)/admin/authoring/[projectId]/page.tsx
@@ -7,6 +7,7 @@ import {
   ArrowLeft,
   Boxes,
   Camera,
+  Check,
   RotateCcw,
   Sparkles,
   Wand2,
@@ -17,6 +18,7 @@ import { StatusBadge } from "@/components/authoring/StatusBadge";
 import { StructuredTocEditor } from "@/components/authoring/StructuredTocEditor";
 import { TopicReviewPanel } from "@/components/authoring/TopicReviewPanel";
 import {
+  acceptTopic,
   analyzeProject,
   createSnapshot,
   flowRecheck,
@@ -105,6 +107,19 @@ export default function AuthoringWorkspacePage({
     mutationFn: (v: "private" | "catalog") => publishProject(projectId, v),
     onSuccess: invalidateAll,
   });
+  // Accept every (still-pending) content type for one or more topics.
+  const acceptMut = useMutation({
+    mutationFn: async (items: TopicListItem[]) => {
+      for (const t of items) {
+        for (const c of t.contents) {
+          if (c.review_status !== "accepted") {
+            await acceptTopic(projectId, t.unit_id, c.content_type, c.lang);
+          }
+        }
+      }
+    },
+    onSuccess: () => invalidate("topics"),
+  });
 
   if (isLoading || !project) {
     return (
@@ -115,6 +130,10 @@ export default function AuthoringWorkspacePage({
   }
 
   const topics = topicData?.topics ?? [];
+  const hasContent = topics.some((t) => t.content_count > 0);
+  const pendingTopics = topics.filter(
+    (t) => t.content_count > 0 && t.accepted_count < t.content_count,
+  );
   const allAccepted =
     topics.length > 0 &&
     topics.every((t) => t.content_count > 0 && t.accepted_count === t.content_count);
@@ -253,7 +272,7 @@ export default function AuthoringWorkspacePage({
                     <th className="px-3 py-2 text-left font-medium">Topic</th>
                     <th className="px-3 py-2 text-left font-medium">Content</th>
                     <th className="px-3 py-2 text-left font-medium">Accepted</th>
-                    <th className="w-20" />
+                    <th className="w-32" />
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-100">
@@ -278,12 +297,27 @@ export default function AuthoringWorkspacePage({
                       </td>
                       <td className="px-3 py-2 text-right">
                         {t.content_count > 0 && (
-                          <button
-                            onClick={() => setSelectedTopic(t)}
-                            className="text-xs font-medium text-indigo-600 hover:underline"
-                          >
-                            Review
-                          </button>
+                          <div className="flex items-center justify-end gap-3">
+                            <button
+                              onClick={() => setSelectedTopic(t)}
+                              className="text-xs font-medium text-indigo-600 hover:underline"
+                            >
+                              Review
+                            </button>
+                            {t.accepted_count === t.content_count ? (
+                              <span className="inline-flex items-center gap-1 text-xs font-medium text-emerald-600">
+                                <Check className="h-3.5 w-3.5" /> Accepted
+                              </span>
+                            ) : (
+                              <button
+                                disabled={acceptMut.isPending}
+                                onClick={() => acceptMut.mutate([t])}
+                                className="text-xs font-medium text-emerald-700 hover:underline disabled:opacity-50"
+                              >
+                                Accept
+                              </button>
+                            )}
+                          </div>
                         )}
                       </td>
                     </tr>
@@ -335,9 +369,23 @@ export default function AuthoringWorkspacePage({
 
           <div className="border-t border-gray-100 pt-4">
             {!allAccepted && (
-              <p className="mb-2 text-xs text-amber-600">
-                Accept every topic&apos;s content before publishing.
-              </p>
+              <div className="mb-3 flex items-center gap-3">
+                <p className="text-xs text-amber-600">
+                  {!hasContent
+                    ? "Generate content first, then accept every topic before publishing."
+                    : `Accept every topic's content before publishing — ${pendingTopics.length} topic(s) still pending.`}
+                </p>
+                {pendingTopics.length > 0 && (
+                  <button
+                    disabled={acceptMut.isPending}
+                    onClick={() => acceptMut.mutate(pendingTopics)}
+                    className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+                  >
+                    <Check className="h-3.5 w-3.5" />
+                    {acceptMut.isPending ? "Accepting…" : "Accept all topics"}
+                  </button>
+                )}
+              </div>
             )}
             <div className="flex items-center gap-2">
               <button

--- a/web/app/(admin)/admin/authoring/page.tsx
+++ b/web/app/(admin)/admin/authoring/page.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Plus, Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { StatusBadge } from "@/components/authoring/StatusBadge";
+import {
+  listProjects,
+  createProject,
+  type CreateProjectInput,
+} from "@/lib/api/authoring";
+
+const LANGS = ["en", "fr", "es"] as const;
+
+export default function AuthoringListPage() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [showCreate, setShowCreate] = useState(false);
+
+  const { data: projects, isLoading } = useQuery({
+    queryKey: ["admin", "authoring", "projects"],
+    queryFn: listProjects,
+    staleTime: 15_000,
+  });
+
+  return (
+    <div className="mx-auto max-w-6xl p-8">
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-bold text-gray-900">
+            <Sparkles className="h-6 w-6 text-indigo-600" />
+            Curriculum Authoring Studio
+          </h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Paste a table of contents, structure and review the flow, generate content,
+            and publish to the platform catalog. Super-admin only.
+          </p>
+        </div>
+        <button
+          onClick={() => setShowCreate(true)}
+          className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          <Plus className="h-4 w-4" /> New project
+        </button>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-14 animate-pulse rounded-xl bg-gray-100" />
+          ))}
+        </div>
+      ) : !projects || projects.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-gray-300 bg-white p-12 text-center">
+          <p className="text-sm text-gray-500">No authoring projects yet.</p>
+          <button
+            onClick={() => setShowCreate(true)}
+            className="mt-3 text-sm font-medium text-indigo-600 hover:underline"
+          >
+            Create your first project
+          </button>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+          <table className="w-full text-sm">
+            <thead className="border-b border-gray-200 bg-gray-50">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">Title</th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">Grade</th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Languages
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">Status</th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Visibility
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">Updated</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {projects.map((p) => (
+                <tr
+                  key={p.project_id}
+                  className="cursor-pointer hover:bg-gray-50"
+                  onClick={() => router.push(`/admin/authoring/${p.project_id}`)}
+                >
+                  <td className="px-4 py-3 font-medium text-gray-900">
+                    <Link
+                      href={`/admin/authoring/${p.project_id}`}
+                      className="hover:text-indigo-600"
+                    >
+                      {p.title}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-gray-600">{p.grade ?? "—"}</td>
+                  <td className="px-4 py-3 text-gray-600">{p.languages.join(", ")}</td>
+                  <td className="px-4 py-3">
+                    <StatusBadge status={p.status} />
+                  </td>
+                  <td className="px-4 py-3 text-gray-600">{p.visibility}</td>
+                  <td className="px-4 py-3 text-gray-500">
+                    {new Date(p.updated_at).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {showCreate && (
+        <CreateProjectModal
+          onClose={() => setShowCreate(false)}
+          onCreated={(id) => {
+            void queryClient.invalidateQueries({
+              queryKey: ["admin", "authoring", "projects"],
+            });
+            router.push(`/admin/authoring/${id}`);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function CreateProjectModal({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void;
+  onCreated: (id: string) => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [grade, setGrade] = useState<string>("");
+  const [languages, setLanguages] = useState<string[]>(["en"]);
+  const [rawToc, setRawToc] = useState("");
+
+  const createMut = useMutation({
+    mutationFn: (input: CreateProjectInput) => createProject(input),
+    onSuccess: (res) => onCreated(res.project_id),
+  });
+
+  const canSubmit =
+    title.trim().length > 0 && rawToc.trim().length > 0 && languages.length > 0;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-2xl rounded-xl bg-white p-6 shadow-xl">
+        <h2 className="mb-4 text-lg font-bold text-gray-900">New authoring project</h2>
+
+        <label className="mb-1 block text-sm font-medium text-gray-700">Title</label>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="e.g. Grade 9 Physics"
+          className="mb-4 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+        />
+
+        <div className="mb-4 flex gap-4">
+          <div className="w-28">
+            <label className="mb-1 block text-sm font-medium text-gray-700">Grade</label>
+            <input
+              type="number"
+              min={1}
+              max={12}
+              value={grade}
+              onChange={(e) => setGrade(e.target.value)}
+              placeholder="9"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700">
+              Languages
+            </label>
+            <div className="flex gap-2 pt-1.5">
+              {LANGS.map((l) => (
+                <button
+                  key={l}
+                  type="button"
+                  onClick={() =>
+                    setLanguages((prev) =>
+                      prev.includes(l) ? prev.filter((x) => x !== l) : [...prev, l],
+                    )
+                  }
+                  className={cn(
+                    "rounded-full px-3 py-1 text-sm font-medium",
+                    languages.includes(l)
+                      ? "bg-indigo-600 text-white"
+                      : "bg-gray-100 text-gray-600 hover:bg-gray-200",
+                  )}
+                >
+                  {l}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <label className="mb-1 block text-sm font-medium text-gray-700">
+          Table of contents (paste free text)
+        </label>
+        <textarea
+          value={rawToc}
+          onChange={(e) => setRawToc(e.target.value)}
+          rows={10}
+          placeholder={
+            "Chapter 1: Motion\n  1.1 Speed and velocity\n  1.2 Acceleration\nChapter 2: Forces\n  2.1 Newton's Laws"
+          }
+          className="mb-2 w-full rounded-lg border border-gray-300 px-3 py-2 font-mono text-sm focus:border-indigo-500 focus:outline-none"
+        />
+
+        {createMut.isError && (
+          <p className="mb-2 text-sm text-red-600">
+            Could not create the project. Check the fields and try again.
+          </p>
+        )}
+
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+          >
+            Cancel
+          </button>
+          <button
+            disabled={!canSubmit || createMut.isPending}
+            onClick={() =>
+              createMut.mutate({
+                title: title.trim(),
+                grade: grade ? Number(grade) : null,
+                languages,
+                raw_toc: rawToc,
+              })
+            }
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {createMut.isPending ? "Creating…" : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/components/authoring/StatusBadge.tsx
+++ b/web/components/authoring/StatusBadge.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { AuthoringStatus } from "@/lib/api/authoring";
+
+const STATUS_STYLES: Record<string, string> = {
+  draft: "bg-gray-100 text-gray-600",
+  analyzing: "bg-amber-100 text-amber-700",
+  analyzed: "bg-sky-100 text-sky-700",
+  structured: "bg-indigo-100 text-indigo-700",
+  generating: "bg-amber-100 text-amber-700",
+  generated: "bg-violet-100 text-violet-700",
+  published: "bg-emerald-100 text-emerald-700",
+};
+
+export function StatusBadge({
+  status,
+  className,
+}: {
+  status: AuthoringStatus | string | null | undefined;
+  className?: string;
+}) {
+  const s = status ?? "draft";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+        STATUS_STYLES[s] ?? "bg-gray-100 text-gray-600",
+        className,
+      )}
+    >
+      {s}
+    </span>
+  );
+}

--- a/web/components/authoring/StructuredTocEditor.tsx
+++ b/web/components/authoring/StructuredTocEditor.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, Trash2, Save } from "lucide-react";
+import type { StructuredTOC } from "@/lib/api/authoring";
+
+/**
+ * Editable subjects → units table for the Authoring Studio (requirement c).
+ * Each unit row has an editable title, subtopics (comma-separated), and
+ * prerequisites (comma-separated). Subjects/units can be added or removed.
+ */
+export function StructuredTocEditor({
+  value,
+  saving,
+  onSave,
+}: {
+  value: StructuredTOC;
+  saving: boolean;
+  onSave: (toc: StructuredTOC) => void;
+}) {
+  const [toc, setToc] = useState<StructuredTOC>(() => structuredClone(value));
+  const [dirty, setDirty] = useState(false);
+
+  function update(next: StructuredTOC) {
+    setToc(next);
+    setDirty(true);
+  }
+
+  function setUnit(
+    si: number,
+    ui: number,
+    patch: Partial<{ title: string; subtopics: string[]; prerequisites: string[] }>,
+  ) {
+    const next = structuredClone(toc);
+    next.subjects[si].units[ui] = { ...next.subjects[si].units[ui], ...patch };
+    update(next);
+  }
+
+  function addUnit(si: number) {
+    const next = structuredClone(toc);
+    next.subjects[si].units.push({
+      title: "New topic",
+      subtopics: [],
+      prerequisites: [],
+    });
+    update(next);
+  }
+  function removeUnit(si: number, ui: number) {
+    const next = structuredClone(toc);
+    next.subjects[si].units.splice(ui, 1);
+    update(next);
+  }
+  function addSubject() {
+    const next = structuredClone(toc);
+    next.subjects.push({
+      subject_label: "New subject",
+      units: [{ title: "New topic", subtopics: [], prerequisites: [] }],
+    });
+    update(next);
+  }
+  function removeSubject(si: number) {
+    const next = structuredClone(toc);
+    next.subjects.splice(si, 1);
+    update(next);
+  }
+
+  return (
+    <div className="space-y-5">
+      {toc.subjects.map((subject, si) => (
+        <div key={si} className="rounded-xl border border-gray-200 bg-white">
+          <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-2">
+            <input
+              value={subject.subject_label}
+              onChange={(e) => {
+                const next = structuredClone(toc);
+                next.subjects[si].subject_label = e.target.value;
+                update(next);
+              }}
+              className="flex-1 rounded-md border border-transparent px-2 py-1 text-sm font-semibold text-gray-900 hover:border-gray-200 focus:border-indigo-500 focus:outline-none"
+            />
+            <button
+              onClick={() => removeSubject(si)}
+              title="Remove subject"
+              className="rounded-md p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600"
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          </div>
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-xs text-gray-500">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium">Topic</th>
+                <th className="px-3 py-2 text-left font-medium">
+                  Subtopics (comma-separated)
+                </th>
+                <th className="px-3 py-2 text-left font-medium">
+                  Prerequisites (comma-separated)
+                </th>
+                <th className="w-10" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {subject.units.map((unit, ui) => (
+                <tr key={ui}>
+                  <td className="px-3 py-2 align-top">
+                    <input
+                      value={unit.title}
+                      onChange={(e) => setUnit(si, ui, { title: e.target.value })}
+                      className="w-full rounded-md border border-gray-200 px-2 py-1 focus:border-indigo-500 focus:outline-none"
+                    />
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    <input
+                      value={unit.subtopics.join(", ")}
+                      onChange={(e) =>
+                        setUnit(si, ui, {
+                          subtopics: e.target.value
+                            .split(",")
+                            .map((s) => s.trim())
+                            .filter(Boolean),
+                        })
+                      }
+                      className="w-full rounded-md border border-gray-200 px-2 py-1 focus:border-indigo-500 focus:outline-none"
+                    />
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    <input
+                      value={unit.prerequisites.join(", ")}
+                      onChange={(e) =>
+                        setUnit(si, ui, {
+                          prerequisites: e.target.value
+                            .split(",")
+                            .map((s) => s.trim())
+                            .filter(Boolean),
+                        })
+                      }
+                      className="w-full rounded-md border border-gray-200 px-2 py-1 focus:border-indigo-500 focus:outline-none"
+                    />
+                  </td>
+                  <td className="px-2 py-2 align-top">
+                    <button
+                      onClick={() => removeUnit(si, ui)}
+                      title="Remove topic"
+                      className="rounded-md p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="px-3 py-2">
+            <button
+              onClick={() => addUnit(si)}
+              className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:underline"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add topic
+            </button>
+          </div>
+        </div>
+      ))}
+
+      <div className="flex items-center justify-between">
+        <button
+          onClick={addSubject}
+          className="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:underline"
+        >
+          <Plus className="h-4 w-4" /> Add subject
+        </button>
+        <button
+          disabled={!dirty || saving}
+          onClick={() => onSave(toc)}
+          className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+        >
+          <Save className="h-4 w-4" /> {saving ? "Saving…" : "Save structure"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/components/authoring/TopicReviewPanel.tsx
+++ b/web/components/authoring/TopicReviewPanel.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Check, History, RefreshCw, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { SBMarkdown } from "@/components/content/Markdown";
+import {
+  acceptTopic,
+  getTopic,
+  getTopicHistory,
+  regenerateTopic,
+  type ContentType,
+  type TopicListItem,
+} from "@/lib/api/authoring";
+
+export function TopicReviewPanel({
+  projectId,
+  topic,
+  onClose,
+  onChanged,
+}: {
+  projectId: string;
+  topic: TopicListItem;
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const types = topic.contents.map((c) => c.content_type);
+  const [active, setActive] = useState<ContentType>(types[0] ?? "lesson");
+  const [showHistory, setShowHistory] = useState(false);
+  const [reason, setReason] = useState("");
+
+  const key = ["admin", "authoring", projectId, "topic", topic.unit_id, active];
+  const { data: version, isLoading } = useQuery({
+    queryKey: key,
+    queryFn: () => getTopic(projectId, topic.unit_id, active),
+  });
+  const { data: history } = useQuery({
+    queryKey: [...key, "history"],
+    queryFn: () => getTopicHistory(projectId, topic.unit_id, active),
+    enabled: showHistory,
+  });
+
+  const refetch = () => {
+    void queryClient.invalidateQueries({ queryKey: key });
+    onChanged();
+  };
+
+  const acceptMut = useMutation({
+    mutationFn: () => acceptTopic(projectId, topic.unit_id, active),
+    onSuccess: refetch,
+  });
+  const regenMut = useMutation({
+    mutationFn: (r: string) => regenerateTopic(projectId, topic.unit_id, active, r),
+    onSuccess: () => {
+      setReason("");
+      refetch();
+    },
+  });
+
+  return (
+    <div className="fixed inset-y-0 right-0 z-50 flex w-full max-w-3xl flex-col border-l border-gray-200 bg-white shadow-2xl">
+      <div className="flex items-center justify-between border-b border-gray-200 px-5 py-3">
+        <div>
+          <h3 className="font-semibold text-gray-900">{topic.title}</h3>
+          <p className="text-xs text-gray-500">
+            {topic.subject} · {topic.unit_id}
+          </p>
+        </div>
+        <button
+          onClick={onClose}
+          className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      {/* content-type tabs */}
+      <div className="flex flex-wrap gap-1.5 border-b border-gray-100 px-5 py-2">
+        {types.map((t) => {
+          const c = topic.contents.find((x) => x.content_type === t)!;
+          return (
+            <button
+              key={t}
+              onClick={() => {
+                setActive(t);
+                setShowHistory(false);
+              }}
+              className={cn(
+                "rounded-full px-3 py-1 text-xs font-medium",
+                active === t
+                  ? "bg-indigo-600 text-white"
+                  : "bg-gray-100 text-gray-600 hover:bg-gray-200",
+              )}
+            >
+              {t}
+              {c.review_status === "accepted" && (
+                <Check className="ml-1 inline h-3 w-3" />
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-5 py-4">
+        {isLoading || !version ? (
+          <div className="h-40 animate-pulse rounded-xl bg-gray-100" />
+        ) : (
+          <>
+            <div className="mb-3 flex items-center justify-between text-xs text-gray-500">
+              <span>
+                version {version.version_number} ·{" "}
+                <span
+                  className={
+                    version.review_status === "accepted"
+                      ? "text-emerald-600"
+                      : "text-amber-600"
+                  }
+                >
+                  {version.review_status}
+                </span>
+              </span>
+              <button
+                onClick={() => setShowHistory((v) => !v)}
+                className="inline-flex items-center gap-1 hover:text-gray-700"
+              >
+                <History className="h-3.5 w-3.5" /> {showHistory ? "Hide" : "History"}
+              </button>
+            </div>
+
+            {showHistory && history && (
+              <ul className="mb-4 space-y-1 rounded-lg bg-gray-50 p-3 text-xs text-gray-600">
+                {history.map((h) => (
+                  <li key={h.topic_version_id} className="flex items-center gap-2">
+                    <span className="font-mono">v{h.version_number}</span>
+                    {h.is_active && <span className="text-indigo-600">active</span>}
+                    {h.regen_reason && <span className="italic">“{h.regen_reason}”</span>}
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <ContentBody contentType={active} body={version.body} />
+          </>
+        )}
+      </div>
+
+      {/* actions */}
+      <div className="border-t border-gray-200 px-5 py-3">
+        <div className="mb-2 flex items-center gap-2">
+          <input
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Reason for regeneration (e.g. too terse — add a diagram)"
+            className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+          />
+          <button
+            disabled={reason.trim().length === 0 || regenMut.isPending}
+            onClick={() => regenMut.mutate(reason.trim())}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-amber-500 px-3 py-2 text-sm font-medium text-white hover:bg-amber-600 disabled:opacity-50"
+          >
+            <RefreshCw className={cn("h-4 w-4", regenMut.isPending && "animate-spin")} />{" "}
+            Regenerate
+          </button>
+          <button
+            disabled={acceptMut.isPending || version?.review_status === "accepted"}
+            onClick={() => acceptMut.mutate()}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+          >
+            <Check className="h-4 w-4" /> Accept
+          </button>
+        </div>
+        {regenMut.data && regenMut.data.flow_recheck.length > 0 && (
+          <p className="text-xs text-amber-700">
+            Flow recheck flagged {regenMut.data.flow_recheck.length} issue(s) — review
+            topic ordering.
+          </p>
+        )}
+        {regenMut.isError && <p className="text-xs text-red-600">Regeneration failed.</p>}
+      </div>
+    </div>
+  );
+}
+
+// ── Per-content-type renderers ───────────────────────────────────────────────
+
+function ContentBody({
+  contentType,
+  body,
+}: {
+  contentType: ContentType;
+  body: Record<string, unknown> | null;
+}) {
+  if (!body) return <p className="text-sm text-gray-400">No content.</p>;
+
+  if (contentType === "lesson") {
+    const sections = (body.sections as { heading: string; body: string }[]) ?? [];
+    const keyPoints = (body.key_points as string[]) ?? [];
+    return (
+      <div className="space-y-4">
+        {typeof body.synopsis === "string" && (
+          <p className="text-sm text-gray-500 italic">{body.synopsis}</p>
+        )}
+        {sections.map((s, i) => (
+          <section key={i}>
+            <h4 className="mb-1 font-semibold text-gray-900">{s.heading}</h4>
+            <SBMarkdown className="text-sm">{s.body}</SBMarkdown>
+          </section>
+        ))}
+        {keyPoints.length > 0 && (
+          <div>
+            <h4 className="mb-1 font-semibold text-gray-900">Key points</h4>
+            <ul className="list-disc pl-5 text-sm text-gray-700">
+              {keyPoints.map((k, i) => (
+                <li key={i}>{k}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (contentType === "tutorial") {
+    const sections =
+      (body.sections as { title: string; content: string; examples?: string[] }[]) ?? [];
+    return (
+      <div className="space-y-4">
+        {typeof body.title === "string" && (
+          <h4 className="font-semibold text-gray-900">{body.title}</h4>
+        )}
+        {sections.map((s, i) => (
+          <section key={i}>
+            <h5 className="mb-1 font-medium text-gray-800">{s.title}</h5>
+            <SBMarkdown className="text-sm">{s.content}</SBMarkdown>
+            {(s.examples ?? []).map((ex, j) => (
+              <SBMarkdown key={j} className="mt-1 text-sm">
+                {ex}
+              </SBMarkdown>
+            ))}
+          </section>
+        ))}
+      </div>
+    );
+  }
+
+  if (contentType.startsWith("quiz_set_")) {
+    const questions =
+      (body.questions as {
+        question_text: string;
+        options: { option_id: string; text: string }[];
+        correct_option: string;
+        explanation: string;
+        difficulty: string;
+      }[]) ?? [];
+    return (
+      <ol className="space-y-4 text-sm">
+        {questions.map((q, i) => (
+          <li key={i}>
+            <p className="font-medium text-gray-900">
+              {i + 1}. {q.question_text}{" "}
+              <span className="text-xs text-gray-400">({q.difficulty})</span>
+            </p>
+            <ul className="mt-1 space-y-0.5 pl-4">
+              {q.options.map((o) => (
+                <li
+                  key={o.option_id}
+                  className={
+                    o.option_id === q.correct_option
+                      ? "font-medium text-emerald-700"
+                      : "text-gray-600"
+                  }
+                >
+                  {o.option_id}. {o.text}
+                  {o.option_id === q.correct_option && " ✓"}
+                </li>
+              ))}
+            </ul>
+            <p className="mt-1 text-xs text-gray-500 italic">{q.explanation}</p>
+          </li>
+        ))}
+      </ol>
+    );
+  }
+
+  // experiment / fallback
+  return (
+    <pre className="overflow-x-auto rounded-lg bg-gray-50 p-3 text-xs text-gray-700">
+      {JSON.stringify(body, null, 2)}
+    </pre>
+  );
+}

--- a/web/components/authoring/TopicReviewPanel.tsx
+++ b/web/components/authoring/TopicReviewPanel.tsx
@@ -88,10 +88,12 @@ export function TopicReviewPanel({
                 setShowHistory(false);
               }}
               className={cn(
-                "rounded-full px-3 py-1 text-xs font-medium",
+                "rounded-full px-3 py-1 text-xs font-semibold ring-1",
                 active === t
-                  ? "bg-indigo-600 text-white"
-                  : "bg-gray-100 text-gray-600 hover:bg-gray-200",
+                  ? "bg-indigo-600 text-white ring-indigo-600"
+                  : c.review_status === "accepted"
+                    ? "bg-emerald-100 text-emerald-800 ring-emerald-300 hover:bg-emerald-200"
+                    : "bg-gray-200 text-gray-700 ring-gray-300 hover:bg-gray-300",
               )}
             >
               {t}
@@ -109,14 +111,15 @@ export function TopicReviewPanel({
         ) : (
           <>
             <div className="mb-3 flex items-center justify-between text-xs text-gray-500">
-              <span>
-                version {version.version_number} ·{" "}
+              <span className="flex items-center gap-2">
+                version {version.version_number}
                 <span
-                  className={
+                  className={cn(
+                    "rounded-full px-2 py-0.5 text-xs font-semibold",
                     version.review_status === "accepted"
-                      ? "text-emerald-600"
-                      : "text-amber-600"
-                  }
+                      ? "bg-emerald-600 text-white"
+                      : "bg-amber-500 text-white",
+                  )}
                 >
                   {version.review_status}
                 </span>
@@ -258,26 +261,39 @@ function ContentBody({
       <ol className="space-y-4 text-sm">
         {questions.map((q, i) => (
           <li key={i}>
-            <p className="font-medium text-gray-900">
-              {i + 1}. {q.question_text}{" "}
-              <span className="text-xs text-gray-400">({q.difficulty})</span>
-            </p>
+            <div className="flex items-start gap-1.5 font-medium text-gray-900">
+              <span>{i + 1}.</span>
+              {/* Render through SBMarkdown so embedded GFM tables / KaTeX / code
+                  render instead of showing as raw freeform text. */}
+              <div className="min-w-0 flex-1">
+                <SBMarkdown className="text-sm">{q.question_text}</SBMarkdown>
+              </div>
+              <span className="shrink-0 text-xs text-gray-400">({q.difficulty})</span>
+            </div>
             <ul className="mt-1 space-y-0.5 pl-4">
               {q.options.map((o) => (
                 <li
                   key={o.option_id}
-                  className={
+                  className={cn(
+                    "flex gap-1.5",
                     o.option_id === q.correct_option
                       ? "font-medium text-emerald-700"
-                      : "text-gray-600"
-                  }
+                      : "text-gray-600",
+                  )}
                 >
-                  {o.option_id}. {o.text}
-                  {o.option_id === q.correct_option && " ✓"}
+                  <span className="shrink-0">{o.option_id}.</span>
+                  <div className="min-w-0 flex-1">
+                    <SBMarkdown className="text-sm">{o.text}</SBMarkdown>
+                  </div>
+                  {o.option_id === q.correct_option && (
+                    <span className="shrink-0">✓</span>
+                  )}
                 </li>
               ))}
             </ul>
-            <p className="mt-1 text-xs text-gray-500 italic">{q.explanation}</p>
+            <div className="mt-1 text-xs text-gray-500 italic">
+              <SBMarkdown className="text-xs">{q.explanation}</SBMarkdown>
+            </div>
           </li>
         ))}
       </ol>

--- a/web/components/layout/AdminNav.tsx
+++ b/web/components/layout/AdminNav.tsx
@@ -63,6 +63,12 @@ const NAV_ITEMS: NavItem[] = [
     minRole: "product_admin" as AdminRole,
   },
   {
+    label: "Authoring Studio",
+    href: "/admin/authoring",
+    icon: <Sparkles className="h-4 w-4" />,
+    minRole: "super_admin" as AdminRole,
+  },
+  {
     label: "Content Review",
     href: "/admin/content-review",
     icon: <ClipboardList className="h-4 w-4" />,

--- a/web/lib/api/authoring.ts
+++ b/web/lib/api/authoring.ts
@@ -1,0 +1,261 @@
+/**
+ * web/lib/api/authoring.ts
+ *
+ * Admin API client for the Curriculum Authoring Studio (super-admin only).
+ * Mirrors the backend endpoints under /api/v1/admin/authoring/. All calls go
+ * through the admin axios instance (sb_admin_token injected).
+ */
+import adminApi from "./admin-client";
+
+// ── Structured TOC tree ────────────────────────────────────────────────────
+export interface TopicNode {
+  title: string;
+  subtopics: string[];
+  prerequisites: string[];
+}
+export interface SubjectNode {
+  subject_label: string;
+  units: TopicNode[];
+}
+export interface StructuredTOC {
+  subjects: SubjectNode[];
+}
+
+export interface FlowWarning {
+  kind: string;
+  unit?: string;
+  subject?: string | null;
+  detail?: string;
+}
+export interface FlowReport {
+  warnings: FlowWarning[];
+  summary: string;
+}
+
+// ── Project ────────────────────────────────────────────────────────────────
+export type AuthoringStatus =
+  | "draft"
+  | "analyzing"
+  | "analyzed"
+  | "structured"
+  | "generating"
+  | "generated"
+  | "published";
+
+export interface ProjectSummary {
+  project_id: string;
+  title: string;
+  grade: number | null;
+  languages: string[];
+  status: AuthoringStatus;
+  curriculum_id: string | null;
+  visibility: "private" | "catalog";
+  created_at: string;
+  updated_at: string;
+}
+export interface ProjectDetail extends ProjectSummary {
+  raw_toc: string | null;
+  structured_toc: StructuredTOC | null;
+  flow_report: FlowReport | null;
+  analyze_error: string | null;
+}
+
+export interface CreateProjectInput {
+  title: string;
+  grade: number | null;
+  languages: string[];
+  raw_toc: string;
+}
+
+// ── Topics / content ─────────────────────────────────────────────────────────
+export type ContentType =
+  | "lesson"
+  | "tutorial"
+  | "quiz_set_1"
+  | "quiz_set_2"
+  | "quiz_set_3"
+  | "experiment";
+
+export interface TopicContentStatus {
+  content_type: ContentType;
+  lang: string;
+  version_number: number;
+  review_status: "pending" | "accepted";
+}
+export interface TopicListItem {
+  unit_id: string;
+  title: string;
+  subject: string;
+  contents: TopicContentStatus[];
+  content_count: number;
+  accepted_count: number;
+}
+export interface TopicListResponse {
+  curriculum_id: string | null;
+  status: AuthoringStatus | null;
+  topics: TopicListItem[];
+  total: number;
+}
+
+export interface TopicVersion {
+  topic_version_id: string;
+  unit_id: string;
+  lang: string;
+  content_type: ContentType;
+  version_number: number;
+  body: Record<string, unknown> | null;
+  regen_reason: string | null;
+  flow_recheck: FlowWarning[] | null;
+  review_status: "pending" | "accepted";
+  created_at: string;
+  is_active: boolean;
+}
+
+// ── Snapshots ────────────────────────────────────────────────────────────────
+export interface SnapshotItem {
+  snapshot_id: string;
+  snapshot_number: number;
+  label: string | null;
+  created_at: string;
+}
+
+// ── Endpoints ──────────────────────────────────────────────────────────────
+const BASE = "/admin/authoring/projects";
+
+export async function listProjects(): Promise<ProjectSummary[]> {
+  const res = await adminApi.get<{ projects: ProjectSummary[]; total: number }>(BASE);
+  return res.data.projects;
+}
+
+export async function createProject(
+  input: CreateProjectInput,
+): Promise<{ project_id: string }> {
+  const res = await adminApi.post<{ project_id: string; status: string }>(BASE, input);
+  return res.data;
+}
+
+export async function getProject(id: string): Promise<ProjectDetail> {
+  const res = await adminApi.get<ProjectDetail>(`${BASE}/${id}`);
+  return res.data;
+}
+
+export async function analyzeProject(id: string): Promise<void> {
+  await adminApi.post(`${BASE}/${id}/analyze`);
+}
+
+export async function saveStructure(
+  id: string,
+  structured_toc: StructuredTOC,
+): Promise<ProjectDetail> {
+  const res = await adminApi.put<ProjectDetail>(`${BASE}/${id}/structure`, {
+    structured_toc,
+  });
+  return res.data;
+}
+
+export async function materialize(
+  id: string,
+): Promise<{ curriculum_id: string; units_created: number }> {
+  const res = await adminApi.post<{ curriculum_id: string; units_created: number }>(
+    `${BASE}/${id}/materialize`,
+  );
+  return res.data;
+}
+
+export async function generate(id: string, langs = "en", force = false): Promise<void> {
+  await adminApi.post(`${BASE}/${id}/generate`, { langs, force });
+}
+
+export async function listTopics(id: string): Promise<TopicListResponse> {
+  const res = await adminApi.get<TopicListResponse>(`${BASE}/${id}/topics`);
+  return res.data;
+}
+
+export async function getTopic(
+  id: string,
+  unitId: string,
+  contentType: ContentType,
+  lang = "en",
+): Promise<TopicVersion> {
+  const res = await adminApi.get<TopicVersion>(`${BASE}/${id}/topics/${unitId}`, {
+    params: { content_type: contentType, lang },
+  });
+  return res.data;
+}
+
+export async function getTopicHistory(
+  id: string,
+  unitId: string,
+  contentType: ContentType,
+  lang = "en",
+): Promise<TopicVersion[]> {
+  const res = await adminApi.get<{ versions: TopicVersion[] }>(
+    `${BASE}/${id}/topics/${unitId}`,
+    {
+      params: { content_type: contentType, lang, history: 1 },
+    },
+  );
+  return res.data.versions;
+}
+
+export async function regenerateTopic(
+  id: string,
+  unitId: string,
+  contentType: ContentType,
+  reason: string,
+  lang = "en",
+): Promise<{ version_number: number; flow_recheck: FlowWarning[] }> {
+  const res = await adminApi.post<{
+    version_number: number;
+    flow_recheck: FlowWarning[];
+  }>(`${BASE}/${id}/topics/${unitId}/regenerate`, {
+    content_type: contentType,
+    reason,
+    lang,
+  });
+  return res.data;
+}
+
+export async function acceptTopic(
+  id: string,
+  unitId: string,
+  contentType: ContentType,
+  lang = "en",
+): Promise<void> {
+  await adminApi.post(`${BASE}/${id}/topics/${unitId}/accept`, {
+    content_type: contentType,
+    lang,
+  });
+}
+
+export async function listSnapshots(id: string): Promise<SnapshotItem[]> {
+  const res = await adminApi.get<{ snapshots: SnapshotItem[] }>(
+    `${BASE}/${id}/snapshots`,
+  );
+  return res.data.snapshots;
+}
+
+export async function createSnapshot(id: string, label?: string): Promise<SnapshotItem> {
+  const res = await adminApi.post<SnapshotItem>(`${BASE}/${id}/snapshots`, {
+    label: label ?? null,
+  });
+  return res.data;
+}
+
+export async function restoreSnapshot(id: string, snapshotId: string): Promise<void> {
+  await adminApi.post(`${BASE}/${id}/snapshots/${snapshotId}/restore`);
+}
+
+export async function flowRecheck(id: string): Promise<void> {
+  await adminApi.post(`${BASE}/${id}/flow-recheck`);
+}
+
+export async function publishProject(
+  id: string,
+  visibility: "private" | "catalog",
+): Promise<{ curriculum_id: string }> {
+  const res = await adminApi.post<{ curriculum_id: string }>(`${BASE}/${id}/publish`, {
+    visibility,
+  });
+  return res.data;
+}

--- a/web/lib/api/types.gen.ts
+++ b/web/lib/api/types.gen.ts
@@ -2209,6 +2209,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/authoring/projects/{project_id}/topics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Topics */
+        get: operations["list_topics_api_v1_admin_authoring_projects__project_id__topics_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/curricula/{curriculum_id}/usage": {
         parameters: {
             query?: never;
@@ -10069,10 +10086,47 @@ export interface components {
             student_id: string;
             student: components["schemas"]["StudentPublic"];
         };
+        /** TopicContentStatus */
+        TopicContentStatus: {
+            /** Content Type */
+            content_type: string;
+            /** Lang */
+            lang: string;
+            /** Version Number */
+            version_number: number;
+            /** Review Status */
+            review_status: string;
+        };
         /** TopicHistoryResponse */
         TopicHistoryResponse: {
             /** Versions */
             versions: components["schemas"]["TopicVersion"][];
+        };
+        /** TopicListItem */
+        TopicListItem: {
+            /** Unit Id */
+            unit_id: string;
+            /** Title */
+            title: string;
+            /** Subject */
+            subject: string;
+            /** Contents */
+            contents: components["schemas"]["TopicContentStatus"][];
+            /** Content Count */
+            content_count: number;
+            /** Accepted Count */
+            accepted_count: number;
+        };
+        /** TopicListResponse */
+        TopicListResponse: {
+            /** Curriculum Id */
+            curriculum_id?: string | null;
+            /** Status */
+            status?: string | null;
+            /** Topics */
+            topics: components["schemas"]["TopicListItem"][];
+            /** Total */
+            total: number;
         };
         /** TopicNode */
         TopicNode: {
@@ -14151,6 +14205,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["src__admin__authoring_schemas__PublishResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_topics_api_v1_admin_authoring_projects__project_id__topics_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopicListResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -5499,6 +5499,53 @@
         }
       }
     },
+    "/api/v1/admin/authoring/projects/{project_id}/topics": {
+      "get": {
+        "tags": [
+          "authoring"
+        ],
+        "summary": "List Topics",
+        "operationId": "list_topics_api_v1_admin_authoring_projects__project_id__topics_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopicListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/admin/curricula/{curriculum_id}/usage": {
       "get": {
         "summary": "Get Curriculum Usage",
@@ -26780,6 +26827,34 @@
         "title": "TokenExchangeResponse",
         "description": "Response for POST /auth/exchange"
       },
+      "TopicContentStatus": {
+        "properties": {
+          "content_type": {
+            "type": "string",
+            "title": "Content Type"
+          },
+          "lang": {
+            "type": "string",
+            "title": "Lang"
+          },
+          "version_number": {
+            "type": "integer",
+            "title": "Version Number"
+          },
+          "review_status": {
+            "type": "string",
+            "title": "Review Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "content_type",
+          "lang",
+          "version_number",
+          "review_status"
+        ],
+        "title": "TopicContentStatus"
+      },
       "TopicHistoryResponse": {
         "properties": {
           "versions": {
@@ -26795,6 +26870,90 @@
           "versions"
         ],
         "title": "TopicHistoryResponse"
+      },
+      "TopicListItem": {
+        "properties": {
+          "unit_id": {
+            "type": "string",
+            "title": "Unit Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "subject": {
+            "type": "string",
+            "title": "Subject"
+          },
+          "contents": {
+            "items": {
+              "$ref": "#/components/schemas/TopicContentStatus"
+            },
+            "type": "array",
+            "title": "Contents"
+          },
+          "content_count": {
+            "type": "integer",
+            "title": "Content Count"
+          },
+          "accepted_count": {
+            "type": "integer",
+            "title": "Accepted Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "unit_id",
+          "title",
+          "subject",
+          "contents",
+          "content_count",
+          "accepted_count"
+        ],
+        "title": "TopicListItem"
+      },
+      "TopicListResponse": {
+        "properties": {
+          "curriculum_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Curriculum Id"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "topics": {
+            "items": {
+              "$ref": "#/components/schemas/TopicListItem"
+            },
+            "type": "array",
+            "title": "Topics"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "topics",
+          "total"
+        ],
+        "title": "TopicListResponse"
       },
       "TopicNode": {
         "properties": {


### PR DESCRIPTION
## What

Adds the super-admin **web UI** for the Curriculum Authoring Studio (the backend shipped API-only in #383/#385). New nav item **Authoring Studio** (super_admin-gated).

## Screens

- **`/admin/authoring`** — project list + a create modal (title, grade, languages, free-text TOC paste).
- **`/admin/authoring/[projectId]`** — staged workspace driven by project status:
  1. **TOC + analyze** (polls while `analyzing`) + advisory **flow report** with re-run.
  2. **Structure & edit topics** — editable subjects→units table (titles / subtopics / prerequisites, add/remove subjects & topics) with save; then **materialize** → staged platform curriculum.
  3. **Generate & review** — generate all (polls while `generating`); per-topic table → **review panel** (content-type tabs, version history, **regenerate-with-reason**, **accept**). Lesson/tutorial render through `<SBMarkdown>` so **Mermaid diagrams render**.
  4. **Versions & publish** — snapshot / list / restore; **publish** (private | school catalog), gated until every topic is accepted.

## Backend

- `GET /admin/authoring/projects/{id}/topics` — lists materialised units with per-content-type status (the UI needs to enumerate topics; PR-B only exposed single-topic GET). Service + schema + 2 tests; OpenAPI + TS types regenerated.

## Verification

- Web: `typecheck` + `eslint --max-warnings=0` + `prettier --check` + **`npm run build`** all clean (both `/admin/authoring` routes compile).
- Backend: `ruff check/format src/` clean; new endpoint tests pass; migration unaffected.

## Notes

- Super-admin only throughout (`curriculum:author`); no other role sees the nav item or can call the API.
- The async analyze/generate steps require the `celery-pipeline` worker running and a real `ANTHROPIC_API_KEY` (operator-run; cost a few cents/calls).
- CI will be green except the standing pre-existing coverage gate is now satisfied (#387 ratchet merged); this PR adds frontend + one small endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)