### PR TITLE
fix(web): bump axios → 1.17.0 to clear high-severity npm audit advisory

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,7 @@
         "@hookform/resolvers": "5.2.2",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "5.96.2",
-        "axios": "1.15.2",
+        "axios": "1.17.0",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "diff": "^8.0.4",
@@ -3580,6 +3580,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
@@ -5410,14 +5474,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {

--- a/web/package.json
+++ b/web/package.json
@@ -29,7 +29,7 @@
     "@hookform/resolvers": "5.2.2",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "5.96.2",
-    "axios": "1.15.2",
+    "axios": "1.17.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "diff": "^8.0.4",


### PR DESCRIPTION
## What

Bump `axios` `1.15.2` → `1.17.0` in `web/` and regenerate `package-lock.json`.

## Why

The scheduled **CI → "Frontend — Lint & Typecheck"** job started failing. Despite the job name, ESLint / Prettier / TypeScript all pass — the failing step is **`npm audit --audit-level=high`** (`.github/workflows/test.yml:195`).

Root cause: a **high-severity advisory cluster against `axios ≤ 1.15.2`** (our exact pin):
- `NO_PROXY` bypass — `shouldBypassProxy` doesn't recognize IPv4-mapped IPv6 (incomplete fix for CVE-2025-62718) — [GHSA-pjwm-pj3p-43mv](https://github.com/advisories/GHSA-pjwm-pj3p-43mv)
- DoS & header injection via prototype-pollution gadgets in merge fns — [GHSA-898c-q2cr-xwhg](https://github.com/advisories/GHSA-898c-q2cr-xwhg)
- Proxy-Authorization header injection (incomplete null-prototype fix) — [GHSA-654m-c8p4-x5fp](https://github.com/advisories/GHSA-654m-c8p4-x5fp)
- Full MitM via prototype-pollution gadget in `config.proxy` — [GHSA-35jp-ww65-95wh](https://github.com/advisories/GHSA-35jp-ww65-95wh)

`1.17.0` is the patched release. No code change introduced this — a new advisory + patch landed, so a previously-green pin went red on the nightly schedule.

## Alternatives considered

- `npm audit fix` — would have produced the same axios bump; did it via an explicit pin instead so the change is reviewable.
- Lowering the CI gate to `critical` — rejected; the gate is doing its job.

## Risk

Low. Patch-level minor bump within axios 1.x; no API changes. Lockfile diff is axios + its new nested proxy-agent deps (`agent-base`, `https-proxy-agent`) plus an npm refresh of optional `@tailwindcss/oxide-wasm32-wasi` fallback entries.

## Test plan

- [x] `npm audit --audit-level=high` exits **0** (5 moderate findings remain — auth0, next-intl, postcss-via-next, qs — which don't fail the high gate)
- [ ] CI green on this PR

## Follow-up

The 5 remaining **moderate** advisories need major/breaking bumps (e.g. `next` for the transitive `postcss`). Out of scope here; worth a dedicated dependency-maintenance pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)