### PR TITLE
fix(feedback): quick-win fixes from Vneki's 2026-06-13 testing (#437 #438 #446 #451 #452 #453)

### DIFF
--- a/backend/src/reports/service.py
+++ b/backend/src/reports/service.py
@@ -833,10 +833,16 @@ async def get_trends(
         f"AND student_id = ANY(ARRAY[{id_placeholders}]::uuid[])" if id_uuids else "AND FALSE"
     )
 
+    # Anchor buckets to ISO weeks (Monday 00:00 UTC) so the week_start labels are
+    # always Mondays, regardless of which weekday the report happens to be run on.
+    # (Previously week_start = now - N weeks, which tracked today's weekday.)
+    this_monday = (now - timedelta(days=now.weekday())).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
     weeks = []
     for i in range(n_weeks - 1, -1, -1):
-        week_end = now - timedelta(weeks=i)
-        week_start = week_end - timedelta(weeks=1)
+        week_start = this_monday - timedelta(weeks=i)
+        week_end = week_start + timedelta(weeks=1)
 
         lv_row = await conn.fetchrow(
             f"""

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -21,7 +21,7 @@ Coverage:
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import pytest
@@ -103,7 +103,7 @@ async def _insert_session(
     days_ago: int = 1,
 ) -> None:
     pool = client._transport.app.state.pool
-    started_at = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    started_at = datetime.now(UTC) - timedelta(days=days_ago)
     await pool.execute(
         """
         INSERT INTO progress_sessions
@@ -126,7 +126,7 @@ async def _insert_lesson_view(
     days_ago: int = 1,
 ) -> None:
     pool = client._transport.app.state.pool
-    started_at = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    started_at = datetime.now(UTC) - timedelta(days=days_ago)
     await pool.execute(
         """
         INSERT INTO lesson_views
@@ -406,10 +406,17 @@ async def test_trends_report_returns_4_weeks(client, db_conn):
     assert r.status_code == 200, r.text
     data = r.json()
     assert len(data["weeks"]) == 4
+    from datetime import datetime as _dt
+
     for week in data["weeks"]:
         assert "week_start" in week
         assert "active_students" in week
         assert "lessons_viewed" in week
+        # week_start must always be a Monday (ISO week), regardless of the day the
+        # report is run — regression guard for feedback ticket #451.
+        assert (
+            _dt.strptime(week["week_start"], "%Y-%m-%d").weekday() == 0
+        ), f"week_start {week['week_start']} is not a Monday"
 
 
 # ── Export ─────────────────────────────────────────────────────────────────────

--- a/web/app/(school)/school/reports/alerts/settings/page.tsx
+++ b/web/app/(school)/school/reports/alerts/settings/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import Link from "next/link";
+import { useTeacher } from "@/lib/hooks/useTeacher";
+import { updateAlertSettings, type AlertSettings } from "@/lib/api/reports";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { ArrowLeft, Check } from "lucide-react";
+
+// The backend has no GET for current settings yet, so the form starts from the
+// same defaults the server applies (src/reports/service.py::save_alert_settings).
+const DEFAULTS: AlertSettings = {
+  pass_rate_threshold: 50,
+  feedback_count_threshold: 3,
+  inactive_days_threshold: 14,
+  score_drop_threshold: 10,
+  new_feedback_immediate: true,
+};
+
+export default function AlertSettingsPage() {
+  const teacher = useTeacher();
+  const schoolId = teacher?.school_id ?? "";
+  const [settings, setSettings] = useState<AlertSettings>(DEFAULTS);
+
+  const { mutate, isPending, isSuccess, isError } = useMutation({
+    mutationFn: () => updateAlertSettings(schoolId, settings),
+  });
+
+  function num(key: keyof AlertSettings, value: string) {
+    setSettings((s) => ({ ...s, [key]: Number(value) }));
+  }
+
+  return (
+    <div className="max-w-2xl space-y-6 p-6">
+      <Link
+        href="/school/alerts"
+        className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to alerts
+      </Link>
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Alert thresholds</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Alerts fire when these limits are crossed. Changes apply to future alerts.
+        </p>
+      </div>
+      <Card className="border shadow-sm">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Thresholds</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="pass_rate">Low pass-rate alert below (%)</Label>
+            <Input
+              id="pass_rate"
+              type="number"
+              min={0}
+              max={100}
+              value={settings.pass_rate_threshold}
+              onChange={(e) => num("pass_rate_threshold", e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="inactive_days">Inactive-student alert after (days)</Label>
+            <Input
+              id="inactive_days"
+              type="number"
+              min={1}
+              value={settings.inactive_days_threshold}
+              onChange={(e) => num("inactive_days_threshold", e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="feedback_count">Feedback-spike alert at (count)</Label>
+            <Input
+              id="feedback_count"
+              type="number"
+              min={1}
+              value={settings.feedback_count_threshold}
+              onChange={(e) => num("feedback_count_threshold", e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="score_drop">Score-drop alert at (% drop)</Label>
+            <Input
+              id="score_drop"
+              type="number"
+              min={0}
+              max={100}
+              value={settings.score_drop_threshold}
+              onChange={(e) => num("score_drop_threshold", e.target.value)}
+            />
+          </div>
+          <label className="flex items-center gap-2 pt-1 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              className="h-4 w-4 rounded border-gray-300"
+              checked={settings.new_feedback_immediate}
+              onChange={(e) =>
+                setSettings((s) => ({
+                  ...s,
+                  new_feedback_immediate: e.target.checked,
+                }))
+              }
+            />
+            Notify immediately on new feedback
+          </label>
+        </CardContent>
+      </Card>
+      {isError && (
+        <p className="text-sm text-red-600">Could not save settings. Please try again.</p>
+      )}
+      <Button
+        onClick={() => mutate()}
+        disabled={isPending || !schoolId}
+        className="gap-2"
+      >
+        {isPending ? (
+          "Saving…"
+        ) : isSuccess ? (
+          <>
+            <Check className="h-4 w-4" />
+            Saved
+          </>
+        ) : (
+          "Save thresholds"
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/web/app/(school)/school/reports/export/page.tsx
+++ b/web/app/(school)/school/reports/export/page.tsx
@@ -43,50 +43,83 @@ export default function ExportPage() {
     if (!schoolId) return;
     setState("loading");
     try {
+      // Friendly column headers ("%", not "pct"). `fields` is kept explicit so an
+      // empty dataset still produces a header row instead of a BOM-only file (which
+      // Excel renders as the junk "\u00EF\u00BB\u00BF"). See feedback tickets #452 / #453.
       let rows: Record<string, unknown>[] = [];
+      let fields: string[] = [];
       let filename = "export.csv";
       if (reportType === "overview") {
         const data = await getOverviewReport(schoolId, "30d");
+        fields = [
+          "Enrolled students",
+          "Active students",
+          "Active %",
+          "Lessons viewed",
+          "Quiz attempts",
+          "First-attempt pass rate %",
+          "Audio play rate %",
+          "Unreviewed feedback",
+        ];
         rows = [
           {
-            enrolled_students: data.enrolled_students,
-            active_students: data.active_students_period,
-            active_pct: data.active_pct.toFixed(1),
-            lessons_viewed: data.lessons_viewed,
-            quiz_attempts: data.quiz_attempts,
-            first_attempt_pass_rate_pct: data.first_attempt_pass_rate_pct.toFixed(1),
-            audio_play_rate_pct: data.audio_play_rate_pct.toFixed(1),
-            unreviewed_feedback: data.unreviewed_feedback_count,
+            "Enrolled students": data.enrolled_students,
+            "Active students": data.active_students_period,
+            "Active %": data.active_pct.toFixed(1),
+            "Lessons viewed": data.lessons_viewed,
+            "Quiz attempts": data.quiz_attempts,
+            "First-attempt pass rate %": data.first_attempt_pass_rate_pct.toFixed(1),
+            "Audio play rate %": data.audio_play_rate_pct.toFixed(1),
+            "Unreviewed feedback": data.unreviewed_feedback_count,
           },
         ];
         filename = `overview_${data.period}.csv`;
       } else if (reportType === "trends") {
         const data = await getTrendsReport(schoolId, "12w");
+        fields = [
+          "Week start",
+          "Active students",
+          "Lessons viewed",
+          "Quiz attempts",
+          "Average score %",
+          "First-attempt pass rate %",
+        ];
         rows = data.weeks.map((w) => ({
-          week_start: w.week_start,
-          active_students: w.active_students,
-          lessons_viewed: w.lessons_viewed,
-          quiz_attempts: w.quiz_attempts,
-          avg_score_pct: w.avg_score_pct.toFixed(1),
-          first_attempt_pass_rate_pct: w.first_attempt_pass_rate_pct.toFixed(1),
+          "Week start": w.week_start,
+          "Active students": w.active_students,
+          "Lessons viewed": w.lessons_viewed,
+          "Quiz attempts": w.quiz_attempts,
+          "Average score %": w.avg_score_pct.toFixed(1),
+          "First-attempt pass rate %": w.first_attempt_pass_rate_pct.toFixed(1),
         }));
         filename = "trends_12w.csv";
       } else if (reportType === "curriculum-health") {
         const data = await getCurriculumHealth(schoolId);
+        fields = [
+          "Unit ID",
+          "Unit name",
+          "Subject",
+          "Health tier",
+          "First-attempt pass rate %",
+          "Average score %",
+          "Avg attempts to pass",
+          "Feedback count",
+          "Recommended action",
+        ];
         rows = data.units.map((u) => ({
-          unit_id: u.unit_id,
-          unit_name: u.unit_name ?? "",
-          subject: u.subject,
-          health_tier: u.health_tier,
-          first_attempt_pass_rate_pct: u.first_attempt_pass_rate_pct.toFixed(1),
-          avg_score_pct: u.avg_score_pct.toFixed(1),
-          avg_attempts_to_pass: u.avg_attempts_to_pass.toFixed(2),
-          feedback_count: u.feedback_count,
-          recommended_action: u.recommended_action,
+          "Unit ID": u.unit_id,
+          "Unit name": u.unit_name ?? "",
+          Subject: u.subject,
+          "Health tier": u.health_tier,
+          "First-attempt pass rate %": u.first_attempt_pass_rate_pct.toFixed(1),
+          "Average score %": u.avg_score_pct.toFixed(1),
+          "Avg attempts to pass": u.avg_attempts_to_pass.toFixed(2),
+          "Feedback count": u.feedback_count,
+          "Recommended action": u.recommended_action,
         }));
         filename = "unit_performance.csv";
       }
-      const csv = Papa.unparse(rows);
+      const csv = Papa.unparse({ fields, data: rows });
       const blob = new Blob(["\uFEFF" + csv], { type: "text/csv;charset=utf-8;" });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");

--- a/web/app/(school)/school/students/page.tsx
+++ b/web/app/(school)/school/students/page.tsx
@@ -460,11 +460,32 @@ function AdminStudentView({ schoolId }: { schoolId: string }) {
       qc.invalidateQueries({ queryKey: ["roster", schoolId] });
     },
     onError: (err: unknown) => {
-      const status = (err as { response?: { status?: number } })?.response?.status;
+      const resp = (
+        err as { response?: { status?: number; data?: { detail?: unknown } } }
+      )?.response;
+      const status = resp?.status;
       if (status === 409) {
         setAddError("A student with that email already exists.");
       } else if (status === 422) {
-        setAddError("Invalid grade — must be between 1 and 12.");
+        // FastAPI returns detail: [{ loc: ["body", <field>], msg }]. Surface a
+        // message for the field that actually failed rather than always blaming grade.
+        const detail = resp?.data?.detail;
+        const fields = Array.isArray(detail)
+          ? detail.flatMap((d) =>
+              Array.isArray((d as { loc?: unknown[] })?.loc)
+                ? ((d as { loc: unknown[] }).loc as unknown[]).map(String)
+                : [],
+            )
+          : [];
+        if (fields.includes("email")) {
+          setAddError("Enter a valid email address.");
+        } else if (fields.includes("grade")) {
+          setAddError("Invalid grade — must be between 1 and 12.");
+        } else if (fields.includes("name")) {
+          setAddError("Enter the student's full name.");
+        } else {
+          setAddError("Please check the name, email, and grade and try again.");
+        }
       } else {
         setAddError("Could not add student. Please try again.");
       }

--- a/web/lib/api/school-admin.ts
+++ b/web/lib/api/school-admin.ts
@@ -40,15 +40,18 @@ export async function getRoster(schoolId: string): Promise<RosterResponse> {
 export interface EnrolmentUploadResponse {
   enrolled: number;
   already_enrolled: number;
+  errors?: Array<Record<string, unknown>>;
 }
 
 export async function uploadRoster(
   schoolId: string,
   studentEmails: string[],
 ): Promise<EnrolmentUploadResponse> {
+  // Backend expects { students: [{ email }] } (migration 0024); the old flat
+  // { student_emails: [...] } shape was removed and would 422. See CLAUDE.md pitfall #21.
   const res = await schoolApi.post<EnrolmentUploadResponse>(
     `/schools/${schoolId}/enrolment`,
-    { student_emails: studentEmails },
+    { students: studentEmails.map((email) => ({ email })) },
   );
   return res.data;
 }

--- a/web/tests/unit/invite-link.test.ts
+++ b/web/tests/unit/invite-link.test.ts
@@ -105,7 +105,7 @@ describe("inviteTeacher", () => {
 });
 
 describe("uploadRoster", () => {
-  it("posts student_emails array to enrolment endpoint", async () => {
+  it("posts a students array of {email} to the enrolment endpoint", async () => {
     mockPost.mockResolvedValueOnce({
       data: { enrolled: 3, already_enrolled: 1 },
     });
@@ -114,8 +114,10 @@ describe("uploadRoster", () => {
     const result = await uploadRoster("school-abc", emails);
     expect(result.enrolled).toBe(3);
     expect(result.already_enrolled).toBe(1);
+    // Backend contract (migration 0024): { students: [{ email }] }, not the
+    // removed flat { student_emails: [...] } shape. See feedback #437.
     expect(mockPost).toHaveBeenCalledWith("/schools/school-abc/enrolment", {
-      student_emails: emails,
+      students: emails.map((email) => ({ email })),
     });
   });
 });


### PR DESCRIPTION
## What

Six quick-win fixes from Vneki's 2026-06-13 testing pass (`Feedback_06_13_2026.docx`). Closes #437, #438, #446, #451, #452, #453.

| # | Bug | Fix |
|---|---|---|
| #437 | "Bulk enrol by email" always 422'd | Web now sends `{students:[{email}]}` (the post-migration-0024 contract) instead of the removed `{student_emails:[...]}` shape. See CLAUDE.md pitfall #21. |
| #438 | "Add student" showed "Invalid grade" for *any* validation failure | Parse the FastAPI 422 `detail[].loc` and show a field-specific message (email / grade / name). |
| #446 | "Configure thresholds" link 404'd | Added the missing `/school/reports/alerts/settings` page, wired to the existing `PUT /reports/school/{id}/alerts/settings` endpoint. |
| #451 | Trends CSV `week_start` landed on Saturdays | Anchor week buckets to ISO Monday instead of `now`'s weekday. |
| #452 | Report CSV headers read `…_pct` | Friendly `… %` column headers. |
| #453 | Unit-performance CSV showed `ï»¿` in Excel | Empty datasets now emit a header row (`Papa.unparse({fields,data})`) instead of a BOM-only file. |

## Why

All six were live-verified against the demo deployment during triage (see the linked issues for per-ticket evidence). They're low-risk, well-scoped UX/correctness fixes.

## Test plan

- ✅ Frontend: `prettier --check`, `eslint`, `tsc --noEmit` all clean.
- ✅ #451 logic verified standalone (all `week_start` are Mondays even when run on a Saturday); added a regression assertion to `test_reports.py::test_trends_report_returns_4_weeks`.
- ⚠️ Backend integration suite not run locally (no Docker daemon in the authoring env); the new assertion runs in CI.

## Notes / follow-ups

- #446: there's no GET endpoint for current thresholds yet, so the form starts from the documented defaults and saves via PUT. A follow-up could add a GET to pre-fill live values.
- #439/#440 (add-teacher) are **not** in this PR — triage showed the deployed code equals `main` and isn't reproducible; they need an interactive re-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
