### PR TITLE
fix(backup): stop leaking internal identifiers in failure emails (#413)

### DIFF
--- a/backend/src/backup/tasks.py
+++ b/backend/src/backup/tasks.py
@@ -58,59 +58,61 @@ def _now_iso() -> str:
 @celery_app.task(name="src.backup.tasks.send_backup_notification_task", bind=False)
 def send_backup_notification_task(
     to_email: str,
-    event: str,  # 'backup_completed' | 'backup_failed' | 'restore_completed' | 'restore_failed'
+    event: str,  # 'backup_completed' | 'backup_failed' | 'restore_completed' | 'restore_failed' | 'restore_awaiting_confirm'
     school_id: str,
     backup_id: str,
     scope_type: str,
     scope_value: str | None = None,
-    error_msg: str | None = None,
 ) -> None:
-    """Send a simple notification email for backup/restore lifecycle events."""
+    """Send a customer-facing notification email for backup/restore lifecycle events.
+
+    Customer copy ONLY — this MUST NOT expose internal identifiers (school /
+    backup UUIDs), event names, HTTP status, or raw exception text (Content
+    Rule #5; issue #413). The `school_id` / `backup_id` args are context for the
+    queue/logs, never rendered into the email. Technical diagnostics for failures
+    live in the structured logs emitted by the caller (e.g. `backup_failed`),
+    not in the recipient's inbox.
+    """
 
     async def _send() -> None:
         from src.email.service import _send as send_email
 
+        scope_label = f"{scope_type}" + (f": {scope_value}" if scope_value else "")
+
         subject_map = {
             "backup_completed": f"StudyBuddy: Curriculum backup completed ({scope_type})",
-            "backup_failed": f"StudyBuddy: Curriculum backup FAILED ({scope_type})",
+            "backup_failed": f"StudyBuddy: Curriculum backup couldn't be completed ({scope_type})",
             "restore_completed": f"StudyBuddy: Curriculum restore completed ({scope_type})",
-            "restore_failed": f"StudyBuddy: Curriculum restore FAILED ({scope_type})",
+            "restore_failed": f"StudyBuddy: Curriculum restore couldn't be completed ({scope_type})",
+            "restore_awaiting_confirm": f"StudyBuddy: Curriculum restore needs your review ({scope_type})",
         }
-        subject = subject_map.get(event, f"StudyBuddy: Backup event — {event}")
+        subject = subject_map.get(event, "StudyBuddy: Curriculum backup update")
 
-        scope_label = f"{scope_type}" + (f": {scope_value}" if scope_value else "")
-        if error_msg:
-            text = (
-                f"Event: {event}\n"
-                f"School: {school_id}\n"
-                f"Backup ID: {backup_id}\n"
-                f"Scope: {scope_label}\n\n"
-                f"Error: {error_msg}\n\n"
-                "— The StudyBuddy Team"
-            )
-            html = (
-                f"<p><strong>Event:</strong> {event}</p>"
-                f"<p><strong>School:</strong> {school_id}</p>"
-                f"<p><strong>Backup ID:</strong> {backup_id}</p>"
-                f"<p><strong>Scope:</strong> {scope_label}</p>"
-                f"<p style='color:#dc2626'><strong>Error:</strong> {error_msg}</p>"
-                "<p>— The StudyBuddy Team</p>"
-            )
-        else:
-            text = (
-                f"Event: {event}\n"
-                f"School: {school_id}\n"
-                f"Backup ID: {backup_id}\n"
-                f"Scope: {scope_label}\n\n"
-                "— The StudyBuddy Team"
-            )
-            html = (
-                f"<p><strong>Event:</strong> {event}</p>"
-                f"<p><strong>School:</strong> {school_id}</p>"
-                f"<p><strong>Backup ID:</strong> {backup_id}</p>"
-                f"<p><strong>Scope:</strong> {scope_label}</p>"
-                "<p>— The StudyBuddy Team</p>"
-            )
+        message_map = {
+            "backup_completed": f"Your curriculum backup ({scope_label}) completed successfully.",
+            "backup_failed": (
+                f"We hit a problem creating your curriculum backup ({scope_label}). "
+                "Our team has been notified automatically and is looking into it — "
+                "there's nothing you need to do."
+            ),
+            "restore_completed": f"Your curriculum restore ({scope_label}) completed successfully.",
+            "restore_failed": (
+                f"We hit a problem restoring your curriculum ({scope_label}). "
+                "Our team has been notified automatically and is looking into it — "
+                "there's nothing you need to do."
+            ),
+            "restore_awaiting_confirm": (
+                f"Your curriculum restore ({scope_label}) needs your review: some content "
+                "has changed since this backup was taken. Open Restore Requests in your "
+                "school portal to review and confirm before it proceeds."
+            ),
+        }
+        message = message_map.get(
+            event, f"There's an update on your curriculum backup ({scope_label})."
+        )
+
+        text = f"{message}\n\n— The StudyBuddy Team"
+        html = f"<p>{message}</p><p>— The StudyBuddy Team</p>"
 
         try:
             await send_email(
@@ -437,7 +439,6 @@ def backup_school_task(
                     backup_id=backup_id,
                     scope_type=scope_type,
                     scope_value=scope_value,
-                    error_msg=str(exc),
                 )
             raise
         finally:
@@ -628,12 +629,9 @@ def dry_run_restore_task(request_id: str) -> None:
                             staging_curriculum_id=staging_curriculum_id,
                         )
 
-                        # Email school contact + super-admin about conflicts
-                        conflict_summary = "\n".join(
-                            f"  - subject={c.get('subject')} version={c.get('version_number')} "
-                            f"generated={c.get('generated_at')}"
-                            for c in conflicts[:20]
-                        )
+                        # Notify the school their restore needs review. Conflict
+                        # specifics (subjects/versions/staging curriculum) are
+                        # visible in the portal — never emailed (Content Rule #5).
                         if contact_email:
                             send_backup_notification_task.delay(
                                 to_email=contact_email,
@@ -642,11 +640,6 @@ def dry_run_restore_task(request_id: str) -> None:
                                 backup_id=backup_id,
                                 scope_type=scope_type,
                                 scope_value=scope_value,
-                                error_msg=(
-                                    f"{len(conflicts)} conflicting content versions found "
-                                    f"(updated after backup):\n{conflict_summary}\n\n"
-                                    f"A staging curriculum has been created: {staging_name}"
-                                ),
                             )
             finally:
                 await pool2.close()
@@ -912,9 +905,8 @@ def execute_restore_task(request_id: str) -> None:
                     event="restore_failed",
                     school_id=school_id,
                     backup_id=backup_id,
-                    scope_type="unknown",
+                    scope_type="restore",
                     scope_value=None,
-                    error_msg=str(exc),
                 )
 
             # Audit failure

--- a/backend/tests/test_backup.py
+++ b/backend/tests/test_backup.py
@@ -91,9 +91,7 @@ async def _seed_backup(
     backup_id = str(uuid.uuid4())
     pool = client._transport.app.state.pool
     async with pool.acquire() as conn:
-        await conn.execute(
-            "SELECT set_config('app.current_school_id', 'bypass', false)"
-        )
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
         await conn.execute(
             """
             INSERT INTO curriculum_backups
@@ -117,9 +115,7 @@ async def _seed_restore_request(
     request_id = str(uuid.uuid4())
     pool = client._transport.app.state.pool
     async with pool.acquire() as conn:
-        await conn.execute(
-            "SELECT set_config('app.current_school_id', 'bypass', false)"
-        )
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
         await conn.execute(
             """
             INSERT INTO backup_restore_requests
@@ -259,9 +255,7 @@ async def test_school_submit_restore_deduplicates(client: AsyncClient):
     assert req2_id != req1_id
 
     # First request must now be cancelled
-    r3 = await client.get(
-        f"/api/v1/schools/{school_id}/restore-requests/{req1_id}", headers=hdr
-    )
+    r3 = await client.get(f"/api/v1/schools/{school_id}/restore-requests/{req1_id}", headers=hdr)
     assert r3.status_code == 200
     assert r3.json()["status"] == "cancelled"
 
@@ -394,9 +388,7 @@ async def test_admin_get_backup_found(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_admin_get_backup_not_found(client: AsyncClient):
     await _seed_admin(client)
-    r = await client.get(
-        f"/api/v1/admin/backups/{uuid.uuid4()}", headers=_admin_hdr()
-    )
+    r = await client.get(f"/api/v1/admin/backups/{uuid.uuid4()}", headers=_admin_hdr())
     assert r.status_code == 404
 
 
@@ -405,9 +397,7 @@ async def test_admin_list_school_backups(client: AsyncClient):
     await _seed_admin(client)
     school_id, _ = await _register_school(client, "adm-02")
     await _seed_backup(client, school_id, status="running")
-    r = await client.get(
-        f"/api/v1/admin/schools/{school_id}/backups", headers=_admin_hdr()
-    )
+    r = await client.get(f"/api/v1/admin/schools/{school_id}/backups", headers=_admin_hdr())
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["total"] >= 1
@@ -448,9 +438,7 @@ async def test_admin_acknowledge_wrong_status(client: AsyncClient):
     await _seed_admin(client)
     school_id, _ = await _register_school(client, "adm-11")
     backup_id = await _seed_backup(client, school_id)
-    req_id = await _seed_restore_request(
-        client, school_id, backup_id, status="acknowledged"
-    )
+    req_id = await _seed_restore_request(client, school_id, backup_id, status="acknowledged")
     with patch("src.backup.tasks.dry_run_restore_task.delay", return_value=None):
         r = await client.patch(
             f"/api/v1/admin/restore-requests/{req_id}/acknowledge",
@@ -830,9 +818,7 @@ def test_backup_notification_no_internal_leak(event):
     captured: dict = {}
 
     async def fake_send(*, to_email, subject, text_body, html_body):
-        captured.update(
-            to_email=to_email, subject=subject, text=text_body, html=html_body
-        )
+        captured.update(to_email=to_email, subject=subject, text=text_body, html=html_body)
 
     with patch("src.email.service._send", new=fake_send):
         # The task no longer accepts error_msg — there is nowhere to inject raw

--- a/backend/tests/test_backup.py
+++ b/backend/tests/test_backup.py
@@ -811,3 +811,44 @@ async def test_restore_dry_run_sql_matches_schema(db_conn):
     )
     assert row["status"] == "draft"
     assert row["owner_type"] == "school"
+
+
+# ── Regression: failure notifications don't leak internals (issue #413) ─────────
+
+
+@pytest.mark.parametrize("event", ["backup_failed", "restore_failed"])
+def test_backup_notification_no_internal_leak(event):
+    """Regression for #413: failure-notification emails must not expose internal
+    identifiers (school/backup UUIDs), event names, or raw exception text to the
+    customer (Content Rule #5). They get a generic, reassuring message instead;
+    diagnostics live in the logs.
+    """
+    from src.backup.tasks import send_backup_notification_task
+
+    school_id = "11111111-1111-1111-1111-111111111111"
+    backup_id = "22222222-2222-2222-2222-222222222222"
+    captured: dict = {}
+
+    async def fake_send(*, to_email, subject, text_body, html_body):
+        captured.update(
+            to_email=to_email, subject=subject, text=text_body, html=html_body
+        )
+
+    with patch("src.email.service._send", new=fake_send):
+        # The task no longer accepts error_msg — there is nowhere to inject raw
+        # exception text into a customer email.
+        send_backup_notification_task(
+            to_email="admin@example.com",
+            event=event,
+            school_id=school_id,
+            backup_id=backup_id,
+            scope_type="full",
+        )
+
+    blob = captured["text"] + captured["html"]
+    assert school_id not in blob  # no internal UUIDs
+    assert backup_id not in blob
+    assert "Error:" not in blob and "Event:" not in blob  # no raw error / event dump
+    assert event not in blob  # internal event name not surfaced
+    assert "notified" in captured["text"].lower()  # reassuring message present
+    assert captured["to_email"] == "admin@example.com"


### PR DESCRIPTION
Closes #413.

## What
Backup/restore **failure notification** emails were dumping the raw `str(exc)`, the school + backup **UUIDs**, and the internal **event name** to the school's contact — a Content Rule #5 violation (no raw errors / internal identifiers in customer-facing messages). This was the design flaw behind the `Error: 'id'` screenshot that started this whole thread.

## Fix
- `send_backup_notification_task` now builds a **generic, reassuring per-event message** — no UUIDs, no event name, no exception text. Failures read *"We hit a problem… our team has been notified… nothing you need to do."*
- The **`error_msg` param is removed entirely** — there's no longer anywhere to inject raw error text into a customer email.
- Technical diagnostics stay in the **structured logs** the callers already emit (`backup_failed` / `restore_failed` / `dry_run_failed`).
- The dry-run conflict path drops its per-version summary email (those specifics live in the portal); the school still gets a friendly "your restore needs review" note.

## Test plan
- New **parametrized regression test** (`backup_failed`, `restore_failed`): asserts the email body contains **no** school/backup UUID, no `Error:`/`Event:`, no internal event name — and **does** carry the reassuring copy.
- **33/33** backup tests pass. `ruff check` + `ruff format --check` clean.

## Note
This is the last open item from the backup investigation (#410 cause, #411/#423 restore, #421/#422 flaky test, #413 this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)