### PR TITLE
fix(api): expose health probes under /api/v1 so /api/v1/health works

### DIFF
--- a/backend/src/core/app_factory.py
+++ b/backend/src/core/app_factory.py
@@ -30,7 +30,7 @@ from slowapi.errors import RateLimitExceeded
 from src.core.cors import build_lan_origin_regex
 from src.core.limiter import limiter
 from src.core.middleware import AppVersionMiddleware
-from src.core.observability import CorrelationIdMiddleware, PrometheusMiddleware
+from src.core.observability import CorrelationIdMiddleware, PrometheusMiddleware, api_health_router
 from src.core.observability import router as obs_router
 from src.utils.logger import get_logger
 
@@ -278,6 +278,8 @@ def _register_routers(app: FastAPI) -> None:
 
     # Health + metrics at root (no /api/v1 prefix).
     app.include_router(obs_router)
+    # Same liveness/readiness/health probes, also under /api/v1 (so /api/v1/health works).
+    app.include_router(api_health_router, prefix="/api/v1")
 
     app.include_router(auth_router, prefix="/api/v1")
     app.include_router(admin_auth_router, prefix="/api/v1")

--- a/backend/src/core/observability.py
+++ b/backend/src/core/observability.py
@@ -123,7 +123,18 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
     Excludes /metrics itself (would self-spam) and /healthz (constant noise).
     """
 
-    EXCLUDE_PATHS = frozenset({"/metrics", "/healthz", "/readyz", "/health"})
+    EXCLUDE_PATHS = frozenset(
+        {
+            "/metrics",
+            "/healthz",
+            "/readyz",
+            "/health",
+            # /api/v1 aliases of the health probes (see api_health_router below)
+            "/api/v1/healthz",
+            "/api/v1/readyz",
+            "/api/v1/health",
+        }
+    )
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         if request.url.path in self.EXCLUDE_PATHS:
@@ -266,3 +277,26 @@ async def metrics_endpoint(request: Request) -> PlainTextResponse:
         generate_latest().decode("utf-8"),
         media_type=CONTENT_TYPE_LATEST,
     )
+
+
+# ── /api/v1 health aliases ────────────────────────────────────────────────────
+# The probes above are mounted at root (obs_router). nginx proxies both /healthz
+# and /api/v1/* to the backend, but the health routes never existed under the
+# /api/v1 prefix — so /api/v1/health fell through to the Next.js frontend (404).
+# Re-expose liveness + readiness + deep health under /api/v1 (included with
+# prefix="/api/v1" in app_factory) for callers that assume the API prefix. The
+# /api/v1 paths are added to PrometheusMiddleware.EXCLUDE_PATHS above so probe
+# traffic stays out of the request metrics, exactly like the root paths.
+#
+# All three are include_in_schema=False: these aliases are operational probes,
+# not part of the public API contract, so they must stay OUT of the OpenAPI
+# schema (the root /health + /readyz remain the documented entries). Keeping
+# them unexported avoids drifting the generated TypeScript types.
+api_health_router = APIRouter(tags=["observability"])
+api_health_router.add_api_route(
+    "/healthz", liveness_check, methods=["GET"], include_in_schema=False
+)
+api_health_router.add_api_route(
+    "/readyz", readiness_check, methods=["GET"], include_in_schema=False
+)
+api_health_router.add_api_route("/health", health_check, methods=["GET"], include_in_schema=False)

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -37,6 +37,25 @@ async def test_health_with_provided_correlation_id(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_api_v1_health_ok(client: AsyncClient):
+    """The /api/v1 alias of the deep health check behaves like /health."""
+    response = await client.get("/api/v1/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["db"] == "ok"
+    assert data["redis"] == "ok"
+    assert "version" in data
+
+
+@pytest.mark.asyncio
+async def test_api_v1_healthz_liveness(client: AsyncClient):
+    """The /api/v1 liveness alias returns the same 200 ok payload as /healthz."""
+    response = await client.get("/api/v1/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
 async def test_metrics_requires_token(client: AsyncClient):
     """GET /metrics without a valid token returns 403."""
     response = await client.get("/metrics")


### PR DESCRIPTION
## What
Re-expose the liveness / readiness / deep-health probes under the `/api/v1` prefix, so `/api/v1/health` and `/api/v1/healthz` work — not just the root `/healthz`.

## Why
While verifying the demo deploy, `/api/v1/health` returned a FastAPI 404. The health router (`obs_router`) is mounted only at root, so the probes live at `/healthz`, `/readyz`, `/health`. nginx proxies `/api/v1/*` to the backend, but the backend had no health route under that prefix — so `/api/v1/health` (the natural guess for an API consumer) 404'd, and `/health` at root fell through to the Next.js frontend. Only `/healthz` actually worked.

## How
- New `api_health_router` in `observability.py` re-binds the **same** `liveness_check` / `readiness_check` / `health_check` handlers, included with `prefix="/api/v1"` in `app_factory.py`. No handler logic duplicated.
- Added `/api/v1/healthz`, `/api/v1/readyz`, `/api/v1/health` to `PrometheusMiddleware.EXCLUDE_PATHS` so probe traffic stays out of request metrics, exactly like the root paths.
- Root paths (`/healthz`, `/readyz`, `/health`, `/metrics`) are unchanged — fully backwards-compatible.

## Tests
Added two cases to `tests/test_health.py`:
- `test_api_v1_health_ok` — `/api/v1/health` returns 200 with `db`/`redis`/`version` (deep check parity with `/health`).
- `test_api_v1_healthz_liveness` — `/api/v1/healthz` returns `{"status": "ok"}`.

## Validation note
Edited files compile clean (`py_compile`). I couldn't run the suite locally — this host is Python 3.9 with no backend deps, and a Dockerized targeted run hit local-env trouble (test-DB container wouldn't start). Relying on CI to exercise the new tests; the change is a standard `include_router(prefix=...)` addition.

## Risk
Low — additive routes + a metrics-exclusion tweak; no existing route changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)