### PR TITLE
fix(compose): bind Postgres/Redis/PgBouncer to loopback only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,11 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      # Loopback-only. Docker bypasses ufw, so a bare "5432:5432" binds 0.0.0.0
+      # and exposes Postgres to the internet (BSI/CERT-Bund CB-Report#20260603).
+      # Compose merges `ports` by append, so an override's `ports: []` can NOT
+      # remove this — the public bind must be killed here in the base file.
+      - "127.0.0.1:5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U studybuddy -d studybuddy"]
       interval: 10s
@@ -107,7 +111,8 @@ services:
     volumes:
       - redis_data:/data
     ports:
-      - "6379:6379"
+      # Loopback-only — same internet-exposure risk as Postgres above.
+      - "127.0.0.1:6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 10s
@@ -130,7 +135,8 @@ services:
       DEFAULT_POOL_SIZE: "50"
       AUTH_TYPE: md5
     ports:
-      - "6432:5432"
+      # Loopback-only — pgbouncer fronts Postgres; never expose it publicly.
+      - "127.0.0.1:6432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -h localhost -p 5432 -U studybuddy || exit 1"]
       interval: 10s


### PR DESCRIPTION
## What
Bind the `db` (5432), `redis` (6379), and `pgbouncer` (6432) host ports to `127.0.0.1` instead of `0.0.0.0` in the base `docker-compose.yml`.

## Why
BSI/CERT-Bund report **CB-Report#20260603-10011240** (forwarded via Hetzner abuse, AbuseID 11C8A12:26) flagged the demo VPS `178.105.160.62` as running an **openly reachable PostgreSQL on :5432**. Confirmed live from two vantage points:

```
studybuddy-db-1     db      0.0.0.0:5432->5432/tcp
studybuddy-redis-1  redis   0.0.0.0:6379->6379/tcp   <- not yet reported, same class
```

**Root cause:** `docker-compose.demo.yml` set `ports: []` on `db` intending to unpublish it, but Compose **merges `ports` by append** across `-f` files — the empty list removes nothing, so the base `"5432:5432"` survived. Docker also writes iptables rules that **bypass `ufw`**, so the host firewall never masked it.

The fix must live in the **base** file: an override can only *add* a published port, never *remove* one.

## Risk
Low. Inter-container traffic uses the Docker network (`db:5432` / `redis:6379`) and is unaffected. Host-side `psql`/`redis-cli` still works via loopback. Local dev connects to an external `:5433` host DB regardless.

## Test plan
- [x] Confirmed exposure live (external TCP probe + `docker compose ps`)
- [ ] After deploy: re-probe `178.105.160.62:5432` and `:6379` → expect filtered/closed
- [ ] Demo site still serves (`https://demo.usestudybuddy.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)