### PR TITLE
docs(adr): ADR-005 — school_admin superset role + single-key (email) uniqueness

### DIFF
--- a/docs/ADR_005_school_roles_and_uniqueness.md
+++ b/docs/ADR_005_school_roles_and_uniqueness.md
@@ -1,4 +1,4 @@
-# ADR-005 — School User Roles (school_admin as superset) and Single-Key Uniqueness
+# ADR-005 — School User Roles (school_admin as superset), Single-Key Uniqueness, and Soft-Delete Accounts
 
 **Date:** 2026-06-08
 **Status:** Proposed
@@ -29,6 +29,12 @@ value, or split the admin bit into a separate additive flag?
 `UNIQUE` constraint on `schools.name`. The product owner's call: **email-id
 uniqueness alone is sufficient**; two schools may legitimately share a display
 name (e.g. "St. Mary's").
+
+**Q3 — Deletion semantics.** What does "Delete" mean when a school removes a
+user? A hard delete would destroy student educational records (FERPA-relevant)
+and prevent recognising a returning person. The product owner's call: **soft
+delete** — deactivate + archive, with returning users re-onboarded as new
+accounts.
 
 ---
 
@@ -71,16 +77,41 @@ grant ⊃ plain `teacher`. Curriculum create/modify (Rule 11) requires
 This **supersedes** the `schools.name` uniqueness item in ADR-001's entity-rules
 table and **closes issue #240** as "won't do."
 
+### Decision 3 — Account deletion is a soft delete (deactivate + archive), never a hard delete
+
+- **"Delete" deactivates.** Deleting any school user (teacher, student, or
+  school_admin) sets a `deactivated_at` timestamp; the account can no longer log
+  in and is excluded from active rosters and grade/class assignment queries. The
+  row is **never** physically removed by this action.
+- **Archive on deactivation.** The deactivated record is moved to an archive
+  store — a new **`user_account_archive`** table — carrying the deactivation
+  timestamp, so a returning person can be recognised and re-onboarded later.
+- **Returning user = new account.** Re-onboarding a previously deactivated person
+  grants **no implicit access.** They are treated as a new account: a
+  `school_admin` must re-grant their role and grade/class privileges from scratch.
+  Prior assignments are **not** automatically restored.
+- **Minimum-1 school-admin invariant.** Deactivating the last remaining
+  `school_admin` of a school is **refused** (a school must always retain ≥1 active
+  admin); ≥2 is recommended so this never blocks routine offboarding.
+- **FERPA alignment.** Soft delete + archive preserves educational-record
+  retention (progress, scores, lesson-view history) instead of destroying it on
+  deactivation. Any eventual hard purge follows the separate retention/GDPR
+  schedule (ADR-001 / data-privacy rules), **not** this action.
+
 ---
 
 ## Consequences
 
 ### Positive
-- Matches operational reality: a single migration-free model serves both a
-  10-teacher school and a one-person tutor/home-school (the ADR-001 personas).
+- Matches operational reality: a single migration-free model (Decisions 1–2)
+  serves both a 10-teacher school and a one-person tutor/home-school (the ADR-001
+  personas).
 - No schema change for roles — `school_admin`-as-superset already works; lower risk.
 - Onboarding never fails on a benign name collision; only the email — the real
   identity key — must be unique.
+- Soft delete preserves FERPA-relevant educational records and lets a returning
+  person be recognised, while the "new account" rule keeps re-grant explicit (no
+  stale privileges silently resurrected).
 
 ### Negative
 - "Role" remains overloaded: `school_admin` encodes both "is an admin" and "is a
@@ -89,10 +120,15 @@ table and **closes issue #240** as "won't do."
 - Duplicate school names can confuse super-admin search/disambiguation in the
   console — must surface `contact_email` (the unique key) alongside name in any
   school picker.
+- Decision 3 **does** require new schema + behavior (archive table, `deactivated_at`,
+  roster-exclusion filtering, last-admin guard) — the one part of this ADR that is
+  not migration-free.
 
 ### Neutral
 - The JWT continues to carry a single `role` claim plus a `capabilities[]` array
   (the 0059 design); no token-shape change.
+- Email-ids remain globally unique even across deactivation — re-onboarding the
+  same address reuses it; the archive row is keyed by the original account id.
 
 ## Alternatives considered
 
@@ -105,17 +141,32 @@ table and **closes issue #240** as "won't do."
   the admin must also be assigned to grades and teach.
 - **`UNIQUE (schools.name)` per issue #240** — rejected. Email-id uniqueness is
   sufficient; name collisions are legitimate. Closes #240.
+- **Hard delete of school users** — rejected (Decision 3). Destroys FERPA-relevant
+  educational records and loses the ability to recognise a returning person.
+- **Soft delete that restores prior access on return** — rejected. Silently
+  resurrecting old role/grade grants is a security risk; re-grant must be explicit.
 
 ## Migration / rollout
 
-- **No new migration required.**
+- **Decisions 1 & 2 — no new migration required.**
   - Roles: `teachers.role ∈ {teacher, school_admin}` and `teacher_capabilities`
     (0059) already in place; this ADR documents their intended semantics.
   - Uniqueness: `schools.contact_email` UNIQUE already exists (0025); we
     deliberately **do not** add `UNIQUE (schools.name)`.
+- **Decision 3 — new migration + behavior required (follow-up):**
+  - `deactivated_at TIMESTAMPTZ NULL` on `teachers` and `students`.
+  - New `user_account_archive` table (RLS-scoped per `school_id`), holding the
+    archived account snapshot + deactivation timestamp.
+  - Roster / assignment / login queries filter out `deactivated_at IS NOT NULL`.
+  - Deactivation endpoint(s) enforce the **last-active-`school_admin` guard**
+    (refuse to deactivate the final admin).
+  - Re-onboarding a previously-archived email creates a fresh account with **no**
+    inherited role/grade grants.
+  - *Tracked separately for implementation; not part of this docs-only PR.*
 - **Issue hygiene:** close **#240** referencing this ADR. Cross-check #359 docs
   to ensure the "school_admin = implicit superset" wording matches Decision 1.
 - **UI:** ensure any super-admin/school school-picker shows `contact_email` next
   to `name` (names are non-unique).
 - **Spec linkage:** this ADR is the decision record behind the
-  "School User Account Management — Functional Spec" (Type 1).
+  [School User Account Management — Functional Spec](SCHOOL_USER_MANAGEMENT.md)
+  (Type 1); Decision 3 detail lives in its §6.1.

--- a/docs/ADR_005_school_roles_and_uniqueness.md
+++ b/docs/ADR_005_school_roles_and_uniqueness.md
@@ -1,0 +1,121 @@
+# ADR-005 — School User Roles (school_admin as superset) and Single-Key Uniqueness
+
+**Date:** 2026-06-08
+**Status:** Proposed
+**Branch at decision:** `docs/adr-005-school-roles-uniqueness`
+
+---
+
+## Context
+
+A functional spec for **Type 1 (Self-Managed) school user account management** was
+drafted (super-admin onboards school + school-admin(s); school self-manages
+teachers, students, passwords, and grade/class assignment). Two design questions
+surfaced that this ADR locks in. Both refine — they do not overturn —
+[ADR-001](ADR_001_tenancy_and_subscription_model.md).
+
+**Q1 — Role model.** The spec lists three roles (school admin / teacher /
+student) but also states "an account is a teacher *or* a student, never both"
+and "a teacher may be promoted to school-admin." In small schools the *same
+person* is both a working teacher (assigned to grades/classes) and the
+administrator. Today the codebase stores a **single** `teachers.role` value
+(`teacher | school_admin`); migration 0059 (#358/#359) added `teacher_capabilities`
+as an **additive** grant store for giving *non-admin* teachers partial
+curriculum powers, and explicitly documents "school_admin is an implicit
+superset (no row needed)." The open question: keep `school_admin` as a role
+value, or split the admin bit into a separate additive flag?
+
+**Q2 — Uniqueness.** ADR-001's entity-rules table and open issue #240 propose a
+`UNIQUE` constraint on `schools.name`. The product owner's call: **email-id
+uniqueness alone is sufficient**; two schools may legitimately share a display
+name (e.g. "St. Mary's").
+
+---
+
+## Decision
+
+### Decision 1 — `school_admin` is a superset *role* on the teacher account, not a separate exclusive role
+
+- An account's **type** is fixed at creation: **teacher XOR student** (spec Rule 6).
+  This is unchanged.
+- **`school_admin` is a role *value* on a teacher account with superset
+  semantics:** a `school_admin` is *fully a teacher too* — they can be assigned
+  to grades/classes and teach (spec Rules 7–9) **in addition to** holding the
+  admin capabilities (spec Rule 10: view all curriculum, onboard teachers/students,
+  add/remove school-admin on a teacher, change student grade/class; and Rule 11:
+  create/modify curriculum + content).
+- The small-school case ("one person is teacher *and* admin") is therefore
+  **already satisfied** by `role = 'school_admin'`. No `is_school_admin` boolean
+  and no mutually-exclusive third role are introduced.
+- Promotion/demotion (spec Rule 10c) is a flip of `teachers.role` between
+  `teacher` and `school_admin`, performed by an existing school_admin.
+- `teacher_capabilities` (migration 0059) **remains** and keeps its stated
+  purpose: granting *non-admin* teachers partial curriculum powers
+  (`curriculum.commission`, `curriculum.review`, `curriculum_mgmt`).
+  `school_admin` stays the implicit superset of all capabilities — **no rows
+  required** for an admin.
+
+**Authority precedence:** `school_admin` (role) ⊃ any `teacher_capabilities`
+grant ⊃ plain `teacher`. Curriculum create/modify (Rule 11) requires
+`school_admin`; capability grants cover the narrower commission/review gates only.
+
+### Decision 2 — Email-id is the sole uniqueness key; school name is NOT unique
+
+- **`schools.contact_email`** — `UNIQUE` (already enforced, migration 0025).
+- **`schools.name`** — **no uniqueness constraint.** Duplicate display names are
+  permitted and expected.
+- **`teachers.email` / `students.email`** — globally `UNIQUE` (per ADR-001),
+  unchanged. A school-admin account is bound to exactly one school via
+  `teachers.school_id` (spec constraint b).
+
+This **supersedes** the `schools.name` uniqueness item in ADR-001's entity-rules
+table and **closes issue #240** as "won't do."
+
+---
+
+## Consequences
+
+### Positive
+- Matches operational reality: a single migration-free model serves both a
+  10-teacher school and a one-person tutor/home-school (the ADR-001 personas).
+- No schema change for roles — `school_admin`-as-superset already works; lower risk.
+- Onboarding never fails on a benign name collision; only the email — the real
+  identity key — must be unique.
+
+### Negative
+- "Role" remains overloaded: `school_admin` encodes both "is an admin" and "is a
+  teacher." Anyone reasoning about permissions must know admin ⊃ teacher. Mitigated
+  by documenting the precedence chain above.
+- Duplicate school names can confuse super-admin search/disambiguation in the
+  console — must surface `contact_email` (the unique key) alongside name in any
+  school picker.
+
+### Neutral
+- The JWT continues to carry a single `role` claim plus a `capabilities[]` array
+  (the 0059 design); no token-shape change.
+
+## Alternatives considered
+
+- **Separate `is_school_admin` boolean (additive flag) alongside `role='teacher'`** —
+  rejected. It duplicates what the `school_admin` superset role already expresses
+  and would force every permission check to test two fields. The additive pattern
+  is already correctly scoped to `teacher_capabilities` for *non-admin* partial grants.
+- **A distinct, mutually-exclusive `school_admin` role that cannot teach** —
+  rejected. Breaks the small-school / tutor / home-school personas (ADR-001) where
+  the admin must also be assigned to grades and teach.
+- **`UNIQUE (schools.name)` per issue #240** — rejected. Email-id uniqueness is
+  sufficient; name collisions are legitimate. Closes #240.
+
+## Migration / rollout
+
+- **No new migration required.**
+  - Roles: `teachers.role ∈ {teacher, school_admin}` and `teacher_capabilities`
+    (0059) already in place; this ADR documents their intended semantics.
+  - Uniqueness: `schools.contact_email` UNIQUE already exists (0025); we
+    deliberately **do not** add `UNIQUE (schools.name)`.
+- **Issue hygiene:** close **#240** referencing this ADR. Cross-check #359 docs
+  to ensure the "school_admin = implicit superset" wording matches Decision 1.
+- **UI:** ensure any super-admin/school school-picker shows `contact_email` next
+  to `name` (names are non-unique).
+- **Spec linkage:** this ADR is the decision record behind the
+  "School User Account Management — Functional Spec" (Type 1).

--- a/docs/SCHOOL_USER_MANAGEMENT.md
+++ b/docs/SCHOOL_USER_MANAGEMENT.md
@@ -1,0 +1,199 @@
+# School User Account Management — Functional Spec
+
+**Status:** Draft · **Scope:** School-tenant user lifecycle · **Audience:** Engineering + Product
+
+> **Decision record:** the role model and uniqueness rules below are locked in
+> [ADR-005](ADR_005_school_roles_and_uniqueness.md). This document is the
+> functional companion to that ADR.
+
+---
+
+## 1. Overview
+
+Defines how user accounts are created, modified, and authenticated within a
+**school tenant**. A school is onboarded by a StudyBuddy **super-admin**, after
+which the school manages its own users under a configurable authentication mode.
+
+---
+
+## 2. Authentication Mode (per-school toggle)
+
+Each school has an authentication-system setting:
+
+| Type | Name | Status | Description |
+|---|---|---|---|
+| **Type 1** | Self-Managed | ✅ Active | The school manages its own user accounts and passwords inside StudyBuddy. |
+| **Type 2** | External System Integration | ⏸️ Deferred | Auth delegated to the school's external identity provider. *Not in scope yet.* |
+
+> The remainder of this document specifies **Type 1 (Self-Managed)**.
+
+---
+
+## 3. Super-Admin Responsibilities (StudyBuddy internal)
+
+The super-admin performs the **initial onboarding only**:
+
+1. **Onboards a new school** — supplies the school **name** and a **valid,
+   pre-existing email-id** already registered with the service provider.
+2. **Onboards the school-admin account(s)** — supplies a valid, pre-existing
+   email-id. A school may have **more than one** school-admin account.
+3. Sets the school's authentication mode (Type 1 by default).
+
+The super-admin does **not** manage teachers, students, or curriculum content.
+
+---
+
+## 4. System-Automated Actions (account provisioning)
+
+On creation of any school-admin (and any provisioned user):
+
+1. **System auto-generates** the initial password.
+2. **System emails** the credentials to the account's email-id for first login.
+3. **System sets password expiry on first login** and **forces a password reset**
+   before any portal access is granted.
+
+---
+
+## 5. Roles
+
+Three roles exist within a school tenant:
+
+| Role | Account type | Notes |
+|---|---|---|
+| **School Admin** | Elevated **teacher** | A teacher account that additionally holds the school-admin capability. |
+| **Teacher** | Teacher | Can be assigned to multiple grades/classes. |
+| **Student** | Student | Can be assigned to multiple grades/classes. |
+
+**Constraints on roles:**
+- An account is **either a teacher or a student — never both** (Rule 6).
+- School-admin is **not a separate account type**; it is a superset role layered
+  on a teacher account, added/removed by an existing school-admin (Rule 10c).
+  A school-admin can also teach (be assigned to grades/classes). See
+  [ADR-005, Decision 1](ADR_005_school_roles_and_uniqueness.md).
+
+---
+
+## 6. School-Level Account Management (Type 1)
+
+The **school** (via its school-admins) is responsible for:
+
+1. Managing user accounts — **Add / Modify / Delete** (Rule 1).
+2. Managing user-account **password resets** (Rule 2).
+3. **Onboarding student accounts** (Rule 4).
+4. Maintaining the required school-admin account(s) (Rule 3).
+
+---
+
+## 7. Grade / Class Assignment
+
+| Subject | Rule | Effect |
+|---|---|---|
+| Teacher | Assigned to **multiple** grades/classes (Rule 7) | Can access materials for those grades/classes (Rule 9). |
+| Student | Assigned to **multiple** grades/classes (Rule 8) | Can access materials for those grades/classes (Rule 9). |
+
+Assignment is the access-control mechanism: **assignment to a grade/class ⇒
+access to that grade/class's materials.**
+
+---
+
+## 8. Permissions Matrix
+
+| Capability | Student | Teacher | School Admin |
+|---|:--:|:--:|:--:|
+| Access materials for **assigned** grades/classes | ✅ | ✅ | ✅ |
+| **View all** grade curriculum | ❌ | ❌ | ✅ (Rule 10a) |
+| Onboard a new **teacher** or **student** | ❌ | ❌ | ✅ (Rule 10b) |
+| Change a teacher's role — **add/remove school-admin** | ❌ | ❌ | ✅ (Rule 10c) |
+| Change a student's grade/class — **add/remove** | ❌ | ❌ | ✅ (Rule 10d) |
+| **Create / modify curriculum** and curriculum/course content | ❌ | ❌ | ✅ (Rule 11) |
+| Manage own account password | ✅ | ✅ | ✅ |
+
+> **Curriculum authority (Rule 11):** Only school-admins may create or modify
+> curriculum and course content. Plain teachers and students cannot. Narrower
+> curriculum capabilities (`curriculum.commission` / `curriculum.review`) may be
+> granted to *non-admin* teachers via `teacher_capabilities` (migration 0059) —
+> see [ADR-005](ADR_005_school_roles_and_uniqueness.md).
+
+**Authority precedence:** `school_admin` ⊃ any `teacher_capabilities` grant ⊃
+plain `teacher`.
+
+---
+
+## 9. Uniqueness & Association Constraints
+
+| # | Constraint | Enforcement |
+|---|---|---|
+| a | School **email-id** is unique | `schools.contact_email` UNIQUE (migration 0025). |
+| a | School **name** is **NOT** required to be unique | No constraint — duplicate names permitted. See [ADR-005, Decision 2](ADR_005_school_roles_and_uniqueness.md). |
+| b | A school-admin account is associated with **exactly one** school | One-school binding via `teachers.school_id`. |
+| — | Teacher / student email-ids are globally unique | `teachers.email` / `students.email` UNIQUE (ADR-001). |
+| — | Email-ids supplied at onboarding must be **valid and pre-existing** | Validated before account creation. |
+
+---
+
+## 10. Lifecycle Flows
+
+### 10.1 School Onboarding (super-admin)
+```
+super-admin
+  → enter school name + valid email-id
+  → system checks: contact_email unique  ──(conflict)──▶ reject
+    (school name may duplicate — not checked)
+  → create school (auth mode = Type 1)
+  → create school-admin account(s)  [≥1; may be more than 1]
+  → system auto-generates password → emails credentials
+```
+
+### 10.2 First Login (any provisioned account)
+```
+user receives emailed credentials
+  → logs in with temporary password
+  → system: password expired on first login → force reset
+  → user sets new password
+  → access granted
+```
+
+### 10.3 User Provisioning (school-admin)
+```
+school-admin
+  → Add teacher OR student   (account type fixed: one or the other)
+  → assign to grade(s)/class(es)
+  → system auto-generates password → emails credentials → first-login reset
+```
+
+### 10.4 Role / Assignment Changes (school-admin)
+```
+school-admin
+  → promote/demote teacher  (add/remove school-admin capability)
+  → add/remove student from grade(s)/class(es)
+  → modify / delete accounts
+  → reset any user's password
+```
+
+---
+
+## 11. Implementation Notes (current Phase-A local auth)
+
+Much of Type 1 is already implemented by the Phase-A local-auth track:
+
+- `POST /schools/register` — school founder registration (`auth_provider='local'`).
+- Auto-generated password + emailed credentials + `first_login=TRUE` on
+  provisioned teachers/students.
+- `first_login=true` forces a redirect to `/school/change-password?required=1`
+  before any portal page renders (enforced at the portal layout).
+- Role stored as `teachers.role ∈ {teacher, school_admin}`; `teacher_capabilities`
+  (migration 0059) provides additive partial grants for non-admin teachers.
+
+See the **Authentication** section of `CLAUDE.md` for the three-track auth model
+and JWT payload shapes.
+
+---
+
+## 12. Open Questions / To Confirm
+
+1. **Rule 3 — "2 user accounts that are part of the school admin":** Is this a
+   **minimum of 2 school-admin accounts per school** (for redundancy), or a
+   default of 2 created at onboarding that can later grow? Stated here as
+   "≥1, may be more"; please confirm the minimum.
+2. **Delete semantics:** Is account "Delete" a hard delete or a deactivate
+   (soft delete)? Relevant for FERPA record-retention on student accounts.

--- a/docs/SCHOOL_USER_MANAGEMENT.md
+++ b/docs/SCHOOL_USER_MANAGEMENT.md
@@ -136,6 +136,39 @@ access to that grade/class's materials.**
 **Authority precedence:** `school_admin` ⊃ any `teacher_capabilities` grant ⊃
 plain `teacher`.
 
+### 8.1 Navigation surfacing — top-bar "Administration" menu
+
+The two `school_admin`-oriented task clusters — **Curriculum Management** and
+**User Management** — are grouped under a single top-bar **"Administration"**
+dropdown (replacing the standalone "Curriculum Management" menu). This pulls
+admin tasks off the left rail, keeping the rail focused on teaching/insights.
+
+**Visibility & per-section gating** (hiding is convenience only — the backend
+enforces every action independently; see the `curriculum_mgmt` design doc):
+
+| Surface | Shown when | Contents |
+|---|---|---|
+| **Administration** button | `school_admin` **OR** `canManageCurriculum` (holds any `curriculum*` capability) | The dropdown itself |
+| → **Curriculum** section | `canManageCurriculum` (admin **or** delegated teacher) | Browse Catalog, My Curricula, Lessons & Content, Curriculum Builder, Review Queue |
+| → **User Management** section | `school_admin` **only** | Students, Teachers (provisioning / roles / grade-class assignment) |
+
+Consequences of the gating:
+- A **plain teacher** sees no Administration button.
+- A **delegated curriculum teacher** (non-admin, holds a `curriculum*` capability)
+  sees Administration with the **Curriculum section only** — preserving the #358 /
+  [ADR-005 Decision 1](ADR_005_school_roles_and_uniqueness.md) delegation model.
+- A **school_admin** sees both sections.
+
+> The button is visible to "school_admin **OR** curriculum-capable", a deliberate
+> refinement of "school_admin only": restricting it strictly to admins would hide
+> curriculum management from delegated teachers, reversing #358.
+
+**Left-rail consequence.** User-management items move from the left rail's
+"People" group into Administration → User Management. The existing left-rail
+**"Administration"** group (Subscription, Storage, Visual Library, Content
+Retention, Backups — infrastructure, not authoring) is **renamed "Settings"** so
+there is only one "Administration" surface (the top-bar menu).
+
 ---
 
 ## 9. Uniqueness & Association Constraints

--- a/docs/SCHOOL_USER_MANAGEMENT.md
+++ b/docs/SCHOOL_USER_MANAGEMENT.md
@@ -36,7 +36,8 @@ The super-admin performs the **initial onboarding only**:
 1. **Onboards a new school** — supplies the school **name** and a **valid,
    pre-existing email-id** already registered with the service provider.
 2. **Onboards the school-admin account(s)** — supplies a valid, pre-existing
-   email-id. A school may have **more than one** school-admin account.
+   email-id. **Minimum 1** school-admin account per school; **≥2 is recommended**
+   for redundancy (so the school is never locked out if one admin is unavailable).
 3. Sets the school's authentication mode (Type 1 by default).
 
 The super-admin does **not** manage teachers, students, or curriculum content.
@@ -77,10 +78,28 @@ Three roles exist within a school tenant:
 
 The **school** (via its school-admins) is responsible for:
 
-1. Managing user accounts — **Add / Modify / Delete** (Rule 1).
+1. Managing user accounts — **Add / Modify / Deactivate** (Rule 1; "Delete" is a
+   soft delete — see §6.1).
 2. Managing user-account **password resets** (Rule 2).
 3. **Onboarding student accounts** (Rule 4).
-4. Maintaining the required school-admin account(s) (Rule 3).
+4. Maintaining the required school-admin account(s) (Rule 3; minimum 1, ≥2 recommended).
+
+### 6.1 Account Deletion = Soft Delete
+
+Account "Delete" is **never a hard delete.** It is a **soft delete (deactivation)**:
+
+- The account is **marked deactivated with a `deactivated_at` date/time stamp**;
+  it can no longer log in and is excluded from active rosters/assignments.
+- The deactivated record is **moved to an archive store**
+  (proposed `user_account_archive` table) **with the deactivation timestamp**, so a
+  returning person can be recognised and re-onboarded later.
+- **Returning users get no implicit access.** A returning person is treated as a
+  **new account**: a `school_admin` must re-grant their role and grade/class
+  access/privileges from scratch. Prior assignments are **not** automatically restored.
+- **FERPA:** soft delete + archive preserves the educational-record retention
+  obligation (progress, scores, lesson-view history) rather than destroying it on
+  deactivation. Hard purge, if ever needed, follows the separate retention/GDPR
+  schedule — not this action.
 
 ---
 
@@ -166,7 +185,7 @@ school-admin
 school-admin
   → promote/demote teacher  (add/remove school-admin capability)
   → add/remove student from grade(s)/class(es)
-  → modify / delete accounts
+  → modify / deactivate (soft-delete → archive) accounts
   → reset any user's password
 ```
 
@@ -189,11 +208,17 @@ and JWT payload shapes.
 
 ---
 
-## 12. Open Questions / To Confirm
+## 12. Resolved Decisions
 
-1. **Rule 3 — "2 user accounts that are part of the school admin":** Is this a
-   **minimum of 2 school-admin accounts per school** (for redundancy), or a
-   default of 2 created at onboarding that can later grow? Stated here as
-   "≥1, may be more"; please confirm the minimum.
-2. **Delete semantics:** Is account "Delete" a hard delete or a deactivate
-   (soft delete)? Relevant for FERPA record-retention on student accounts.
+1. **Minimum school-admin accounts per school — RESOLVED.** Minimum is **1**.
+   **≥2 is prudent** for redundancy in case of issues. Reflected in §3 and §6.
+2. **Delete semantics — RESOLVED.** Use **soft delete**: mark the account
+   deactivated with a `deactivated_at` date/time stamp and archive it (proposed
+   `user_account_archive` table) so the same person can be re-onboarded later. A
+   returning user is treated as a **new account** with no inherited access — a
+   `school_admin` must re-grant role and grade/class privileges. Full semantics in
+   §6.1. (FERPA-aligned: record retention preserved.)
+
+## 13. Open Questions / To Confirm
+
+_None outstanding._


### PR DESCRIPTION
## What

Adds **ADR-005 — School User Roles (school_admin as superset) and Single-Key Uniqueness**, the decision record behind the Type 1 (Self-Managed) school user account management spec.

## Decisions

1. **`school_admin` is a superset *role*** on a teacher account — an admin can also teach / be assigned grades/classes (covers the small-school / tutor / home-school personas). No separate exclusive role and no `is_school_admin` boolean. `teacher_capabilities` (migration 0059) stays scoped to *non-admin* partial grants.
2. **Email-id is the sole uniqueness key.** `schools.contact_email` is UNIQUE (migration 0025); `schools.name` is intentionally **not** unique. Supersedes the `schools.name` uniqueness item in ADR-001 and **closes #240** as "won't do."

## Why

Refines ADR-001 against operational reality surfaced while drafting the Type 1 spec. No schema change required — both decisions are documentation of intended semantics over already-shipped structures.

## Risk

None — docs-only. Status is **Proposed**; flip to Accepted once #240 is closed and any UI school-picker shows `contact_email` alongside the (non-unique) name.

## Notes

- Link integrity checked (ADR-005 clean).
- No `docs/adr/index.md` exists yet; not created (this is only the 3rd ADR present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
