### PR TITLE
feat(web): guided "Set up your school" onboarding wizard for school_admins

### DIFF
--- a/web/app/(school)/school/setup/page.tsx
+++ b/web/app/(school)/school/setup/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { useTeacher } from "@/lib/hooks/useTeacher";
+import {
+  listTeachers,
+  getRoster,
+  getLibrary,
+  listClassrooms,
+} from "@/lib/api/school-admin";
+import {
+  computeSetupChecklist,
+  nextIncompleteIndex,
+  type SetupSignals,
+} from "@/lib/school/setup-checklist";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { CheckCircle2, Circle, ArrowRight, Rocket } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export default function SchoolSetupPage() {
+  const teacher = useTeacher();
+  const schoolId = teacher?.school_id ?? "";
+  const enabled = !!schoolId;
+
+  const teachersQ = useQuery({
+    queryKey: ["teachers", schoolId],
+    queryFn: () => listTeachers(schoolId),
+    enabled,
+  });
+  const rosterQ = useQuery({
+    queryKey: ["roster", schoolId],
+    queryFn: () => getRoster(schoolId),
+    enabled,
+  });
+  const libraryQ = useQuery({
+    queryKey: ["library", schoolId],
+    queryFn: () => getLibrary(schoolId),
+    enabled,
+  });
+  const classroomsQ = useQuery({
+    queryKey: ["classrooms", schoolId],
+    queryFn: () => listClassrooms(schoolId),
+    enabled,
+  });
+
+  const loading =
+    teachersQ.isLoading ||
+    rosterQ.isLoading ||
+    libraryQ.isLoading ||
+    classroomsQ.isLoading;
+
+  if (loading) {
+    return (
+      <div className="max-w-2xl space-y-4 p-6">
+        <Skeleton className="h-8 w-64" />
+        {[0, 1, 2, 3, 4, 5].map((i) => (
+          <Skeleton key={i} className="h-20 rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  const classrooms = classroomsQ.data ?? [];
+  const signals: SetupSignals = {
+    teacherCount: (teachersQ.data ?? []).length,
+    studentCount: (rosterQ.data?.roster ?? []).length,
+    activeAdoptionCount: (libraryQ.data?.adoptions ?? []).filter(
+      (a) => a.status === "active",
+    ).length,
+    classroomCount: classrooms.length,
+    classroomsWithPackage: classrooms.filter((c) => c.package_count > 0).length,
+    classroomsWithStudent: classrooms.filter((c) => c.student_count > 0).length,
+  };
+
+  const steps = computeSetupChecklist(signals);
+  const nextIdx = nextIncompleteIndex(steps);
+  const doneCount = steps.filter((s) => s.done).length;
+  const allDone = nextIdx === -1;
+
+  return (
+    <div className="max-w-2xl space-y-6 p-6">
+      <header className="flex items-start gap-3">
+        <Rocket className="mt-0.5 h-6 w-6 shrink-0 text-indigo-600" aria-hidden />
+        <div>
+          <h1 className="text-xl font-bold text-gray-900">Set up your school</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Follow these steps to go from an empty school to students seeing lessons. We
+            tick each one off automatically as you complete it.
+          </p>
+        </div>
+      </header>
+
+      {/* Progress */}
+      <div className="rounded-lg border border-gray-100 bg-white p-4">
+        <div className="mb-2 flex items-center justify-between text-sm">
+          <span className="font-medium text-gray-700">
+            {allDone ? "All set 🎉" : `Step ${doneCount + 1} of ${steps.length}`}
+          </span>
+          <span className="text-gray-400">
+            {doneCount}/{steps.length} done
+          </span>
+        </div>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-gray-100">
+          <div
+            className="h-full rounded-full bg-indigo-600 transition-all"
+            style={{ width: `${(doneCount / steps.length) * 100}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Steps */}
+      <ol className="space-y-3">
+        {steps.map((step, i) => {
+          const isNext = i === nextIdx;
+          return (
+            <li
+              key={step.key}
+              className={cn(
+                "flex items-start gap-3 rounded-lg border p-4 transition-colors",
+                step.done
+                  ? "border-gray-100 bg-white"
+                  : isNext
+                    ? "border-indigo-300 bg-indigo-50 shadow-sm"
+                    : "border-gray-100 bg-white opacity-70",
+              )}
+            >
+              {step.done ? (
+                <CheckCircle2
+                  className="mt-0.5 h-5 w-5 shrink-0 text-green-600"
+                  aria-hidden
+                />
+              ) : (
+                <Circle
+                  className={cn(
+                    "mt-0.5 h-5 w-5 shrink-0",
+                    isNext ? "text-indigo-600" : "text-gray-300",
+                  )}
+                  aria-hidden
+                />
+              )}
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-medium text-gray-400">
+                    {String(i + 1).padStart(2, "0")}
+                  </span>
+                  <p
+                    className={cn(
+                      "font-medium",
+                      step.done ? "text-gray-500 line-through" : "text-gray-900",
+                    )}
+                  >
+                    {step.title}
+                  </p>
+                  {isNext && (
+                    <span className="rounded-full bg-indigo-600 px-2 py-0.5 text-xs font-medium text-white">
+                      Next
+                    </span>
+                  )}
+                </div>
+                <p className="mt-1 text-sm text-gray-500">{step.description}</p>
+              </div>
+              <Link href={step.href} className="shrink-0 self-center">
+                <Button
+                  size="sm"
+                  variant={isNext ? "default" : "outline"}
+                  className="gap-1"
+                >
+                  {step.done ? "Review" : "Go"}
+                  <ArrowRight className="h-3.5 w-3.5" aria-hidden />
+                </Button>
+              </Link>
+            </li>
+          );
+        })}
+      </ol>
+
+      {allDone && (
+        <div className="rounded-lg border border-green-200 bg-green-50 p-4 text-sm text-green-800">
+          Your school is set up. Students enrolled in a class with an assigned curriculum
+          can log in and start learning.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/layout/SchoolNav.tsx
+++ b/web/components/layout/SchoolNav.tsx
@@ -20,6 +20,7 @@ import {
   Images,
   DoorOpen,
   Database,
+  Rocket,
   ChevronDown,
   ChevronRight,
 } from "lucide-react";
@@ -53,6 +54,13 @@ const NAV_GROUPS: NavGroup[] = [
         label: "Dashboard",
         href: "/school/dashboard",
         icon: <LayoutDashboard className="h-4 w-4" />,
+      },
+      {
+        // Guided onboarding checklist for school_admins (#415 follow-up).
+        label: "Get started",
+        href: "/school/setup",
+        icon: <Rocket className="h-4 w-4" />,
+        adminOnly: true,
       },
     ],
   },

--- a/web/lib/school/setup-checklist.ts
+++ b/web/lib/school/setup-checklist.ts
@@ -1,0 +1,84 @@
+/**
+ * Guided "Set up your school" checklist (issue: school_admin onboarding wizard).
+ *
+ * Pure, data-driven step computation so it can be unit-tested without rendering.
+ * Each step's `done` is derived from signals the school portal already exposes
+ * (teacher/student/adoption/classroom counts) — no new backend endpoints.
+ */
+
+export interface SetupSignals {
+  teacherCount: number;
+  studentCount: number;
+  activeAdoptionCount: number;
+  classroomCount: number;
+  /** classrooms that have ≥1 curriculum package assigned */
+  classroomsWithPackage: number;
+  /** classrooms that have ≥1 student enrolled */
+  classroomsWithStudent: number;
+}
+
+export interface SetupStep {
+  key: string;
+  title: string;
+  description: string;
+  href: string;
+  done: boolean;
+}
+
+/**
+ * The ordered onboarding sequence (Path A — Adopt). Order matters: each step
+ * unlocks the next, and the UI highlights the first not-yet-done step.
+ */
+export function computeSetupChecklist(s: SetupSignals): SetupStep[] {
+  return [
+    {
+      key: "teachers",
+      title: "Add your teachers",
+      description:
+        "Provision teacher accounts. Each gets a login and a first-time password.",
+      href: "/school/teachers",
+      done: s.teacherCount > 0,
+    },
+    {
+      key: "students",
+      title: "Add your students",
+      description: "Provision student accounts so they can be enrolled into classes.",
+      href: "/school/students",
+      done: s.studentCount > 0,
+    },
+    {
+      key: "adopt",
+      title: "Adopt a curriculum",
+      description:
+        "Browse the catalog and adopt a curriculum into your school's library.",
+      href: "/school/catalog",
+      done: s.activeAdoptionCount > 0,
+    },
+    {
+      key: "classroom",
+      title: "Create a class",
+      description: "Create a classroom for a grade/section you teach.",
+      href: "/school/classrooms",
+      done: s.classroomCount > 0,
+    },
+    {
+      key: "assign",
+      title: "Assign a curriculum to a class",
+      description: "Open a class and pick one of your adopted curricula to assign.",
+      href: "/school/classrooms",
+      done: s.classroomsWithPackage > 0,
+    },
+    {
+      key: "enrol",
+      title: "Enrol students in a class",
+      description: "Add students to a class so they see its curriculum when they log in.",
+      href: "/school/classrooms",
+      done: s.classroomsWithStudent > 0,
+    },
+  ];
+}
+
+/** Index of the first not-done step, or -1 when everything is complete. */
+export function nextIncompleteIndex(steps: SetupStep[]): number {
+  return steps.findIndex((step) => !step.done);
+}

--- a/web/tests/unit/setup-checklist.test.ts
+++ b/web/tests/unit/setup-checklist.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeSetupChecklist,
+  nextIncompleteIndex,
+  type SetupSignals,
+} from "@/lib/school/setup-checklist";
+
+const empty: SetupSignals = {
+  teacherCount: 0,
+  studentCount: 0,
+  activeAdoptionCount: 0,
+  classroomCount: 0,
+  classroomsWithPackage: 0,
+  classroomsWithStudent: 0,
+};
+
+describe("computeSetupChecklist (school onboarding wizard)", () => {
+  it("has the 6 ordered steps", () => {
+    const keys = computeSetupChecklist(empty).map((s) => s.key);
+    expect(keys).toEqual([
+      "teachers",
+      "students",
+      "adopt",
+      "classroom",
+      "assign",
+      "enrol",
+    ]);
+  });
+
+  it("all steps not-done for an empty school; first incomplete is step 0", () => {
+    const steps = computeSetupChecklist(empty);
+    expect(steps.every((s) => !s.done)).toBe(true);
+    expect(nextIncompleteIndex(steps)).toBe(0);
+  });
+
+  it("marks each step done from its signal", () => {
+    const full: SetupSignals = {
+      teacherCount: 2,
+      studentCount: 5,
+      activeAdoptionCount: 1,
+      classroomCount: 1,
+      classroomsWithPackage: 1,
+      classroomsWithStudent: 1,
+    };
+    const steps = computeSetupChecklist(full);
+    expect(steps.every((s) => s.done)).toBe(true);
+    expect(nextIncompleteIndex(steps)).toBe(-1);
+  });
+
+  it("points at the assign step when classes exist but none has a package", () => {
+    const s: SetupSignals = {
+      ...empty,
+      teacherCount: 1,
+      studentCount: 1,
+      activeAdoptionCount: 1,
+      classroomCount: 1,
+      classroomsWithPackage: 0,
+      classroomsWithStudent: 0,
+    };
+    const steps = computeSetupChecklist(s);
+    expect(steps[nextIncompleteIndex(steps)].key).toBe("assign");
+  });
+
+  it("every step has a /school deep-link", () => {
+    for (const step of computeSetupChecklist(empty)) {
+      expect(step.href.startsWith("/school/")).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## What
A guided **"Set up your school"** checklist at `/school/setup` that leads a school_admin through the full onboarding journey, ticking each step off automatically from existing data.

## Why
The curriculum → class → students tasks were spread across Catalog, My Curricula, and Classrooms with nothing connecting them — school_admins (incl. during the MilfordWaterford walkthrough) couldn't tell what to do next. This sequences them.

## The 6 steps (auto-detected, deep-linked)
| # | Step | Done when | Goes to |
|---|---|---|---|
| 1 | Add your teachers | teacherCount > 0 | /school/teachers |
| 2 | Add your students | roster > 0 | /school/students |
| 3 | Adopt a curriculum | active adoptions > 0 | /school/catalog |
| 4 | Create a class | classrooms > 0 | /school/classrooms |
| 5 | Assign a curriculum to a class | a classroom has a package | /school/classrooms |
| 6 | Enrol students in a class | a classroom has a student | /school/classrooms |

Each row shows done / **Next** / upcoming, with a progress bar and a CTA to the right existing screen. The first incomplete step is highlighted.

## Design choices (confirmed with product owner)
- **Guided checklist + deep-links** (reuses existing screens; auto-detects completion) — not a full inline wizard.
- Coverage = **people + content + class** (the complete empty-school → students-see-lessons path).

## How
- Pure, **unit-tested** step logic in `web/lib/school/setup-checklist.ts` (5 tests: ordering, all-empty, all-done, next-incomplete targeting, deep-link shape).
- Page `web/app/(school)/school/setup/page.tsx` runs 4 existing queries (`listTeachers`, `getRoster`, `getLibrary`, `listClassrooms`) — **no backend change**.
- **"Get started"** rail entry (school_admin only) in `SchoolNav`.

## Test plan
- 5 unit tests pass; ESLint / `tsc` / Prettier clean.
- Against live MilfordWaterford data the wizard correctly shows steps 1–5 done and **"Enrol students" as Next** (we never enrolled) — i.e. it points the user at exactly what they were missing.
- Dependency-heavy page; recommend a host Playwright/manual pass per pitfall #26.

## Follow-ups
- Optional "Customize content" (import/edit + approve) step — omitted as optional.
- Could surface the checklist as a dashboard card for newly-registered schools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
