### PR TITLE
fix(backup): use curriculum_id (TEXT) instead of id in backup_school_task

### DIFF
--- a/backend/src/backup/tasks.py
+++ b/backend/src/backup/tasks.py
@@ -203,20 +203,22 @@ def backup_school_task(
                         school_uuid,
                     )
 
-                curriculum_ids = [str(r["id"]) for r in curricula_rows]
+                # curricula PK is curriculum_id (TEXT), not id. curriculum_id is
+                # also TEXT on curriculum_units and content_subject_versions, so
+                # pass the IDs through as text — never wrap in uuid.UUID().
+                curriculum_ids = [str(r["curriculum_id"]) for r in curricula_rows]
 
                 # Query dependent rows
                 units_rows: list = []
                 versions_rows: list = []
                 if curriculum_ids:
-                    c_uuids = [uuid.UUID(c) for c in curriculum_ids]
                     units_rows = await conn.fetch(
                         "SELECT * FROM curriculum_units WHERE curriculum_id = ANY($1)",
-                        c_uuids,
+                        curriculum_ids,
                     )
                     versions_rows = await conn.fetch(
                         "SELECT * FROM content_subject_versions WHERE curriculum_id = ANY($1)",
-                        c_uuids,
+                        curriculum_ids,
                     )
 
                 llm_config_row = await conn.fetchrow(

--- a/backend/tests/test_backup.py
+++ b/backend/tests/test_backup.py
@@ -577,3 +577,87 @@ async def test_full_backup_classroom_packages_query(db_conn):
     assert len(rows) == 1
     assert rows[0]["curriculum_id"] == curriculum_id
     assert rows[0]["classroom_id"] == classroom_id
+
+
+# ── Regression: full-backup curricula id column + dependent-row query ───────────
+
+
+async def test_full_backup_curricula_id_and_dependent_query(db_conn):
+    """Regression for the `Error: 'id'` backup-failure email reported by a school
+    with content.
+
+    Two bugs in `backup_school_task` made every full backup fail once a school
+    owned at least one curriculum:
+
+      1. `curriculum_ids = [str(r["id"]) for r in curricula_rows]` — the curricula
+         PK is `curriculum_id` (TEXT, migration 0002), so `r["id"]` raised
+         `KeyError: 'id'`, whose str() is the bare `'id'` shown in the email.
+      2. The dependent-row queries then wrapped those IDs in `uuid.UUID(...)` and
+         compared them against `curriculum_units.curriculum_id` /
+         `content_subject_versions.curriculum_id`, both of which are TEXT — which
+         would have raised `operator does not exist: text = uuid` next.
+
+    This seeds a school-owned curriculum (UUID-style id, like a real fork) plus a
+    dependent unit + content version, then runs the exact query sequence from the
+    task and asserts it succeeds end to end.
+    """
+    school_id = uuid.uuid4()
+    curriculum_id = str(uuid.uuid4())  # school forks use UUID-string ids
+
+    await db_conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+    await db_conn.execute(
+        """
+        INSERT INTO schools (school_id, name, contact_email, status)
+        VALUES ($1, 'Backup Id Regression School', $2, 'active')
+        """,
+        school_id,
+        f"backupid_{str(school_id)[:8]}@example.com",
+    )
+    await db_conn.execute(
+        """
+        INSERT INTO curricula
+            (curriculum_id, grade, year, name, is_default, school_id, owner_type)
+        VALUES ($1, 8, 2026, 'Fork of G8 STEM', FALSE, $2, 'school')
+        """,
+        curriculum_id,
+        school_id,
+    )
+    await db_conn.execute(
+        """
+        INSERT INTO curriculum_units (unit_id, curriculum_id, subject, title, unit_name)
+        VALUES ('G8-MATH-001', $1, 'Mathematics', 'Fractions', 'Fractions')
+        """,
+        curriculum_id,
+    )
+    await db_conn.execute(
+        """
+        INSERT INTO content_subject_versions (curriculum_id, subject)
+        VALUES ($1, 'Mathematics')
+        """,
+        curriculum_id,
+    )
+
+    # Exact query sequence from src/backup/tasks.py::backup_school_task (full scope)
+    curricula_rows = await db_conn.fetch("SELECT * FROM curricula WHERE school_id=$1", school_id)
+    assert len(curricula_rows) == 1
+    # The buggy `id` key does not exist on the row — `curriculum_id` is the PK.
+    assert "id" not in curricula_rows[0]
+    with pytest.raises(KeyError):
+        _ = curricula_rows[0]["id"]
+
+    curriculum_ids = [str(r["curriculum_id"]) for r in curricula_rows]
+    assert curriculum_ids == [curriculum_id]
+
+    # Dependent rows: TEXT ids passed straight through (never wrapped in uuid.UUID).
+    units_rows = await db_conn.fetch(
+        "SELECT * FROM curriculum_units WHERE curriculum_id = ANY($1)",
+        curriculum_ids,
+    )
+    versions_rows = await db_conn.fetch(
+        "SELECT * FROM content_subject_versions WHERE curriculum_id = ANY($1)",
+        curriculum_ids,
+    )
+    assert len(units_rows) == 1
+    assert units_rows[0]["unit_id"] == "G8-MATH-001"
+    assert len(versions_rows) == 1
+    assert versions_rows[0]["subject"] == "Mathematics"


### PR DESCRIPTION
## What

Fixes `backup_school_task` so full backups succeed for schools that own curricula. Two schema-mismatch bugs are corrected and a regression test is added.

## Why

Venkatesh T reported a `StudyBuddy: Curriculum backup FAILED (full)` email with `Error: 'id'`. That string is `str(KeyError('id'))`.

Root cause — two bugs in `backend/src/backup/tasks.py`:

1. **`tasks.py:206`** — `[str(r["id"]) for r in curricula_rows]`. The `curricula` PK is **`curriculum_id`** (TEXT, migration 0002), not `id` → `KeyError: 'id'`.
2. **Lines 212–219** — the IDs were wrapped in `uuid.UUID(...)` then compared against `curriculum_units.curriculum_id` / `content_subject_versions.curriculum_id`, both **TEXT** → would have failed next with `operator does not exist: text = uuid`.

**Impact:** every *full* backup failed for any school owning ≥1 curriculum. Schools with zero curricula backed up "fine" (the comprehension never iterated), which is why it slipped past casual testing. The existing 27 tests only exercised the REST endpoints, never the task body against seeded rows. This is the same family as the earlier #398 fix (`cl.id` → `cl.classroom_id`) in this same task.

## How

- Read `r["curriculum_id"]` and pass the TEXT IDs straight into the `ANY($1)` queries — no `uuid.UUID()` wrap.

## Test plan

- Added `test_full_backup_curricula_id_and_dependent_query`: seeds a school-owned curriculum (UUID-style id, like a real fork) + dependent unit + content version, runs the exact query sequence from the task, asserts it succeeds end-to-end (with an explicit `KeyError` guard on the old `["id"]` key). Modeled on the existing #398 regression test.
- `tests/test_backup.py`: **29 passed**. `ruff check src/backup/tasks.py` clean.

## Risk

Low. Two-line behavioral change confined to the backup query path; no schema or API change.

## Follow-up (not in this PR)

The **restore** path (`dry_run_restore_task`, `execute_restore_task`) has the same family of bugs and worse — it references `id`, `grade`, `ordering` columns that don't exist (real columns: `curriculum_id`, `sort_order`), omits the NOT NULL `year`, and uses `ON CONFLICT (id)`. Latent today because no backup ever succeeded; now reachable. Needs its own PR + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
