### PR TITLE
fix(authoring): regenerate 'Regeneration Failed' — pipeline import + client timeout

### DIFF
--- a/backend/src/admin/authoring_generation.py
+++ b/backend/src/admin/authoring_generation.py
@@ -31,7 +31,11 @@ from datetime import UTC, datetime
 import asyncpg
 
 from src.admin.authoring_flow import check_topic_ordering
-from src.admin.authoring_service import _build_authoring_provider, _coerce_json
+from src.admin.authoring_service import (
+    _build_authoring_provider,
+    _coerce_json,
+    ensure_pipeline_path,
+)
 from src.utils.logger import get_logger
 
 log = get_logger("authoring")
@@ -114,6 +118,7 @@ def generate_one(
     Raises GenerationError on a provider error, unparseable JSON, or schema
     validation failure — the caller decides whether to skip or surface it.
     """
+    ensure_pipeline_path()  # API (sync regenerate) needs pipeline on sys.path
     prompt = _build_prompt(
         content_type, unit_id=unit_id, subject=subject, topic=topic, grade=grade, lang=lang
     )

--- a/backend/src/admin/authoring_service.py
+++ b/backend/src/admin/authoring_service.py
@@ -37,6 +37,26 @@ log = get_logger("authoring")
 # ── Provider factory (patched in tests) ───────────────────────────────────────
 
 
+def ensure_pipeline_path() -> None:
+    """Make the repo-root ``pipeline`` package importable from THIS process.
+
+    The Celery pipeline tasks insert this path themselves, but the synchronous
+    regenerate endpoint runs in the API process — which does not — so
+    ``pipeline.config`` / ``pipeline.prompts`` imports would fail with
+    ModuleNotFoundError. authoring_service.py lives at
+    ``<root>/backend/src/admin/`` so the repo root is four dirs up; ``pipeline``
+    is its sibling (``/pipeline`` in the container). Idempotent.
+    """
+    import os
+    import sys
+
+    root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    )
+    if root not in sys.path:
+        sys.path.insert(0, root)
+
+
 def _build_authoring_provider():
     """Build the default LLM provider for authoring analysis/generation.
 
@@ -44,6 +64,7 @@ def _build_authoring_provider():
     for a real Anthropic key. Imports are deferred: pipeline.config requires
     ANTHROPIC_API_KEY at import time, which we don't want at module load.
     """
+    ensure_pipeline_path()
     from pipeline.config import settings as pipeline_settings
     from pipeline.providers import get_provider
 

--- a/web/lib/api/authoring.ts
+++ b/web/lib/api/authoring.ts
@@ -208,11 +208,13 @@ export async function regenerateTopic(
   const res = await adminApi.post<{
     version_number: number;
     flow_recheck: FlowWarning[];
-  }>(`${BASE}/${id}/topics/${unitId}/regenerate`, {
-    content_type: contentType,
-    reason,
-    lang,
-  });
+  }>(
+    `${BASE}/${id}/topics/${unitId}/regenerate`,
+    { content_type: contentType, reason, lang },
+    // Regeneration runs the LLM synchronously (~10-30s); override the admin
+    // client's 15s default so the request doesn't time out mid-generation.
+    { timeout: 180_000 },
+  );
   return res.data;
 }
 


### PR DESCRIPTION
## Bug

In the Authoring Studio, **Regenerate** on a topic returned **"Regeneration Failed"**. Backend logs showed a **500** with:

```
File ".../authoring_service.py", line 47, in _build_authoring_provider
ModuleNotFoundError: No module named 'pipeline.config'
```

## Root cause

`regenerate` runs **synchronously in the API process**, unlike `analyze`/`generate` which run in the `celery-pipeline` worker. The Celery tasks insert the repo root onto `sys.path` so `import pipeline.*` works; the **API process never does**. So `_build_authoring_provider()` (and `generate_one()`'s `pipeline.prompts`/`schemas` imports) failed → 500 → generic "Regeneration Failed".

Second, latent issue: even with imports fixed, a real regen LLM call (~10–30s) exceeds the admin axios client's **15s** default timeout → client-side failure.

## Fix

- `ensure_pipeline_path()` (authoring_service) inserts the repo root (sibling of `backend`; `/pipeline`'s parent in the container) onto `sys.path`. Called in `_build_authoring_provider` and at the top of `generate_one`. Idempotent; Celery paths unaffected.
- `regenerateTopic` (web) overrides the timeout to **180s** for that call only.

## Verification

- `ensure_pipeline_path()` → `import pipeline.config/prompts/providers` succeeds in the API process.
- 7 regenerate/generate/list_topics tests pass; backend ruff + web typecheck/lint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)