### PR TITLE
feat(authoring): book export — authored curriculum → StudyBuddy Q Book JSON

### DIFF
--- a/backend/scripts/export_book.py
+++ b/backend/scripts/export_book.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+backend/scripts/export_book.py
+
+Export a *published* authored curriculum (Curriculum Authoring Studio) to a
+StudyBuddy Q ``Book`` JSON file. Phase 1 of the content migration documented in
+StudyBuddy_SelfLearner `docs/CONTENT_MIGRATION_CONTEXT_ENGINEERING.md`.
+
+The transform logic lives in ``src/admin/book_export.py`` (pure, unit-tested);
+this is the thin asyncpg shell that reads the authoring tables and writes the
+file.
+
+Usage (operator-run, from backend/ or inside the api container):
+    python scripts/export_book.py --project-id <uuid> --out book.json
+    # find the project id by title first:
+    python scripts/export_book.py --list
+
+Notes:
+- Reads the DB (authoring_projects + active topic versions + curriculum_units),
+  not the content store — the bodies are the same, and the DB also carries the
+  TOC + authoritative unit order in one place.
+- Sets app.current_school_id='bypass' before querying platform-owned curricula
+  (pitfall #28).
+- "Ready" gate: the project should be published (status='published'); a warning
+  is printed if it is not, but the export still runs against accepted versions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import asyncpg
+from dotenv import load_dotenv
+
+_here = Path(__file__).parent.parent
+load_dotenv(_here / ".env")
+sys.path.insert(0, str(_here))
+
+from src.admin.book_export import BookExportError, assemble_book  # noqa: E402
+
+DATABASE_URL = os.environ["DATABASE_URL"]
+
+
+def _as_dict(value) -> dict | None:
+    """asyncpg returns JSONB as str or dict depending on codec; normalise."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return json.loads(value)
+    return dict(value)
+
+
+async def _list_projects(conn: asyncpg.Connection) -> None:
+    rows = await conn.fetch(
+        "SELECT project_id, title, status, curriculum_id "
+        "FROM authoring_projects ORDER BY created_at DESC"
+    )
+    if not rows:
+        print("(no authoring projects found)")
+        return
+    for r in rows:
+        print(f"{r['project_id']}  [{r['status']:>10}]  {r['title']}")
+
+
+async def _export(conn: asyncpg.Connection, project_id: str, lang: str) -> tuple[dict, list[str]]:
+    proj = await conn.fetchrow(
+        "SELECT project_id, title, grade, structured_toc, status, curriculum_id "
+        "FROM authoring_projects WHERE project_id = $1",
+        project_id,
+    )
+    if proj is None:
+        raise BookExportError(f"no authoring project with id {project_id!r}")
+    if not proj["curriculum_id"]:
+        raise BookExportError("project has not been materialized (no curriculum_id)")
+    if proj["status"] != "published":
+        print(
+            f"[export_book] WARNING: project status is {proj['status']!r}, not 'published' — "
+            "exporting accepted versions anyway.",
+            file=sys.stderr,
+        )
+
+    unit_rows = await conn.fetch(
+        "SELECT unit_id, title FROM curriculum_units WHERE curriculum_id = $1 ORDER BY sort_order",
+        proj["curriculum_id"],
+    )
+    version_rows = await conn.fetch(
+        """
+        SELECT tv.unit_id, tv.content_type, tv.lang, tv.body
+          FROM authoring_active_versions av
+          JOIN authoring_topic_versions tv ON tv.topic_version_id = av.topic_version_id
+         WHERE av.project_id = $1 AND tv.review_status = 'accepted'
+        """,
+        project_id,
+    )
+
+    project = {
+        "project_id": str(proj["project_id"]),
+        "title": proj["title"],
+        "grade": proj["grade"],
+        "structured_toc": _as_dict(proj["structured_toc"]),
+    }
+    units = [{"unit_id": r["unit_id"], "title": r["title"]} for r in unit_rows]
+    versions = [
+        {
+            "unit_id": r["unit_id"],
+            "content_type": r["content_type"],
+            "lang": r["lang"],
+            "body": _as_dict(r["body"]),
+        }
+        for r in version_rows
+    ]
+    return assemble_book(project, units, versions, lang=lang)
+
+
+async def _run(args: argparse.Namespace) -> None:
+    conn = await asyncpg.connect(DATABASE_URL)
+    try:
+        await conn.execute("SET app.current_school_id = 'bypass'")
+        if args.list:
+            await _list_projects(conn)
+            return
+        book, warnings = await _export(conn, args.project_id, args.lang)
+    finally:
+        await conn.close()
+
+    for w in warnings:
+        print(f"[export_book] WARNING: {w}", file=sys.stderr)
+
+    out = Path(args.out)
+    out.write_text(json.dumps(book, ensure_ascii=False, indent=2), encoding="utf-8")
+    topic_count = len(book["content"])
+    print(
+        f"[export_book] wrote {out} — '{book['title']}' "
+        f"({topic_count} topic(s) with content, {len(warnings)} warning(s))"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Export a published authored curriculum to a StudyBuddy Q Book JSON."
+    )
+    parser.add_argument("--list", action="store_true", help="List authoring projects and exit")
+    parser.add_argument("--project-id", help="Authoring project id to export")
+    parser.add_argument("--out", default="book.json", help="Output JSON path (default: book.json)")
+    parser.add_argument("--lang", default="en", help="Language to export (default: en)")
+    args = parser.parse_args()
+
+    if not args.list and not args.project_id:
+        parser.error("--project-id is required (or use --list to find one)")
+
+    asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyError as exc:
+        print(f"[export_book] Missing env var: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except BookExportError as exc:
+        print(f"[export_book] {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/backend/src/admin/book_export.py
+++ b/backend/src/admin/book_export.py
@@ -1,0 +1,229 @@
+"""
+backend/src/admin/book_export.py
+
+Phase 1 of the "Context Engineering in the Enterprise" content migration
+(StudyBuddy_SelfLearner `docs/CONTENT_MIGRATION_CONTEXT_ENGINEERING.md`).
+
+Pure transform layer: turn a *published* authored curriculum (the Curriculum
+Authoring Studio's per-topic content) into a StudyBuddy Q-shaped ``Book`` JSON.
+Kept free of DB / filesystem / network so the field mappings are unit-testable
+without a live database — ``scripts/export_book.py`` is the thin asyncpg shell
+that feeds these functions.
+
+This moves *data*, not code: nothing here imports from or is imported by the Q
+repo. The emitted JSON is consumed by Q's local-first ``bookStore``. That keeps
+Q's ADR-002 one-way-vendoring rule (which forbids *code* cross-import) untouched.
+
+Shape parity (both repos descend from the same vendored ``pipeline/prompts.py``):
+- TOC (``structured_toc``) is byte-identical to Q's ``StructuredTOC`` — we only
+  inject a stable ``id`` per unit so generated content can be keyed to it.
+- Lesson differs from Q's ``LessonOutput`` only by field renames (mapped below).
+- Tutorial / quiz / experiment have no Q type yet (migration plan Phase 2). We
+  emit them in the vendored-schema shape (snake_case, minus pipeline-only
+  metadata) so the Q-side types can mirror this module's output verbatim.
+"""
+
+from __future__ import annotations
+
+import copy
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+# Deterministic topic ids: uuid5(unit_id) is stable across re-exports, so a
+# re-run produces the same Book/topic ids (idempotent import on the Q side).
+_TOPIC_NS = uuid.UUID("6f9b1d2e-3c4a-5b6d-8e9f-0a1b2c3d4e5f")
+
+
+class BookExportError(Exception):
+    """Raised when the authored curriculum cannot be assembled into a Book."""
+
+
+def topic_id_for(unit_id: str) -> str:
+    """Stable Q topic id derived from the OnDemand unit_id."""
+    return str(uuid.uuid5(_TOPIC_NS, unit_id))
+
+
+def _iso_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+# ── Per-content-type transforms (OnDemand body → Q shape) ─────────────────────
+
+
+def lesson_to_q(body: dict, *, unit_title: str, grade: int | None = None) -> dict:
+    """OnDemand lesson body → Q ``LessonOutput``.
+
+    Renames: ``sections[].body`` → ``body_markdown``, ``key_points`` →
+    ``key_takeaways``, ``reading_level`` → ``level``. ``further_reading`` has no
+    OnDemand counterpart, so it defaults to ``[]``.
+    """
+    sections = [
+        {"heading": s.get("heading", ""), "body_markdown": s.get("body", "")}
+        for s in body.get("sections", [])
+    ]
+    level = body.get("reading_level") or (f"Grade {grade}" if grade is not None else "")
+    return {
+        "topic": body.get("topic") or unit_title,
+        "level": level,
+        "language": body.get("language", "en"),
+        "synopsis": body.get("synopsis", ""),
+        "learning_objectives": list(body.get("learning_objectives", [])),
+        "sections": sections,
+        "key_takeaways": list(body.get("key_points", [])),
+        "further_reading": list(body.get("further_reading", [])),
+    }
+
+
+def tutorial_to_q(body: dict) -> dict:
+    """OnDemand tutorial body → Q tutorial shape (pipeline metadata stripped)."""
+    return {
+        "title": body.get("title", ""),
+        "sections": [
+            {
+                "section_id": s.get("section_id", ""),
+                "title": s.get("title", ""),
+                "content": s.get("content", ""),
+                "examples": list(s.get("examples", [])),
+                "practice_question": s.get("practice_question", ""),
+            }
+            for s in body.get("sections", [])
+        ],
+        "common_mistakes": list(body.get("common_mistakes", [])),
+    }
+
+
+def quiz_to_q(body: dict) -> dict:
+    """OnDemand quiz-set body → Q quiz shape (pipeline metadata stripped)."""
+    return {
+        "set_number": body.get("set_number"),
+        "questions": [
+            {
+                "question_id": q.get("question_id", ""),
+                "question_text": q.get("question_text", ""),
+                "question_type": q.get("question_type", "multiple_choice"),
+                "options": [
+                    {"option_id": o.get("option_id"), "text": o.get("text", "")}
+                    for o in q.get("options", [])
+                ],
+                "correct_option": q.get("correct_option"),
+                "explanation": q.get("explanation", ""),
+                "difficulty": q.get("difficulty", ""),
+            }
+            for q in body.get("questions", [])
+        ],
+        "total_questions": body.get("total_questions"),
+        "passing_score": body.get("passing_score"),
+        "estimated_duration_minutes": body.get("estimated_duration_minutes"),
+    }
+
+
+def experiment_to_q(body: dict) -> dict:
+    """OnDemand experiment body → Q experiment shape (pipeline metadata stripped)."""
+    return {
+        "experiment_title": body.get("experiment_title", ""),
+        "materials": list(body.get("materials", [])),
+        "safety_notes": list(body.get("safety_notes", [])),
+        "steps": [
+            {
+                "step_number": s.get("step_number"),
+                "instruction": s.get("instruction", ""),
+                "expected_observation": s.get("expected_observation", ""),
+            }
+            for s in body.get("steps", [])
+        ],
+        "questions": [
+            {"question": q.get("question", ""), "answer": q.get("answer", "")}
+            for q in body.get("questions", [])
+        ],
+        "conclusion_prompt": body.get("conclusion_prompt", ""),
+    }
+
+
+# ── Assembly ──────────────────────────────────────────────────────────────────
+
+
+def assemble_book(
+    project: dict,
+    units: list[dict],
+    versions: list[dict],
+    *,
+    lang: str = "en",
+    now: str | None = None,
+) -> tuple[dict, list[str]]:
+    """Build a Q ``Book`` dict from a published authored curriculum.
+
+    Args:
+        project: ``{project_id, title, grade, structured_toc}`` (structured_toc
+            is the StructuredTOC dict).
+        units: ``curriculum_units`` rows ordered by ``sort_order`` —
+            ``[{unit_id, title}, ...]``. This is the authoritative unit list and
+            its order matches ``materialize()``'s nested TOC walk, so it zips
+            positionally with the flattened TOC units.
+        versions: active+accepted topic versions —
+            ``[{unit_id, content_type, lang, body}, ...]`` (body is a dict).
+        lang: language to export (only this lang's versions are used).
+        now: ISO timestamp for createdAt/updatedAt/generatedAt (defaults to UTC now).
+
+    Returns:
+        ``(book, warnings)``. ``warnings`` lists units skipped for lacking a
+        lesson (Q's GeneratedTopic requires a lesson).
+    """
+    now = now or _iso_now()
+    toc = copy.deepcopy(project.get("structured_toc") or {})
+    grade = project.get("grade")
+
+    flat_units = [u for s in toc.get("subjects", []) for u in (s.get("units") or [])]
+    if len(flat_units) != len(units):
+        raise BookExportError(
+            f"TOC unit count ({len(flat_units)}) != curriculum_units count "
+            f"({len(units)}); cannot align topics to content"
+        )
+
+    # Group bodies by unit, for the requested language.
+    bodies_by_unit: dict[str, dict[str, Any]] = {}
+    for v in versions:
+        if v.get("lang") != lang:
+            continue
+        bodies_by_unit.setdefault(v["unit_id"], {})[v["content_type"]] = v["body"]
+
+    content: dict[str, dict] = {}
+    warnings: list[str] = []
+
+    for toc_unit, cu in zip(flat_units, units, strict=True):
+        unit_id = cu["unit_id"]
+        tid = topic_id_for(unit_id)
+        toc_unit["id"] = tid  # key the TOC unit to its generated content
+
+        bodies = bodies_by_unit.get(unit_id, {})
+        lesson_body = bodies.get("lesson")
+        if not lesson_body:
+            warnings.append(f"unit {unit_id} ({cu.get('title', '')!r}) has no lesson — skipped")
+            continue
+
+        topic_title = cu.get("title", "") or toc_unit.get("title", "")
+        gen: dict[str, Any] = {
+            "topicId": tid,
+            "title": topic_title,
+            "generatedAt": now,
+            "lesson": lesson_to_q(lesson_body, unit_title=topic_title, grade=grade),
+        }
+        if "tutorial" in bodies:
+            gen["tutorial"] = tutorial_to_q(bodies["tutorial"])
+        quiz_types = sorted(ct for ct in bodies if ct.startswith("quiz_set_"))
+        if quiz_types:
+            gen["quizSets"] = [quiz_to_q(bodies[ct]) for ct in quiz_types]
+        if "experiment" in bodies:
+            gen["experiment"] = experiment_to_q(bodies["experiment"])
+
+        content[tid] = gen
+
+    book = {
+        "id": f"authored-{project['project_id']}",
+        "title": project.get("title", ""),
+        "toc": toc,
+        "createdAt": now,
+        "updatedAt": now,
+        "content": content,
+    }
+    return book, warnings

--- a/backend/tests/test_book_export.py
+++ b/backend/tests/test_book_export.py
@@ -1,0 +1,276 @@
+"""
+backend/tests/test_book_export.py
+
+Unit tests for the OnDemand → StudyBuddy Q book export transforms
+(``src/admin/book_export.py``). Pure functions, no DB — synthetic bodies mirror
+the shapes enforced by ``pipeline/schemas.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.admin.book_export import (
+    BookExportError,
+    assemble_book,
+    experiment_to_q,
+    lesson_to_q,
+    quiz_to_q,
+    topic_id_for,
+    tutorial_to_q,
+)
+
+# ── Synthetic bodies (match pipeline/schemas.py required fields) ───────────────
+
+
+def _lesson_body() -> dict:
+    return {
+        "unit_id": "AUTH-abc-CE-001",
+        "subject": "Context Engineering",
+        "topic": "Why Context Engineering Emerged",
+        "synopsis": "A short overview of the topic.",
+        "sections": [
+            {"heading": "Introduction", "body": "Intro **markdown** body."},
+            {"heading": "Core Concepts", "body": "Core body with a $formula$."},
+        ],
+        "key_points": ["point one", "point two"],
+        "learning_objectives": ["Explain X", "Identify Y"],
+        "reading_level": "Grade 11 reading level",
+        "estimated_duration_minutes": 20,
+        "language": "en",
+        "generated_at": "2026-05-26T00:00:00Z",
+        "model": "claude-sonnet-4-6",
+        "content_version": 1,
+    }
+
+
+def _tutorial_body() -> dict:
+    return {
+        "unit_id": "AUTH-abc-CE-001",
+        "language": "en",
+        "title": "Tutorial: Context Engineering",
+        "sections": [
+            {
+                "section_id": "s1",
+                "title": "Step 1",
+                "content": "Do the thing.",
+                "examples": ["example a"],
+                "practice_question": "What is the thing?",
+            }
+        ],
+        "common_mistakes": ["forgetting context"],
+        "generated_at": "2026-05-26T00:00:00Z",
+        "model": "claude-sonnet-4-6",
+        "content_version": 1,
+    }
+
+
+def _quiz_body(set_number: int) -> dict:
+    return {
+        "unit_id": "AUTH-abc-CE-001",
+        "set_number": set_number,
+        "language": "en",
+        "questions": [
+            {
+                "question_id": "q1",
+                "question_text": "Which is correct?",
+                "question_type": "multiple_choice",
+                "options": [
+                    {"option_id": "A", "text": "alpha"},
+                    {"option_id": "B", "text": "beta"},
+                    {"option_id": "C", "text": "gamma"},
+                    {"option_id": "D", "text": "delta"},
+                ],
+                "correct_option": "B",
+                "explanation": "Because beta.",
+                "difficulty": "medium",
+            }
+        ],
+        "total_questions": 1,
+        "estimated_duration_minutes": 5,
+        "passing_score": 1,
+        "generated_at": "2026-05-26T00:00:00Z",
+        "model": "claude-sonnet-4-6",
+        "content_version": 1,
+    }
+
+
+def _experiment_body() -> dict:
+    return {
+        "unit_id": "AUTH-abc-CE-001",
+        "language": "en",
+        "experiment_title": "Observe context windows",
+        "materials": ["a laptop"],
+        "safety_notes": ["mind the cables"],
+        "steps": [
+            {"step_number": 1, "instruction": "Open the tool.", "expected_observation": "It opens."}
+        ],
+        "questions": [{"question": "What happened?", "answer": "It opened."}],
+        "conclusion_prompt": "Summarise what you observed.",
+        "generated_at": "2026-05-26T00:00:00Z",
+        "model": "claude-sonnet-4-6",
+        "content_version": 1,
+    }
+
+
+# ── Per-type transforms ────────────────────────────────────────────────────────
+
+
+def test_lesson_to_q_renames_fields():
+    q = lesson_to_q(_lesson_body(), unit_title="Why Context Engineering Emerged", grade=11)
+    # Renamed/derived fields
+    assert q["key_takeaways"] == ["point one", "point two"]  # was key_points
+    assert q["level"] == "Grade 11 reading level"  # was reading_level
+    assert q["sections"][0] == {
+        "heading": "Introduction",
+        "body_markdown": "Intro **markdown** body.",
+    }
+    assert "body" not in q["sections"][0]  # old field name dropped
+    # Direct fields
+    assert q["topic"] == "Why Context Engineering Emerged"
+    assert q["synopsis"] == "A short overview of the topic."
+    assert q["learning_objectives"] == ["Explain X", "Identify Y"]
+    assert q["language"] == "en"
+    # No OnDemand counterpart → empty default
+    assert q["further_reading"] == []
+    # Pipeline metadata not carried over
+    assert "model" not in q and "content_version" not in q
+
+
+def test_lesson_to_q_level_falls_back_to_grade():
+    body = _lesson_body()
+    del body["reading_level"]
+    q = lesson_to_q(body, unit_title="T", grade=9)
+    assert q["level"] == "Grade 9"
+
+
+def test_lesson_to_q_topic_falls_back_to_unit_title():
+    body = _lesson_body()
+    del body["topic"]
+    q = lesson_to_q(body, unit_title="Fallback Title")
+    assert q["topic"] == "Fallback Title"
+
+
+def test_tutorial_to_q_keeps_schema_strips_metadata():
+    q = tutorial_to_q(_tutorial_body())
+    assert q["title"] == "Tutorial: Context Engineering"
+    assert q["sections"][0]["practice_question"] == "What is the thing?"
+    assert q["sections"][0]["examples"] == ["example a"]
+    assert q["common_mistakes"] == ["forgetting context"]
+    assert "unit_id" not in q and "model" not in q
+
+
+def test_quiz_to_q_preserves_questions_and_options():
+    q = quiz_to_q(_quiz_body(2))
+    assert q["set_number"] == 2
+    assert q["passing_score"] == 1
+    assert q["questions"][0]["correct_option"] == "B"
+    assert q["questions"][0]["options"][1] == {"option_id": "B", "text": "beta"}
+    assert "model" not in q
+
+
+def test_experiment_to_q_maps_steps_and_questions():
+    q = experiment_to_q(_experiment_body())
+    assert q["experiment_title"] == "Observe context windows"
+    assert q["steps"][0]["expected_observation"] == "It opens."
+    assert q["questions"][0] == {"question": "What happened?", "answer": "It opened."}
+    assert q["conclusion_prompt"] == "Summarise what you observed."
+    assert "unit_id" not in q
+
+
+# ── Assembly ────────────────────────────────────────────────────────────────────
+
+
+def _project(units_titles: list[str]) -> dict:
+    return {
+        "project_id": "11111111-1111-1111-1111-111111111111",
+        "title": "Context Engineering in the Enterprise",
+        "grade": 11,
+        "structured_toc": {
+            "subjects": [
+                {
+                    "subject_label": "Context Engineering",
+                    "units": [
+                        {"title": t, "subtopics": ["a", "b"], "prerequisites": []}
+                        for t in units_titles
+                    ],
+                }
+            ]
+        },
+    }
+
+
+def test_assemble_book_full_fidelity():
+    units = [{"unit_id": "U1", "title": "Why Context Engineering Emerged"}]
+    versions = [
+        {"unit_id": "U1", "content_type": "lesson", "lang": "en", "body": _lesson_body()},
+        {"unit_id": "U1", "content_type": "tutorial", "lang": "en", "body": _tutorial_body()},
+        {"unit_id": "U1", "content_type": "quiz_set_1", "lang": "en", "body": _quiz_body(1)},
+        {"unit_id": "U1", "content_type": "quiz_set_2", "lang": "en", "body": _quiz_body(2)},
+        {"unit_id": "U1", "content_type": "quiz_set_3", "lang": "en", "body": _quiz_body(3)},
+        {"unit_id": "U1", "content_type": "experiment", "lang": "en", "body": _experiment_body()},
+    ]
+    book, warnings = assemble_book(_project(["Why Context Engineering Emerged"]), units, versions)
+
+    assert warnings == []
+    assert book["id"] == "authored-11111111-1111-1111-1111-111111111111"
+    assert book["title"] == "Context Engineering in the Enterprise"
+
+    tid = topic_id_for("U1")
+    # TOC unit got the stable id injected so content can be keyed to it.
+    assert book["toc"]["subjects"][0]["units"][0]["id"] == tid
+    assert tid in book["content"]
+
+    topic = book["content"][tid]
+    assert topic["title"] == "Why Context Engineering Emerged"
+    assert topic["lesson"]["key_takeaways"] == ["point one", "point two"]
+    assert topic["tutorial"]["title"] == "Tutorial: Context Engineering"
+    assert [qs["set_number"] for qs in topic["quizSets"]] == [1, 2, 3]  # ordered
+    assert topic["experiment"]["experiment_title"] == "Observe context windows"
+
+
+def test_assemble_book_optional_types_absent_when_not_generated():
+    units = [{"unit_id": "U1", "title": "Lesson-only topic"}]
+    versions = [
+        {"unit_id": "U1", "content_type": "lesson", "lang": "en", "body": _lesson_body()},
+    ]
+    book, warnings = assemble_book(_project(["Lesson-only topic"]), units, versions)
+    topic = book["content"][topic_id_for("U1")]
+    assert "lesson" in topic
+    assert "tutorial" not in topic
+    assert "quizSets" not in topic
+    assert "experiment" not in topic
+    assert warnings == []
+
+
+def test_assemble_book_skips_unit_without_lesson_and_warns():
+    units = [{"unit_id": "U1", "title": "No lesson here"}]
+    versions = [
+        {"unit_id": "U1", "content_type": "tutorial", "lang": "en", "body": _tutorial_body()},
+    ]
+    book, warnings = assemble_book(_project(["No lesson here"]), units, versions)
+    assert book["content"] == {}  # nothing emitted without a lesson
+    assert len(warnings) == 1 and "no lesson" in warnings[0]
+
+
+def test_assemble_book_filters_by_language():
+    units = [{"unit_id": "U1", "title": "T"}]
+    versions = [
+        {"unit_id": "U1", "content_type": "lesson", "lang": "fr", "body": _lesson_body()},
+    ]
+    book, warnings = assemble_book(_project(["T"]), units, versions, lang="en")
+    # The only version is fr; exporting en yields no content and a warning.
+    assert book["content"] == {}
+    assert len(warnings) == 1
+
+
+def test_assemble_book_raises_on_toc_unit_count_mismatch():
+    units = [{"unit_id": "U1", "title": "T1"}]  # 1 curriculum unit
+    project = _project(["T1", "T2"])  # 2 TOC units
+    with pytest.raises(BookExportError, match="cannot align"):
+        assemble_book(project, units, [])
+
+
+def test_topic_id_is_deterministic():
+    assert topic_id_for("U1") == topic_id_for("U1")
+    assert topic_id_for("U1") != topic_id_for("U2")


### PR DESCRIPTION
## Summary

**Phase 1** of the "Context Engineering in the Enterprise" content migration (plan: StudyBuddy Q `docs/CONTENT_MIGRATION_CONTEXT_ENGINEERING.md`). Exports a **published** authored curriculum from the Curriculum Authoring Studio into a StudyBuddy Q-shaped `Book` JSON, for Q's local-first reader.

This is a **data copy, not a code port** — nothing imports across repos; the script emits plain JSON that Q ingests. So Q's ADR-002 one-way *code*-vendoring rule is untouched.

## What's here

| File | Role |
|---|---|
| `backend/src/admin/book_export.py` | Pure, DB-free transform layer + `assemble_book()`. CI-linted, unit-tested. |
| `backend/scripts/export_book.py` | Thin asyncpg CLI shell — `--project-id` / `--list` / `--out` / `--lang`. Sets `app.current_school_id='bypass'` (pitfall #28). |
| `backend/tests/test_book_export.py` | 12 unit tests on the transforms + assembly (synthetic bodies matching `pipeline/schemas.py`; no DB). |

## Shape mapping (why it's clean)

Both repos descend from the same vendored `pipeline/prompts.py`, so:
- **TOC** (`structured_toc`) is byte-identical to Q's `StructuredTOC` — we only inject a stable `id` (`uuid5(unit_id)`) per unit so content keys to it.
- **Lesson** → Q `LessonOutput` by field renames: `sections[].body`→`body_markdown`, `key_points`→`key_takeaways`, `reading_level`→`level`; `further_reading` defaults `[]`.
- **Tutorial / quiz / experiment** (full-fidelity scope) emitted in vendored-schema shape (snake_case, pipeline metadata stripped). Q's not-yet-built types (migration plan Phase 2) should **mirror this module's output** — this PR is the de-facto contract for them.

## Verification

- `pytest tests/test_book_export.py` → **12 passed** (transform + assembly + edge cases: missing lesson, lang filter, TOC/unit count mismatch).
- `ruff check src/admin/book_export.py scripts/export_book.py` → clean; all files formatted.
- `python scripts/export_book.py --help` → imports resolve, CLI wired.

## Not in scope / next

- **Not yet run against real content** — waits on the project being **published** in the Studio (the "ready" gate).
- Phases 2–4 (Q's `GeneratedTopic` growing to 5 types + renderer + ingest) belong in a **Q-rooted session**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)