### PR TITLE
docs: reconcile curriculum-menu items with shipped CurriculumMenu.tsx

### DIFF
--- a/docs/DESIGN_curriculum_mgmt_capability.md
+++ b/docs/DESIGN_curriculum_mgmt_capability.md
@@ -111,7 +111,21 @@ returns 403 regardless of the button. Hiding ≠ enforcing.
 
 ### Menu items that move under "Curriculum Management"
 
-Catalog · Our Library · Content Library · Curriculum (builder/upload) · Review Queue.
+As shipped in `web/components/layout/CurriculumMenu.tsx` (5 items):
+
+| Label | Route |
+|---|---|
+| Browse Catalog | `/school/catalog` |
+| My Curricula | `/school/library` |
+| Lessons & Content | `/school/curriculum/content` |
+| Curriculum Builder | `/school/curriculum` |
+| Review Queue | `/school/review` |
+
+> Labels were clarified under issue #367 AP-3 (reviewers couldn't distinguish
+> "Catalog" / "Our Library" / "Content Library"): Catalog → **Browse Catalog**,
+> Our Library → **My Curricula**, Content Library → **Lessons & Content**. See
+> `docs/feedback/VISUAL_VALIDATION_GUIDE.md`.
+
 Content-ops items (Visual Library, Content Retention, Backups, Storage) stay under
 Admin — they're infrastructure, not authoring.
 

--- a/docs/SPEC_curriculum_mgmt_capability.md
+++ b/docs/SPEC_curriculum_mgmt_capability.md
@@ -264,7 +264,7 @@ test("plain teacher does NOT see Curriculum Management", async ({ page }) => {
 test("granted teacher sees the top-bar menu with curriculum items", async ({ page }) => {
   await loginAsTeacher(page, { capabilities: ["curriculum_mgmt"] });
   await page.getByRole("button", { name: /curriculum management/i }).click();
-  await expect(page.getByRole("menuitem", { name: /our library/i })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: /my curricula/i })).toBeVisible();
 });
 
 test("school_admin sees it implicitly (no grant)", async ({ page }) => {


### PR DESCRIPTION
## What

Reconciles the curriculum-menu documentation with the shipped component `web/components/layout/CurriculumMenu.tsx`.

## Why

The "Curriculum Management" top-bar menu's labels were renamed under issue #367 AP-3 (reviewers couldn't distinguish "Catalog" / "Our Library" / "Content Library"). The rename was recorded in the feedback/visual-validation docs, but the **design and spec docs were never updated** — they still listed the pre-rename labels, and the spec's Playwright nav test asserted a menu item (`/our library/i`) that the shipped menu no longer renders.

## Changes

- **`DESIGN_curriculum_mgmt_capability.md`** — replaced the prose menu list with the 5 shipped label→route pairs, plus a note recording the #367 AP-3 rename:

  | Label | Route |
  |---|---|
  | Browse Catalog | `/school/catalog` |
  | My Curricula | `/school/library` |
  | Lessons & Content | `/school/curriculum/content` |
  | Curriculum Builder | `/school/curriculum` |
  | Review Queue | `/school/review` |

- **`SPEC_curriculum_mgmt_capability.md`** — nav test now asserts `/my curricula/i` (was `/our library/i`).

## Risk

None — docs-only. No new link-integrity findings introduced.

## Out of scope

The spec has 4 **pre-existing** doc-audit findings (aspirational test paths referenced before creation, incl. `web/tests/e2e/curriculum-mgmt-nav.spec.ts` which doesn't exist yet) at lines unrelated to this change. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
