### PR TITLE
fix(email): point provisioned-user welcome/reset emails to /signin (#408)

### DIFF
--- a/backend/src/email/service.py
+++ b/backend/src/email/service.py
@@ -643,7 +643,7 @@ _RESET_PASSWORD_HTML = """\
 
 async def send_welcome_teacher_email(to_email: str, name: str, password: str) -> None:
     """Send welcome credentials email to a school-provisioned teacher."""
-    login_url = f"{settings.FRONTEND_URL}/login"
+    login_url = f"{settings.FRONTEND_URL}/signin"
     fmt = {"name": name, "login_url": login_url, "email": to_email, "password": password}
     await _send(
         to_email=to_email,
@@ -655,7 +655,7 @@ async def send_welcome_teacher_email(to_email: str, name: str, password: str) ->
 
 async def send_welcome_student_email(to_email: str, name: str, password: str) -> None:
     """Send welcome credentials email to a school-provisioned student."""
-    login_url = f"{settings.FRONTEND_URL}/login"
+    login_url = f"{settings.FRONTEND_URL}/signin"
     fmt = {"name": name, "login_url": login_url, "email": to_email, "password": password}
     await _send(
         to_email=to_email,
@@ -667,7 +667,7 @@ async def send_welcome_student_email(to_email: str, name: str, password: str) ->
 
 async def send_password_reset_email(to_email: str, name: str, password: str) -> None:
     """Send admin-initiated password reset email to a teacher or student."""
-    login_url = f"{settings.FRONTEND_URL}/login"
+    login_url = f"{settings.FRONTEND_URL}/signin"
     fmt = {"name": name, "login_url": login_url, "email": to_email, "password": password}
     await _send(
         to_email=to_email,


### PR DESCRIPTION
## What

Change the Login URL in the three school-provisioning emails from `/login` to `/signin`:
- `send_welcome_teacher_email` (`service.py:646`)
- `send_welcome_student_email` (`service.py:658`)
- `send_password_reset_email` (`service.py:670`)

## Why

`/login` is the Auth0-first page; its primary CTA ("Sign in with school account") is the
one path a school-provisioned (local-auth) user **cannot** use — and on the demo it
returns a 500. So a newly provisioned teacher/student was emailed a working
email+password, then funneled straight to a button that can't accept it.

Every other transactional email (incl. the demo test-run email) already uses `/signin`,
the local credential form. This aligns the three outliers. Confirmed root cause of the
top issue in demo feedback from Venki T (2026-06-07).

## Alternatives considered

- *Fix the `/login` page hierarchy / hide the Auth0 button instead* — still worth doing
  (P2 in #408), but the email is the highest-payoff one-liner and unblocks provisioned
  users regardless of how `/login` is laid out.

## Risk

Minimal — three string constants. No behavioral change beyond the link target. Existing
tests mock these email functions and don't assert the URL, so nothing breaks.

## Test plan

- [x] `grep` confirms no `FRONTEND_URL}/login` remains in `service.py`
- [ ] Provision a teacher/student on a deploy; confirm the welcome email links to `/signin`
      and that page accepts the emailed credentials

Part of #408 (P0). Does not address the Auth0 500 (1b) or the change-password error (1c),
which need live repro and are tracked separately in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)