### PR TITLE
fix(backup): reconcile restore path with the real schema (#411)

### DIFF
--- a/backend/src/backup/tasks.py
+++ b/backend/src/backup/tasks.py
@@ -546,9 +546,7 @@ def dry_run_restore_task(request_id: str) -> None:
                     backup_data = json.loads(backup_data_bytes)
                     # curricula PK is curriculum_id (TEXT); content_subject_versions
                     # keys on curriculum_id (TEXT) too — pass IDs as text, not UUID.
-                    curriculum_ids = [
-                        c["curriculum_id"] for c in backup_data.get("curricula", [])
-                    ]
+                    curriculum_ids = [c["curriculum_id"] for c in backup_data.get("curricula", [])]
 
                     if curriculum_ids:
                         # A version generated after the backup was taken is a conflict.
@@ -592,9 +590,7 @@ def dry_run_restore_task(request_id: str) -> None:
                         )
                         staging_name = f"{orig_name}.restore-staging.{today_str}"
                         first_cur = (
-                            backup_data["curricula"][0]
-                            if backup_data.get("curricula")
-                            else {}
+                            backup_data["curricula"][0] if backup_data.get("curricula") else {}
                         )
                         # curricula.curriculum_id is a TEXT PK with no default and
                         # year is NOT NULL — supply both. A UUID string also fits

--- a/backend/src/backup/tasks.py
+++ b/backend/src/backup/tasks.py
@@ -544,18 +544,25 @@ def dry_run_restore_task(request_id: str) -> None:
                         f"{school_id}/{backup_id}/backup_data.json"
                     )
                     backup_data = json.loads(backup_data_bytes)
-                    curriculum_ids = [c["id"] for c in backup_data.get("curricula", [])]
+                    # curricula PK is curriculum_id (TEXT); content_subject_versions
+                    # keys on curriculum_id (TEXT) too — pass IDs as text, not UUID.
+                    curriculum_ids = [
+                        c["curriculum_id"] for c in backup_data.get("curricula", [])
+                    ]
 
                     if curriculum_ids:
-                        c_uuids = [uuid.UUID(c) for c in curriculum_ids]
+                        # A version generated after the backup was taken is a conflict.
+                        # (content_subject_versions PK is version_id; it has
+                        # generated_at, not an updated_at column.)
                         conflict_rows = await conn.fetch(
                             """
-                            SELECT id, curriculum_id, subject, version_number, updated_at
+                            SELECT version_id, curriculum_id, subject, version_number,
+                                   generated_at
                             FROM content_subject_versions
                             WHERE curriculum_id = ANY($1)
-                              AND updated_at > $2
+                              AND generated_at > $2
                             """,
-                            c_uuids,
+                            curriculum_ids,
                             backup_created_at,
                         )
                         conflicts = [dict(r) for r in conflict_rows]
@@ -584,20 +591,28 @@ def dry_run_restore_task(request_id: str) -> None:
                             else "unknown"
                         )
                         staging_name = f"{orig_name}.restore-staging.{today_str}"
-                        staging_row = await conn.fetchrow(
+                        first_cur = (
+                            backup_data["curricula"][0]
+                            if backup_data.get("curricula")
+                            else {}
+                        )
+                        # curricula.curriculum_id is a TEXT PK with no default and
+                        # year is NOT NULL — supply both. A UUID string also fits
+                        # conflict_catalog_id (UUID) set below.
+                        staging_curriculum_id = str(uuid.uuid4())
+                        await conn.execute(
                             """
                             INSERT INTO curricula
-                                (school_id, name, grade, owner_type, status)
-                            VALUES ($1, $2, $3, 'school', 'draft')
-                            RETURNING id
+                                (curriculum_id, school_id, name, grade, year,
+                                 owner_type, status)
+                            VALUES ($1, $2, $3, $4, $5, 'school', 'draft')
                             """,
+                            staging_curriculum_id,
                             uuid.UUID(school_id),
                             staging_name,
-                            backup_data["curricula"][0].get("grade", 0)
-                            if backup_data.get("curricula")
-                            else 0,
+                            first_cur.get("grade", 0),
+                            first_cur.get("year", 0),
                         )
-                        staging_curriculum_id = str(staging_row["id"])
 
                         await conn.execute(
                             """
@@ -620,7 +635,7 @@ def dry_run_restore_task(request_id: str) -> None:
                         # Email school contact + super-admin about conflicts
                         conflict_summary = "\n".join(
                             f"  - subject={c.get('subject')} version={c.get('version_number')} "
-                            f"updated={c.get('updated_at')}"
+                            f"generated={c.get('generated_at')}"
                             for c in conflicts[:20]
                         )
                         if contact_email:
@@ -752,69 +767,74 @@ def execute_restore_task(request_id: str) -> None:
                     await _bypass(conn)
 
                     for cur in backup_data.get("curricula", []):
-                        orig_id = cur["id"]
+                        # curricula PK is curriculum_id (TEXT), not id; year is NOT NULL.
+                        orig_id = cur["curriculum_id"]
                         if side_by_side:
-                            # Create a new curriculum row with a dated name
+                            # Create a NEW curriculum (UUID-string id) with a dated name.
                             new_name = f"{cur.get('name', orig_id)}.{today_str}"
-                            new_row = await conn.fetchrow(
+                            target_id = str(uuid.uuid4())
+                            await conn.execute(
                                 """
                                 INSERT INTO curricula
-                                    (school_id, name, grade, owner_type, status, stream_code)
-                                VALUES ($1, $2, $3, $4, $5, $6)
-                                RETURNING id
+                                    (curriculum_id, school_id, name, grade, year,
+                                     owner_type, status, stream_code)
+                                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
                                 """,
+                                target_id,
                                 uuid.UUID(school_id),
                                 new_name,
                                 cur.get("grade", 0),
+                                cur.get("year", 0),
                                 cur.get("owner_type", "school"),
                                 cur.get("status", "active"),
                                 cur.get("stream_code"),
                             )
-                            target_id = str(new_row["id"])
                         else:
-                            # Upsert into existing curriculum row
+                            # Upsert into the original curriculum row (by curriculum_id).
                             await conn.execute(
                                 """
                                 INSERT INTO curricula
-                                    (id, school_id, name, grade, owner_type, status, stream_code)
-                                VALUES ($1, $2, $3, $4, $5, $6, $7)
-                                ON CONFLICT (id) DO UPDATE
-                                SET name=$3, grade=$4, owner_type=$5,
-                                    status=$6, stream_code=$7
+                                    (curriculum_id, school_id, name, grade, year,
+                                     owner_type, status, stream_code)
+                                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                                ON CONFLICT (curriculum_id) DO UPDATE
+                                SET name=$3, grade=$4, year=$5, owner_type=$6,
+                                    status=$7, stream_code=$8
                                 """,
-                                uuid.UUID(orig_id),
+                                orig_id,
                                 uuid.UUID(school_id),
                                 cur.get("name", ""),
                                 cur.get("grade", 0),
+                                cur.get("year", 0),
                                 cur.get("owner_type", "school"),
                                 cur.get("status", "active"),
                                 cur.get("stream_code"),
                             )
                             target_id = orig_id
 
-                        # Restore curriculum_units
+                        # Restore curriculum_units. PK is (unit_id, curriculum_id);
+                        # the real columns are subject/title/unit_name/has_lab/sort_order
+                        # (no id / grade / ordering).
                         for unit in backup_data.get("curriculum_units", []):
                             if unit.get("curriculum_id") != orig_id:
                                 continue
                             await conn.execute(
                                 """
                                 INSERT INTO curriculum_units
-                                    (id, curriculum_id, unit_id, title, unit_name,
-                                     subject, grade, has_lab, ordering)
-                                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-                                ON CONFLICT (id) DO UPDATE
-                                SET title=$4, unit_name=$5, subject=$6,
-                                    grade=$7, has_lab=$8, ordering=$9
+                                    (unit_id, curriculum_id, subject, title,
+                                     unit_name, has_lab, sort_order)
+                                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                                ON CONFLICT (unit_id, curriculum_id) DO UPDATE
+                                SET subject=$3, title=$4, unit_name=$5,
+                                    has_lab=$6, sort_order=$7
                                 """,
-                                uuid.UUID(unit["id"]),
-                                uuid.UUID(target_id),
                                 unit.get("unit_id", ""),
+                                target_id,
+                                unit.get("subject", ""),
                                 unit.get("title", ""),
                                 unit.get("unit_name") or unit.get("title", ""),
-                                unit.get("subject", ""),
-                                unit.get("grade", 0),
                                 unit.get("has_lab", False),
-                                unit.get("ordering", 0),
+                                unit.get("sort_order", 0),
                             )
 
                     # Write content files from backup storage to content store

--- a/backend/tests/test_backup.py
+++ b/backend/tests/test_backup.py
@@ -25,6 +25,7 @@ Coverage:
 from __future__ import annotations
 
 import uuid
+from datetime import UTC
 from unittest.mock import patch
 
 import pytest
@@ -661,3 +662,152 @@ async def test_full_backup_curricula_id_and_dependent_query(db_conn):
     assert units_rows[0]["unit_id"] == "G8-MATH-001"
     assert len(versions_rows) == 1
     assert versions_rows[0]["subject"] == "Mathematics"
+
+
+# ── Regression: restore SQL matches the real schema (issue #411) ────────────────
+
+
+async def test_restore_execute_sql_matches_schema(db_conn):
+    """Regression for #411: execute_restore_task referenced columns that don't
+    exist (`id`, `grade`, `ordering`), omitted the NOT NULL `year`, wrapped TEXT
+    curriculum_id in uuid.UUID(), and used `ON CONFLICT (id)`. This runs the
+    corrected curricula + curriculum_units upserts against the real schema, with a
+    backup_data-shaped payload (the shape `backup_school_task._row_to_dict`
+    produces), and asserts they land — and are idempotent on re-run.
+    """
+    school_id = uuid.uuid4()
+    curriculum_id = str(uuid.uuid4())  # school fork ids are UUID strings (TEXT col)
+    await db_conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+    await db_conn.execute(
+        """
+        INSERT INTO schools (school_id, name, contact_email, status)
+        VALUES ($1, 'Restore Regression School', $2, 'active')
+        """,
+        school_id,
+        f"restore_{str(school_id)[:8]}@example.com",
+    )
+
+    cur = {
+        "curriculum_id": curriculum_id,
+        "name": "Restored G8 STEM",
+        "grade": 8,
+        "year": 2026,
+        "owner_type": "school",
+        "status": "active",
+        "stream_code": None,
+    }
+    unit = {
+        "unit_id": "G8-MATH-001",
+        "curriculum_id": curriculum_id,
+        "subject": "Mathematics",
+        "title": "Fractions",
+        "unit_name": "Fractions",
+        "has_lab": False,
+        "sort_order": 0,
+    }
+
+    async def restore_once():
+        # Exact in-place upserts from execute_restore_task (post-#411).
+        await db_conn.execute(
+            """
+            INSERT INTO curricula
+                (curriculum_id, school_id, name, grade, year, owner_type, status, stream_code)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            ON CONFLICT (curriculum_id) DO UPDATE
+            SET name=$3, grade=$4, year=$5, owner_type=$6, status=$7, stream_code=$8
+            """,
+            cur["curriculum_id"],
+            school_id,
+            cur["name"],
+            cur["grade"],
+            cur["year"],
+            cur["owner_type"],
+            cur["status"],
+            cur["stream_code"],
+        )
+        await db_conn.execute(
+            """
+            INSERT INTO curriculum_units
+                (unit_id, curriculum_id, subject, title, unit_name, has_lab, sort_order)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (unit_id, curriculum_id) DO UPDATE
+            SET subject=$3, title=$4, unit_name=$5, has_lab=$6, sort_order=$7
+            """,
+            unit["unit_id"],
+            curriculum_id,
+            unit["subject"],
+            unit["title"],
+            unit["unit_name"],
+            unit["has_lab"],
+            unit["sort_order"],
+        )
+
+    await restore_once()
+    await restore_once()  # idempotent — must not error or duplicate
+
+    crow = await db_conn.fetchrow(
+        "SELECT name, grade, year, owner_type FROM curricula WHERE curriculum_id=$1",
+        curriculum_id,
+    )
+    assert crow["name"] == "Restored G8 STEM"
+    assert crow["grade"] == 8
+    assert crow["year"] == 2026
+    urows = await db_conn.fetch(
+        "SELECT unit_name, sort_order FROM curriculum_units WHERE curriculum_id=$1",
+        curriculum_id,
+    )
+    assert len(urows) == 1  # upsert, not duplicate
+    assert urows[0]["unit_name"] == "Fractions"
+
+
+async def test_restore_dry_run_sql_matches_schema(db_conn):
+    """Regression for #411: dry_run_restore_task selected non-existent columns
+    (`id`, `updated_at`) on content_subject_versions and wrapped TEXT ids in
+    uuid.UUID(); the staging-curriculum INSERT omitted curriculum_id + the NOT
+    NULL year. Run the corrected conflict query and staging insert.
+    """
+    school_id = uuid.uuid4()
+    curriculum_id = str(uuid.uuid4())
+    await db_conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+    await db_conn.execute(
+        """
+        INSERT INTO schools (school_id, name, contact_email, status)
+        VALUES ($1, 'Restore DryRun School', $2, 'active')
+        """,
+        school_id,
+        f"dryrun_{str(school_id)[:8]}@example.com",
+    )
+
+    # Conflict query (corrected: version_id + generated_at, TEXT ids) must validate.
+    from datetime import datetime
+
+    rows = await db_conn.fetch(
+        """
+        SELECT version_id, curriculum_id, subject, version_number, generated_at
+        FROM content_subject_versions
+        WHERE curriculum_id = ANY($1)
+          AND generated_at > $2
+        """,
+        [curriculum_id],
+        datetime(2000, 1, 1, tzinfo=UTC),
+    )
+    assert rows == []  # no versions yet — but the query columns all resolve
+
+    # Staging-curriculum INSERT (corrected: supplies curriculum_id + NOT NULL year).
+    await db_conn.execute(
+        """
+        INSERT INTO curricula
+            (curriculum_id, school_id, name, grade, year, owner_type, status)
+        VALUES ($1, $2, $3, $4, $5, 'school', 'draft')
+        """,
+        curriculum_id,
+        school_id,
+        "Staged.restore-staging.20260609",
+        8,
+        2026,
+    )
+    row = await db_conn.fetchrow(
+        "SELECT status, owner_type FROM curricula WHERE curriculum_id=$1", curriculum_id
+    )
+    assert row["status"] == "draft"
+    assert row["owner_type"] == "school"


### PR DESCRIPTION
Closes #411.

## What
Fixes the restore path (`dry_run_restore_task` + `execute_restore_task` in `backend/src/backup/tasks.py`), which was written against a schema that doesn't exist — the same family as the #410 backup bug, plus more. Latent until #410 made backups succeed; now reachable.

## Bugs fixed
**dry_run_restore_task**
- `c["id"]` → `c["curriculum_id"]` (curricula PK is TEXT)
- conflict query selected non-existent `id` / `updated_at` on `content_subject_versions` → `version_id` + `generated_at`; pass TEXT ids (dropped `uuid.UUID()` wrap)
- staging-curriculum INSERT omitted `curriculum_id` (TEXT PK, no default) and NOT NULL `year` → supplies both (a UUID-string id, which also fits the UUID `conflict_catalog_id`); dropped `RETURNING id`
- conflict email used `updated_at` → `generated_at`

**execute_restore_task**
- `cur["id"]` → `cur["curriculum_id"]`
- curricula upserts used `id` / `ON CONFLICT (id)` / `RETURNING id` and omitted `year` → `curriculum_id`, `ON CONFLICT (curriculum_id)`, supply `year`; side-by-side now generates a UUID-string id (no non-existent default)
- `curriculum_units` INSERT referenced `id`/`grade`/`ordering` + `ON CONFLICT (id)` → real columns (`unit_id, curriculum_id, subject, title, unit_name, has_lab, sort_order`) with `ON CONFLICT (unit_id, curriculum_id)`; dropped `uuid.UUID()` wraps

## Test plan
- 2 new regression tests run the corrected upserts + dry-run conflict/staging SQL against the **real schema** (idempotent on re-run). **31/31** backup tests pass. `ruff` clean.

## Scope note
This fixes the existing operations (curricula + units + content files). Restoring `content_subject_versions` rows themselves is still not done by `execute_restore_task` (it wasn't before either) — a reasonable follow-up so restored curricula show full version metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)