### PR TITLE
fix(authoring): block publish of incomplete curricula (#401)

### DIFF
--- a/backend/src/admin/authoring_service.py
+++ b/backend/src/admin/authoring_service.py
@@ -542,6 +542,11 @@ _CONTENT_FILENAMES = {
     "experiment": "experiment",
 }
 
+# Content types every unit is expected to have at publish time (mirrors
+# authoring_generation.BASE_CONTENT_TYPES; kept local to avoid a circular import).
+# `experiment` is expected only when the unit has has_lab=TRUE.
+_EXPECTED_BASE_CONTENT_TYPES = ("lesson", "tutorial", "quiz_set_1", "quiz_set_2", "quiz_set_3")
+
 
 async def publish(
     conn: asyncpg.Connection,
@@ -549,16 +554,19 @@ async def publish(
     project_id: str,
     *,
     visibility: str,
+    allow_incomplete: bool = False,
 ) -> dict:
     """Publish an authored curriculum.
 
-    Requires status='generated' and every active topic version accepted. Writes
-    accepted bodies to the content store, creates content_subject_versions rows
-    (status='published') per subject, sets curricula.is_default = (visibility ==
-    'catalog'), and flips the project to status='published'.
+    Requires status='generated', every active topic version accepted, and (unless
+    allow_incomplete) every unit complete — an accepted active version for each
+    expected content type per project language (experiment only where has_lab).
+    Writes accepted bodies to the content store, creates content_subject_versions
+    rows (status='published') per subject, sets curricula.is_default = (visibility
+    == 'catalog'), and flips the project to status='published'.
     """
     proj = await conn.fetchrow(
-        "SELECT curriculum_id, status FROM authoring_projects WHERE project_id = $1",
+        "SELECT curriculum_id, status, languages FROM authoring_projects WHERE project_id = $1",
         project_id,
     )
     if proj is None:
@@ -589,6 +597,35 @@ async def publish(
         raise PublishError(
             f"{len(unaccepted)} topic version(s) are not accepted; accept all before publishing"
         )
+
+    # Gate: completeness (issue #401). Every unit must have an active version for
+    # each expected content type, per project language — experiment only where
+    # has_lab. Without this, a unit whose generation failed (no active version)
+    # publishes silently with holes.
+    if not allow_incomplete:
+        langs = list(proj["languages"] or ["en"])
+        units_meta = await conn.fetch(
+            "SELECT unit_id, has_lab FROM curriculum_units WHERE curriculum_id = $1",
+            curriculum_id,
+        )
+        present = {(a["unit_id"], a["lang"], a["content_type"]) for a in actives}
+        missing: list[str] = []
+        for u in units_meta:
+            expected = list(_EXPECTED_BASE_CONTENT_TYPES)
+            if u["has_lab"]:
+                expected.append("experiment")
+            missing.extend(
+                f"{u['unit_id']}/{lang}/{ct}"
+                for lang in langs
+                for ct in expected
+                if (u["unit_id"], lang, ct) not in present
+            )
+        if missing:
+            preview = ", ".join(missing[:8]) + (" …" if len(missing) > 8 else "")
+            raise PublishError(
+                f"curriculum is incomplete — {len(missing)} expected content piece(s) missing "
+                f"({preview}). Generate the missing content, or publish with allow_incomplete=True."
+            )
 
     # Write accepted bodies to the content store.
     for a in actives:

--- a/backend/tests/test_authoring_pr_b.py
+++ b/backend/tests/test_authoring_pr_b.py
@@ -365,6 +365,48 @@ async def test_publish_private_keeps_is_default_false(
     assert is_default is False
 
 
+async def _drop_active_lesson(pid: str, unit_id: str) -> None:
+    """Simulate a generation gap — remove a unit's active lesson version."""
+    async with app.state.pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        await conn.execute(
+            "DELETE FROM authoring_active_versions "
+            "WHERE project_id=$1 AND unit_id=$2 AND content_type='lesson'",
+            pid,
+            unit_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_publish_blocks_incomplete_curriculum(
+    client: AsyncClient, admin_token: str
+) -> None:
+    # Regression for #401: a unit missing its lesson must not publish silently.
+    pid = await _seed_generated_project()
+    await _accept_all(pid)
+    await _drop_active_lesson(pid, _first_unit_id(pid))
+    r = await client.post(
+        f"/api/v1/admin/authoring/projects/{pid}/publish",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"visibility": "private"},
+    )
+    assert r.status_code == 409
+    assert "incomplete" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_publish_allow_incomplete_overrides_gate(client: AsyncClient) -> None:
+    pid = await _seed_generated_project()
+    await _accept_all(pid)
+    await _drop_active_lesson(pid, _first_unit_id(pid))
+    async with app.state.pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        result = await svc.publish(
+            conn, app.state.storage, pid, visibility="private", allow_incomplete=True
+        )
+    assert result["curriculum_id"]
+
+
 @pytest.mark.asyncio
 async def test_list_topics(client: AsyncClient, admin_token: str) -> None:
     pid = await _seed_generated_project()


### PR DESCRIPTION
## Summary

Closes #401. `publish()` gated only on *existing* active versions being accepted — never on **completeness**. A unit whose lesson generation failed (no active version) had nothing to gate on, so the curriculum **published silently with holes**. The published "Context Engineering in the Enterprise" book did exactly this (missing 3 lessons, 2 tutorials, 1 quiz — found during the StudyBuddy Q migration).

## Fix

A pre-publish **completeness gate**: every `curriculum_units` row must have an active version for each expected content type, per project language — `experiment` required **only where `has_lab`** (so lab-less books like this one aren't falsely flagged). The error lists the missing `unit/lang/content_type` pieces. A new `allow_incomplete=True` param is the explicit escape hatch.

```
PublishError: curriculum is incomplete — 6 expected content piece(s) missing
(AUTH-…-001/en/lesson, AUTH-…-004/en/lesson, …). Generate the missing content,
or publish with allow_incomplete=True.
```

- `src/admin/authoring_service.py`: completeness gate in `publish()`; `_EXPECTED_BASE_CONTENT_TYPES` (mirrors `authoring_generation.BASE_CONTENT_TYPES`, kept local to avoid a circular import); publish query now selects `languages`.
- `tests/test_authoring_pr_b.py`: missing-lesson publish → **409 "incomplete"**; `allow_incomplete=True` overrides.

## Verification

- `pytest tests/test_authoring_pr_b.py` → **17 passed** (15 existing + 2 new). Existing publish tests (which publish fully-generated projects) still pass — the gate only fires on real gaps.
- `ruff check src/admin/authoring_service.py` → clean.

## Note

Doesn't auto-wire `allow_incomplete` into the HTTP endpoint — publish via the API now always enforces completeness (the desired default). Exposing an override in the Studio UI is a separate, optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)