### PR TITLE
fix(feedback): remaining UI fixes from Vneki's testing (#442 #445 #447 #448 #450)

### DIFF
--- a/backend/src/visuals/router.py
+++ b/backend/src/visuals/router.py
@@ -46,6 +46,23 @@ MAX_BYTES = int(os.environ.get("VISUAL_UPLOAD_MAX_BYTES", str(20 * 1024 * 1024))
 
 _SLUG_RE = re.compile(r"[^a-z0-9._-]+")
 
+# Path components (curriculum_id / unit_id / section_id) must look like real IDs:
+# start alphanumeric, then alnum / '.' '_' '-'. This rejects junk like
+# "===============" and, by excluding '/', prevents path traversal in the
+# storage key (feedback #445).
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def _validate_id(field: str, value: str) -> None:
+    if not _ID_RE.fullmatch(value or ""):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid {field}: must start with a letter or number and contain "
+                "only letters, numbers, '.', '_', or '-'."
+            ),
+        )
+
 
 def _slugify(name: str) -> str:
     base, ext = os.path.splitext(name.lower())
@@ -94,6 +111,10 @@ async def upload_visual(
     """
     if teacher["school_id"] != school_id:
         raise HTTPException(status_code=403, detail="Forbidden")
+
+    _validate_id("curriculum_id", curriculum_id)
+    _validate_id("unit_id", unit_id)
+    _validate_id("section_id", section_id)
 
     content_type = (file.content_type or "").lower()
     if content_type not in ALLOWED_MIME:

--- a/backend/tests/test_visuals_router.py
+++ b/backend/tests/test_visuals_router.py
@@ -94,6 +94,36 @@ async def test_upload_rejects_empty_file(client: AsyncClient, visuals_root: Path
 
 
 @pytest.mark.asyncio
+async def test_upload_rejects_junk_curriculum_id(client: AsyncClient, visuals_root: Path):
+    """Junk path components (e.g. '===============') are rejected with 400 (feedback #445)."""
+    school_id = str(uuid.uuid4())
+    token = make_teacher_token(school_id=school_id, role="teacher")
+    files = {"file": ("x.svg", io.BytesIO(_svg_payload()), "image/svg+xml")}
+    data = {"curriculum_id": "===============", "unit_id": "u", "section_id": "s1"}
+    res = await client.post(
+        f"/api/v1/schools/{school_id}/visuals/upload",
+        files=files, data=data,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 400, res.text
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_path_traversal_id(client: AsyncClient, visuals_root: Path):
+    """A unit_id containing a slash can't escape the storage key (feedback #445)."""
+    school_id = str(uuid.uuid4())
+    token = make_teacher_token(school_id=school_id, role="teacher")
+    files = {"file": ("x.svg", io.BytesIO(_svg_payload()), "image/svg+xml")}
+    data = {"curriculum_id": "c", "unit_id": "../../etc", "section_id": "s1"}
+    res = await client.post(
+        f"/api/v1/schools/{school_id}/visuals/upload",
+        files=files, data=data,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 400, res.text
+
+
+@pytest.mark.asyncio
 async def test_upload_rejects_other_school(client: AsyncClient, visuals_root: Path):
     """Teacher from school A cannot upload to school B."""
     school_a = str(uuid.uuid4())

--- a/web/app/(school)/school/catalog/page.tsx
+++ b/web/app/(school)/school/catalog/page.tsx
@@ -24,7 +24,7 @@ import {
   LayoutGrid,
   BookOpen as BookOpenIcon,
   CheckCircle2,
-  Circle,
+  Clock,
   BookMarked,
   Plus,
 } from "lucide-react";
@@ -83,7 +83,9 @@ function CatalogDetail({
         </span>
       </div>
 
-      {/* Subject list */}
+      {/* Subject list — these are content-readiness *indicators*, not selectable
+          controls. Adoption is whole-package via "Add to library" below; the empty
+          radio-style circle was misread as a pick-one control (feedback #442). */}
       {pkg.subjects.length > 0 ? (
         <ul className="divide-y divide-gray-50">
           {pkg.subjects.map((s) => (
@@ -94,14 +96,23 @@ function CatalogDetail({
                   aria-hidden="true"
                 />
               ) : (
-                <Circle
-                  className="h-3.5 w-3.5 shrink-0 text-gray-300"
+                <Clock
+                  className="h-3.5 w-3.5 shrink-0 text-amber-400"
                   aria-hidden="true"
                 />
               )}
               <span className="flex-1 text-gray-700">{s.subject_name ?? s.subject}</span>
               <span className="text-xs text-gray-400">
                 {s.unit_count} unit{s.unit_count !== 1 ? "s" : ""}
+              </span>
+              <span
+                className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
+                  s.has_content
+                    ? "bg-green-50 text-green-600"
+                    : "bg-amber-50 text-amber-600"
+                }`}
+              >
+                {s.has_content ? "Ready" : "Pending"}
               </span>
             </li>
           ))}

--- a/web/app/(school)/school/visuals/page.tsx
+++ b/web/app/(school)/school/visuals/page.tsx
@@ -30,6 +30,10 @@ import {
  * `visuals[]` array is a follow-up slice; for now this page lets a school
  * admin manage the asset pool that the tutorial JSON will reference.
  */
+// IDs must start alphanumeric, then alnum / '.' '_' '-' — mirrors the backend
+// guard so junk like "===============" is caught before upload (feedback #445).
+const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
 export default function VisualLibraryPage() {
   const teacher = useTeacher();
   const qc = useQueryClient();
@@ -84,11 +88,17 @@ export default function VisualLibraryPage() {
   const canSubmit = useMemo(
     () =>
       !!upFile &&
-      upCurriculum.trim().length > 0 &&
-      upUnit.trim().length > 0 &&
-      upSection.trim().length > 0,
+      ID_RE.test(upCurriculum.trim()) &&
+      ID_RE.test(upUnit.trim()) &&
+      ID_RE.test(upSection.trim()),
     [upFile, upCurriculum, upUnit, upSection],
   );
+
+  // True when the user has typed something that isn't a valid ID — drives the hint.
+  const showIdHint =
+    (upCurriculum.trim().length > 0 && !ID_RE.test(upCurriculum.trim())) ||
+    (upUnit.trim().length > 0 && !ID_RE.test(upUnit.trim())) ||
+    (upSection.trim().length > 0 && !ID_RE.test(upSection.trim()));
 
   if (!teacher) {
     return (
@@ -155,6 +165,12 @@ export default function VisualLibraryPage() {
                 />
               </div>
             </div>
+            {showIdHint && (
+              <p className="text-xs text-amber-600">
+                IDs must start with a letter or number and use only letters, numbers,
+                &quot;.&quot;, &quot;_&quot;, or &quot;-&quot;.
+              </p>
+            )}
             <div>
               <Label htmlFor="up-file">File (≤20 MB)</Label>
               <Input

--- a/web/app/not-found.tsx
+++ b/web/app/not-found.tsx
@@ -1,6 +1,28 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { LinkButton } from "@/components/ui/link-button";
 
+// Send "Go home" to the signed-in user's own portal home instead of the public
+// landing/login page, which reads as an unexpected logout (feedback #447).
+function homeHref(): string {
+  if (typeof window === "undefined") return "/";
+  try {
+    if (localStorage.getItem("sb_admin_token")) return "/admin";
+    if (localStorage.getItem("sb_teacher_token")) return "/school/dashboard";
+    if (localStorage.getItem("sb_token")) return "/student/dashboard";
+  } catch {
+    // localStorage blocked (private mode) — fall back to the public home.
+  }
+  return "/";
+}
+
 export default function NotFound() {
+  // Default to "/" for SSR/first paint, then resolve the portal home on the
+  // client so the markup matches and there's no hydration mismatch.
+  const [href, setHref] = useState("/");
+  useEffect(() => setHref(homeHref()), []);
+
   return (
     <div className="flex min-h-screen flex-col items-center justify-center px-4 text-center">
       <h1 className="text-6xl font-bold text-gray-200">404</h1>
@@ -8,7 +30,7 @@ export default function NotFound() {
       <p className="mt-2 text-gray-500">
         The page you&apos;re looking for doesn&apos;t exist.
       </p>
-      <LinkButton className="mt-6" href="/">
+      <LinkButton className="mt-6" href={href}>
         Go home
       </LinkButton>
     </div>

--- a/web/components/layout/AdministrationMenu.tsx
+++ b/web/components/layout/AdministrationMenu.tsx
@@ -113,7 +113,9 @@ export function AdministrationMenu() {
                   href={l.href}
                   onClick={() => setOpen(false)}
                   className={cn(
-                    "block px-4 py-2 text-sm transition-colors",
+                    // Indent items under the section heading so the heading↔item
+                    // hierarchy is visually clear (feedback #450).
+                    "block py-2 pr-4 pl-8 text-sm transition-colors",
                     pathname.startsWith(l.href)
                       ? "bg-blue-50 font-medium text-blue-700"
                       : "text-gray-700 hover:bg-gray-50",

--- a/web/components/layout/PortalHeader.tsx
+++ b/web/components/layout/PortalHeader.tsx
@@ -7,6 +7,7 @@ import { Eye } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AdministrationMenu } from "@/components/layout/AdministrationMenu";
 import { AccountMenu } from "@/components/layout/AccountMenu";
+import { useTeacher } from "@/lib/hooks/useTeacher";
 
 const PORTAL_ICONS = {
   public: { src: "/assets/home_banner.png", alt: "StudyBuddy" },
@@ -27,6 +28,22 @@ export function PortalHeader({
   // The clock appears after the first client-side effect and ticks every minute.
   const [now, setNow] = useState<Date | null>(null);
   const { enabled: dyslexic, toggle: toggleDyslexic } = useDyslexia();
+  const teacher = useTeacher();
+
+  // Which kind of account is signed in (feedback #448). For the school portal the
+  // school_admin vs teacher distinction comes from the JWT via useTeacher().
+  const roleLabel =
+    portal === "admin"
+      ? "Admin"
+      : portal === "student"
+        ? "Student"
+        : portal === "school"
+          ? teacher?.role === "school_admin"
+            ? "School Admin"
+            : teacher
+              ? "Teacher"
+              : null
+          : null;
 
   useEffect(() => {
     setNow(new Date());
@@ -88,6 +105,15 @@ export function PortalHeader({
         {/* School portal: username is the account-menu trigger (config + sign out
             moved off the left rail — issue #367 AP-4). Other portals keep the
             static username display. */}
+        {/* Role indicator — Admin / School Admin / Teacher / Student (#448).
+            Gated on `now` so it only renders after mount (avoids a hydration
+            mismatch from useTeacher reading the JWT from localStorage). */}
+        {now && roleLabel && (
+          <span className="hidden rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 sm:inline">
+            {roleLabel}
+          </span>
+        )}
+
         {portal === "school" ? (
           <div className="flex items-center gap-3">
             <AccountMenu userName={userName} />


### PR DESCRIPTION
## What

Fixes the five remaining UI tickets from Vneki's 2026-06-13 testing pass. Closes #442, #445, #447, #448, #450.

| # | Bug | Fix |
|---|---|---|
| #442 | Catalog subject circles looked like selectable radios but weren't | Swapped the empty circle for a clock + a **Ready/Pending** pill, with a comment clarifying adoption is whole-package. No more false "pick one" affordance. |
| #445 | Visual-asset upload accepted junk IDs (`===============`) | Validate `curriculum_id`/`unit_id`/`section_id` format on **both** client and backend (start alphanumeric, then `[A-Za-z0-9._-]`). Also closes a path-traversal hole in the storage key (no `/`). +2 backend tests. |
| #447 | 404 "Go home" dumped logged-in users on the public/login page | Route to the user's own portal home (admin / school / student) based on the token in `localStorage`. |
| #448 | No indication of which role is signed in | Role badge (Admin / School Admin / Teacher / Student) in `PortalHeader`, derived in-component, gated on mount to avoid hydration mismatch. |
| #450 | Administration menu headings vs items hard to tell apart | Indent items (`pl-8`) under the section headings. |

## Test plan

- ✅ Frontend: `prettier --check`, `eslint`, `tsc --noEmit`, and full `vitest` suite (834 tests) all pass locally.
- ✅ Backend: added `test_upload_rejects_junk_curriculum_id` and `test_upload_rejects_path_traversal_id`; the ID regex was verified standalone against the junk/traversal/valid cases. (Backend integration suite runs in CI — no Docker in the authoring env.)

## Notes

- #445: the validation is **format-only** (not an existence check against `curricula`) — that keeps the upload endpoint DB-free as it is today while still rejecting junk and traversal. A follow-up could add a referential check if desired.
- #448: admin portal shows "Admin" (not the specific super/product/etc. sub-role) — enough to satisfy the "which kind of user" ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
