### PR TITLE
fix(docker): install git so the wegofwd-llm git+ pip dep resolves (unblocks Deploy — Demo)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,8 +2,10 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# System dependencies (libpq/gcc for asyncpg; glib/pango/cairo for WeasyPrint PDF)
+# System dependencies (git for the wegofwd-llm git+ pip dep; libpq/gcc for asyncpg;
+# glib/pango/cairo for WeasyPrint PDF)
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
     libpq-dev \
     gcc \
     libglib2.0-0 \

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -8,8 +8,9 @@ FROM python:3.11-slim
 
 WORKDIR /pipeline
 
-# System dependencies
+# System dependencies (git for the wegofwd-llm git+ pip dep)
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
     libpq-dev \
     gcc \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What
Add `git` to the apt-get system-deps layer in **`backend/Dockerfile`** and **`pipeline/Dockerfile`**.

## Why
The **Deploy — Demo** workflow has failed on every push to `main` since **#431** ("Migrate google onto wegofwd-llm's gemini", merged 2026-06-09), at the *Build + push API image* step:

```
#11 1.387 Collecting wegofwd-llm@ git+https://github.com/wegofwd2020-hub/wegofwd-llm@v0.1.2 ...
#11 1.389 ERROR: Cannot find command 'git' - do you have 'git' installed and in your PATH?
```

#431 added a Git-sourced dependency to `backend/requirements.txt` (line 56) and `pipeline/requirements.txt` (line 20):

```
wegofwd-llm[anthropic] @ git+https://github.com/wegofwd2020-hub/wegofwd-llm@v0.1.2
```

Both images build on `python:3.11-slim`, which ships no `git`, so `pip install` aborts before it can clone the dep. The same break affects local `docker compose build api` / `celery-pipeline`.

## Fix scope
- The dep repo `wegofwd2020-hub/wegofwd-llm` is **public** and tag **`v0.1.2`** exists (`c6ca1ce`), so installing `git` is sufficient — no PAT/token or `GIT_*` build-arg needed.
- Both Dockerfiles that install these requirements are patched (Deploy builds only the API image, but the pipeline image hits the identical failure).

## Risk
Low — adds one apt package to the build layer. No runtime code change.

## Test plan
- [ ] CI green on this PR
- [ ] **Deploy — Demo** build step succeeds (`pip install` clones `wegofwd-llm@v0.1.2`) once merged to `main`
- [ ] Couldn't run a local `docker build` to pre-validate — Docker daemon was down on the dev box; relying on CI to confirm the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)