### PR TITLE
docs: refresh CLAUDE.md + curriculum_mgmt docs for Administration menu / onboarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,29 @@ do not swap the word.
 **Active branch:** `main` (next: see `docs/epics/` — product backlog)
 
 **Recently shipped (beyond Phase 11):**
+- **School-admin UX overhaul (2026-06) — Administration menu + pickers + setup wizard:**
+  - **Administration menu (#415 / #417):** top-bar `web/components/layout/AdministrationMenu.tsx`
+    replaces the standalone "Curriculum Management" dropdown — groups a **Curriculum**
+    section (gated `canManageCurriculum`) + a **User Management** section
+    (Students/Teachers, `school_admin` only); left-rail infra group renamed **"Settings"**;
+    `isSchoolAdmin()` helper added to `web/lib/hooks/useTeacher.ts`.
+  - **Classroom assignment pickers (#418 / #419):** the classroom curriculum and student
+    "assign" controls are now **dropdowns** (from the school library / roster,
+    grade-filtered, excluding already-assigned) instead of raw-UUID text inputs.
+  - **"Set up your school" wizard (#420):** guided 6-step checklist at `/school/setup`
+    ("Get started" rail item, school_admin), auto-ticked from existing data; pure logic
+    in `web/lib/school/setup-checklist.ts`.
+  - **School user-management decisions:** [`docs/ADR_005_school_roles_and_uniqueness.md`](docs/ADR_005_school_roles_and_uniqueness.md)
+    (school_admin = teacher **superset** role · **email-only** uniqueness · account delete =
+    **soft-delete + archive** + FERPA retention) + the [`docs/SCHOOL_USER_MANAGEMENT.md`](docs/SCHOOL_USER_MANAGEMENT.md)
+    Type-1 self-managed onboarding spec.
+- **Backup & Restore investigation closed (2026-06):** #410 fixed backup creation
+  (`backup_school_task` read `r["id"]` but the `curricula` PK is `curriculum_id`, TEXT);
+  #423 reconciled the **restore path** schema (#411 — `dry_run_/execute_restore_task`
+  referenced non-existent `id`/`grade`/`ordering`/`updated_at`, omitted NOT NULL `year`,
+  used `ON CONFLICT (id)`); #424 stopped failure-notification emails leaking raw
+  `str(exc)` + school/backup UUIDs to the contact (#413, Content Rule #5).
+  `backend/scripts/purge_account.py` (#416) hard-deletes a single teacher/student by email for test cleanup.
 - Content review unit viewer — Lesson / Tutorial / Quiz / Experiment renderers
 - Inline reviewer annotations scoped per section, question, and step
 - Side-by-side version diff with word-level highlighting
@@ -172,6 +195,23 @@ All documentation has moved to **[studybuddy-docs](https://github.com/wegofwd202
 | [CHEATSHEET.md](https://github.com/wegofwd2020-hub/studybuddy-docs/blob/main/CHEATSHEET.md) | Operator one-liners — dev stack, RLS-aware DB queries, password reset, demo accounts, pipeline triggers, smoke tests, Redis ops, deck regeneration |
 | [SCALABILITY.md](https://github.com/wegofwd2020-hub/studybuddy-docs/blob/main/SCALABILITY.md) | Capacity planning, multi-region, load testing, academic year transitions, API versioning |
 | [GLOSSARY.md](https://github.com/wegofwd2020-hub/studybuddy-docs/blob/main/GLOSSARY.md) | Acronym and term definitions for all abbreviations used across the project |
+
+**In-repo design docs / ADRs** (live under `docs/` in this repo, not studybuddy-docs):
+
+| Doc | Read when |
+|---|---|
+| [`docs/ADR_001_tenancy_and_subscription_model.md`](docs/ADR_001_tenancy_and_subscription_model.md) | Tenancy / subscription / school-as-primary-entity decisions |
+| [`docs/ADR_004_authoring_studio_home_repo.md`](docs/ADR_004_authoring_studio_home_repo.md) | Where the standalone authoring+reader lives (→ became Mentible, see below) |
+| [`docs/ADR_005_school_roles_and_uniqueness.md`](docs/ADR_005_school_roles_and_uniqueness.md) | School roles (`school_admin` = teacher superset), email-only uniqueness, soft-delete + archive |
+| [`docs/SCHOOL_USER_MANAGEMENT.md`](docs/SCHOOL_USER_MANAGEMENT.md) | The Type-1 (self-managed) school user lifecycle + the top-bar **Administration** menu IA (§8.1) |
+| [`docs/DESIGN_curriculum_mgmt_capability.md`](docs/DESIGN_curriculum_mgmt_capability.md) · [`docs/SPEC_curriculum_mgmt_capability.md`](docs/SPEC_curriculum_mgmt_capability.md) | The `curriculum_mgmt` capability (#358) — additive grants; menu now lives under Administration (#415) |
+
+> **Sibling / spun-out projects (2026-06-09):** the standalone, non-school products
+> moved to **Mentible** — the `StudyBuddy_SelfLearner` repo (rebrand of "StudyBuddy Q"):
+> **StudyBuddy Q + BriefCase + Special-needs Social Stories**. Don't build those here.
+> The **home-schooling wedge stays with StudyBuddy** (for now). **MarketingTools**
+> (`wegofwd2020-hub/MarketingTools`) is the cross-portfolio promo repo for any
+> client-facing product.
 
 ---
 

--- a/docs/DESIGN_curriculum_mgmt_capability.md
+++ b/docs/DESIGN_curriculum_mgmt_capability.md
@@ -2,9 +2,19 @@
 
 **Status:** Implemented (migration 0059, branch `feat/curriculum-mgmt-capability`, issue #358) · **Date:** 2026-05-21 · **Extends:** [ADR-001](ADR_001_tenancy_and_subscription_model.md) (role model)
 
+> **Superseded UI (#415 / #417, 2026-06):** the standalone top-bar
+> **"Curriculum Management"** dropdown described below was replaced by a single
+> top-bar **"Administration"** menu (`web/components/layout/AdministrationMenu.tsx`)
+> with a **Curriculum** section (this capability, gated `canManageCurriculum`) and a
+> **User Management** section (`school_admin` only). The capability/gating model is
+> unchanged; only the menu's name/home moved. See
+> [`SCHOOL_USER_MANAGEMENT.md`](SCHOOL_USER_MANAGEMENT.md) §8.1. Read "Curriculum
+> Management menu" below as "the Curriculum section of the Administration menu".
+
 Lets a school_admin delegate curriculum-management powers to a chosen teacher
 **without** promoting them to full school_admin, and groups all curriculum nav
-under one top-bar **"Curriculum Management"** menu shown only to those who hold it.
+under the **Curriculum** section of the top-bar **Administration** menu, shown
+only to those who hold the capability (or are a `school_admin` superset).
 
 ## Decisions (locked 2026-05-21)
 

--- a/docs/SPEC_curriculum_mgmt_capability.md
+++ b/docs/SPEC_curriculum_mgmt_capability.md
@@ -255,21 +255,25 @@ it("defaults capabilities to [] when absent (no coercion drop)", () => {
 
 ### Cross-persona — `web/tests/e2e/curriculum-mgmt-nav.spec.ts` (new, Playwright, run from host — pitfall #26)
 
+> **Note (#415 / #417):** the top-bar button was renamed **"Curriculum Management" →
+> "Administration"** (Curriculum is now a *section* inside it). Assertions below
+> target the **Administration** button accordingly. The capability gating is unchanged.
+
 ```ts
-test("plain teacher does NOT see Curriculum Management", async ({ page }) => {
+test("plain teacher does NOT see the Administration menu", async ({ page }) => {
   await loginAsTeacher(page, { capabilities: [] });
-  await expect(page.getByRole("button", { name: /curriculum management/i })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: /administration/i })).toHaveCount(0);
 });
 
-test("granted teacher sees the top-bar menu with curriculum items", async ({ page }) => {
+test("granted teacher sees the Administration menu with curriculum items", async ({ page }) => {
   await loginAsTeacher(page, { capabilities: ["curriculum_mgmt"] });
-  await page.getByRole("button", { name: /curriculum management/i }).click();
+  await page.getByRole("button", { name: /administration/i }).click();
   await expect(page.getByRole("menuitem", { name: /my curricula/i })).toBeVisible();
 });
 
 test("school_admin sees it implicitly (no grant)", async ({ page }) => {
   await loginAsSchoolAdmin(page);
-  await expect(page.getByRole("button", { name: /curriculum management/i })).toBeVisible();
+  await expect(page.getByRole("button", { name: /administration/i })).toBeVisible();
 });
 ```
 


### PR DESCRIPTION
Brings in-repo docs current with the 2026-06 session (Administration menu #415/#417, classroom pickers #418/#419, setup wizard #420, ADR-005 + SCHOOL_USER_MANAGEMENT spec, backup investigation closeout #410/#411/#423/#413/#424), and records the **Mentible** portfolio split in CLAUDE.md's Document Map.

## Changes
- **CLAUDE.md** — Recently-shipped block for this session; new in-repo ADR/design-doc table; sibling-projects (Mentible) note.
- **DESIGN_/SPEC_curriculum_mgmt_capability.md** — note + nav-test fix that the top-bar button is now **Administration** (was Curriculum Management).

## Scope
Docs-only; link-integrity unchanged (22 pre-existing findings). External `studybuddy-docs` repo (ARCHITECTURE/AGENTS/etc.) is **out of scope** — separate repo; see below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)