### PR TITLE
test(curriculum): unique register email per test to fix flaky 409 (#421)

### DIFF
--- a/backend/tests/test_curriculum_upload.py
+++ b/backend/tests/test_curriculum_upload.py
@@ -16,14 +16,11 @@ Also unit-tests for:
 from __future__ import annotations
 
 import io
-import json
 import uuid
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from httpx import AsyncClient
-
-from tests.helpers.token_factory import make_teacher_token
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -48,10 +45,19 @@ _VALID_UNITS = [
 
 
 async def _register_school(client: AsyncClient, suffix: str = "") -> dict:
-    """Register a school and return {school_id, teacher_id, access_token}."""
+    """Register a school and return {school_id, teacher_id, access_token}.
+
+    The email carries a random token so registrations never collide across tests.
+    The `client` fixture writes via the app pool, which commits and bypasses the
+    per-test `db_conn` transaction rollback — so schools/accounts persist for the
+    whole session. With a static email, register's global email-uniqueness check
+    intermittently 409s depending on test ordering (issue #421). A unique email
+    per call removes that flake.
+    """
+    token = uuid.uuid4().hex[:12]
     r = await client.post("/api/v1/schools/register", json={
         "school_name": f"Upload Test School{suffix}",
-        "contact_email": f"upload{suffix}@testschool.example.com",
+        "contact_email": f"upload{suffix}-{token}@testschool.example.com",
         "country": "US",
         "password": "SecureTestPwd1!",
     })
@@ -276,6 +282,7 @@ async def test_upload_xlsx_wrong_sheet_name_returns_400(client: AsyncClient):
 def test_parse_xlsx_missing_required_column():
     """parse_xlsx returns error when required column is missing."""
     import openpyxl
+
     from src.curriculum.upload_service import parse_xlsx
 
     wb = openpyxl.Workbook()
@@ -294,6 +301,7 @@ def test_parse_xlsx_missing_required_column():
 def test_parse_xlsx_wrong_sheet_name():
     """parse_xlsx returns error when sheet name doesn't match grade."""
     import openpyxl
+
     from src.curriculum.upload_service import parse_xlsx
 
     wb = openpyxl.Workbook()
@@ -311,6 +319,7 @@ def test_parse_xlsx_wrong_sheet_name():
 def test_parse_xlsx_valid_data():
     """parse_xlsx correctly parses a well-formed sheet."""
     import openpyxl
+
     from src.curriculum.upload_service import parse_xlsx
 
     wb = openpyxl.Workbook()


### PR DESCRIPTION
Closes #421.

## What
`_register_school` in `tests/test_curriculum_upload.py` now embeds a `uuid4()` token in the `contact_email`, so registrations never collide across tests.

## Why
The `client` fixture writes via the app pool — those commits **bypass the per-test `db_conn` rollback**, so schools/accounts persist for the whole pytest session. With a static email, `register_school`'s global email-uniqueness check intermittently returned **409** depending on test ordering, randomly red-ing Backend — Tests and blocking merges (seen on #419/#420 runs; passed on re-run).

## Fix
Unique email per `_register_school` call eliminates the whole class of register-email collisions in this file — no product code touched.

## Test plan
- `tests/test_curriculum_upload.py`: **22/22 pass** against a fresh test DB.
- `ruff check` clean.

## Note
Other test files have their own `_register_school` helpers (e.g. `test_backup.py`) with the same latent pattern but distinct email domains; not changed here. If they flake later, the same one-line treatment applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)