### PR TITLE
docs(claude): document /api/v1 health probe aliases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,12 @@ StudyBuddy_OnDemand/
       demo/              ← demo student + demo teacher request/verify flows
       core/              ← cache manager (L1+L2) · entitlement checker · circuit breakers
                             curriculum resolver dependency · Celery dispatcher
-                            observability.py  ← Prometheus metrics, GET /metrics, GET /health, correlation ID middleware
+                            observability.py  ← Prometheus metrics, GET /metrics, health probes, correlation ID middleware
+                                                 Liveness/readiness/health probes are served BOTH at root
+                                                 (/healthz, /readyz, /health) and under the API prefix
+                                                 (/api/v1/healthz, /api/v1/readyz, /api/v1/health) — the
+                                                 /api/v1 aliases exist because nginx proxies /api/v1/* to the
+                                                 backend; all probes are include_in_schema=False (not in OpenAPI)
                             events.py         ← emit_event() structured log + metric counter · write_audit_log() Celery dispatch
     tests/               ← pytest; ALL external calls mocked; no live DB in CI
     requirements.txt


### PR DESCRIPTION
## What
Updates the `observability.py` entry in CLAUDE.md's repo-layout block to note that the liveness/readiness/health probes are served **both** at root (`/healthz`, `/readyz`, `/health`) **and** under the API prefix (`/api/v1/healthz`, `/api/v1/readyz`, `/api/v1/health`).

## Why
PR #434 added the `/api/v1` aliases (nginx proxies `/api/v1/*` to the backend, so `/api/v1/health` is the natural path for API consumers — it now returns 200 on the demo). The doc previously listed only `GET /health`. Also records that all probes are `include_in_schema=False` (intentionally absent from the OpenAPI contract).

## Risk
None — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)