### PR TITLE
fix(feedback): add-teacher 422 no longer crashes the page (#440)

### DIFF
--- a/web/app/(school)/school/teachers/page.tsx
+++ b/web/app/(school)/school/teachers/page.tsx
@@ -500,13 +500,38 @@ export default function TeachersPage() {
       queryClient.invalidateQueries({ queryKey: ["teachers", schoolId] });
     },
     onError: (err: unknown) => {
-      const status = (err as { response?: { status?: number } })?.response?.status;
+      const resp = (
+        err as { response?: { status?: number; data?: { detail?: unknown } } }
+      )?.response;
+      const status = resp?.status;
       if (status === 409) {
         setAddError("A teacher with that email already exists.");
+      } else if (status === 422) {
+        // FastAPI 422 `detail` is an array of {loc, msg} objects. It must NEVER be
+        // set raw — rendering an object array as a React child throws and trips the
+        // "This page couldn't load" error boundary (feedback #440). Map it to a
+        // field-specific message instead.
+        const detail = resp?.data?.detail;
+        const fields = Array.isArray(detail)
+          ? detail.flatMap((d) =>
+              Array.isArray((d as { loc?: unknown[] })?.loc)
+                ? ((d as { loc: unknown[] }).loc as unknown[]).map(String)
+                : [],
+            )
+          : [];
+        if (fields.includes("email")) {
+          setAddError("Enter a valid work email address.");
+        } else if (fields.includes("name")) {
+          setAddError("Enter the teacher's full name.");
+        } else {
+          setAddError(
+            typeof detail === "string"
+              ? detail
+              : "Please check the name and email and try again.",
+          );
+        }
       } else {
-        const detail = (err as { response?: { data?: { detail?: string } } })?.response
-          ?.data?.detail;
-        setAddError(detail ?? "Could not add teacher. Please try again.");
+        setAddError("Could not add teacher. Please try again.");
       }
     },
   });

--- a/web/tests/unit/teachers-page.test.tsx
+++ b/web/tests/unit/teachers-page.test.tsx
@@ -174,6 +174,48 @@ describe("SCH-43 — Successful provisioning", () => {
 });
 
 // ---------------------------------------------------------------------------
+// SCH-43b — A 422 validation error must not crash the page (feedback #440).
+// FastAPI returns detail as an ARRAY of objects; rendering it raw threw
+// "Objects are not valid as a React child" → "This page couldn't load".
+// ---------------------------------------------------------------------------
+
+describe("SCH-43b — 422 validation error shows a message, not a crash", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseTeacher.mockReturnValue(MOCK_ADMIN);
+    mockUseQuery.mockReturnValue({ data: { alerts: [] }, isLoading: false });
+    mockProvisionTeacher.mockRejectedValue({
+      response: {
+        status: 422,
+        data: {
+          detail: [
+            {
+              type: "value_error",
+              loc: ["body", "email"],
+              msg: "value is not a valid email address",
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it("maps the 422 detail array to a friendly email message", async () => {
+    render(<TeachersPage />);
+    fireEvent.change(screen.getByLabelText(TEACHERS_STRINGS.nameLabel), {
+      target: { value: "Junk" },
+    });
+    fireEvent.change(screen.getByLabelText(TEACHERS_STRINGS.emailLabel), {
+      target: { value: "notanemail" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: TEACHERS_STRINGS.addBtn }));
+    expect(
+      await screen.findByText("Enter a valid work email address."),
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // SCH-44 — Teachers/Students moved off the left rail into the Administration
 // menu (#415). The rail no longer lists them; the top-bar AdministrationMenu
 // gates them (User Management = school_admin only).


### PR DESCRIPTION
## What

Verified on the live demo: **POST add-teacher with an invalid email returns a 422** whose `detail` is an **array** of `{loc, msg}` objects. The handler did `setAddError(detail)` and the page renders `{addError && <p>{addError}</p>}` — rendering an object array throws *"Objects are not valid as a React child"* and trips the **"This page couldn't load"** error boundary (#440).

Fix: parse the 422 `detail` array into a field-specific message (email / name), mirroring the #438 students-page fix. Falls back to a string `detail` or a generic message. Keeps the 409 duplicate path unchanged.

Closes #440.

## Verification
- Reproduced the trigger live: `/api/v1/schools/{id}/teachers` → 409 (duplicate) and **422 (invalid email, detail = array)** confirmed against demo.usestudybuddy.com.
- #439 (error text *inside* the input fields) is **not** a defect — inputs bind to state; the 409 renders as a separate message. It's a tester-input artifact (same as the #438 screenshot). Closing #439 separately as not-reproducible.

## Test plan
- +1 regression test `SCH-43b` (422 detail array → friendly message, no crash); teachers-page suite 13/13.
- prettier + eslint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)