### PR TITLE
docs(test-cycles): repeatable test-cycle report process + 2026-06-13 report

### DIFF
--- a/docs/test-cycles/2026-06-13.md
+++ b/docs/test-cycles/2026-06-13.md
@@ -1,0 +1,96 @@
+# StudyBuddy — Test Cycle Report — 2026-06-13
+
+**Build under test:** latest `main` (`fa35cd5`) on <https://demo.usestudybuddy.com>
+**Prepared for:** Venki
+**Prepared by:** StudyBuddy team · **Date:** 2026-06-13
+
+> From the `Feedback_06_13_2026` pass: **17 items** reported. **12 fixed and live**, **1 was
+> not a defect**, **4 deferred** (low-priority copy/docs + one planned feature). Two new
+> surfaces to look at. All demo accounts have been reset to a known password (section 3C).
+
+---
+
+## 1. Issues reported & fixes
+
+| # | Issue | Status | Fix / Notes |
+|---|---|---|---|
+| #437 | Bulk enrol by email always failed ("Failed to enrol…") | ✅ Fixed | Was sending the wrong payload to the server; now enrols correctly (PR #454) |
+| #438 | "Add student" always said "Invalid grade" | ✅ Fixed | Error now names the real problem field — email / grade / name (PR #454) |
+| #439 | "Add teacher" error text appeared *inside* the Name/Email boxes | ⚠️ Not a bug | The boxes show your typed value; the duplicate-email error shows as a separate red message. The screenshot was text pasted into the fields. Closed. |
+| #440 | "Add teacher" → **"This page couldn't load"** | ✅ Fixed | An invalid email used to crash the page; it now shows a friendly inline message (PR #457) |
+| #441 | Bulk-enrol box help text is unclear (commas? one or many?) | 🟡 Open | Copy tweak, low priority — **not in this build** |
+| #442 | Catalog subjects had circles that looked like selectable radio buttons | ✅ Fixed | Replaced with clear **Ready / Pending** status (adoption is whole-package via "Add to library") (PR #455) |
+| #443 | First-login "Current password is incorrect" (callmds@gmail.com) | ✅ Resolved for testing | `callmds@gmail.com` is a **student**, and that screen's "Current password" means the **temporary password from the welcome email** — not a chosen value. All demo accounts are now reset to a known password (3C). *(Optional wording tweak to that field still open.)* |
+| #444 | No self-serve "forgot password" for school-provisioned users | 🟡 Open (feature) | Stop-gap: we reset accounts for you. A real self-serve reset is a **planned feature** — not in this build. |
+| #445 | Visual Asset Library accepted junk Curriculum/Unit/Section IDs | ✅ Fixed | IDs are now validated (and junk like `====` is rejected) on screen and on the server (PR #455) |
+| #446 | "Configure thresholds" link gave a 404 | ✅ Fixed | Built the **Alert thresholds** settings page the link points to (PR #454) — see 2 & 3B |
+| #447 | 404 page's "Go home" logged you out | ✅ Fixed | "Go home" now returns you to *your* portal home, not the public/login page (PR #455) |
+| #448 | Couldn't tell which role you're signed in as | ✅ Fixed | A role badge (Admin / School Admin / Teacher / Student) now shows in the top bar (PR #455) |
+| #449 | Unclear where uploaded visual assets are seen/used | 🟡 Open | Discoverability/docs improvement planned — **not in this build** |
+| #450 | Administration menu: headings vs items hard to tell apart | ✅ Fixed | Items are now indented under their section headings (PR #455) |
+| #451 | Trends CSV weeks started on **Saturday** | ✅ Fixed | Weeks now start on **Monday** (PR #454) |
+| #452 | Report CSV headers said `pct` | ✅ Fixed | Now shown as `%` (e.g. "Active %", "First-attempt pass rate %") (PR #454) |
+| #453 | Unit Performance CSV showed junk `ï»¿` (when there's no data) | ✅ Fixed | Empty exports now produce a clean header row, no junk character (PR #454) |
+
+Legend: ✅ Fixed & live · ⚠️ Not a defect (closed) · 🟡 Open (not in this build).
+
+---
+
+## 2. Additional features added
+
+- **Alert thresholds settings page** *(new)* — School portal → **Reports → Alert Inbox →
+  "Configure thresholds"** (or `/school/reports/alerts/settings`). Set the pass-rate,
+  inactivity, feedback-count, and score-drop thresholds that drive alerts.
+- **Role badge in the top bar** — now always shows whether you're signed in as Admin /
+  School Admin / Teacher / Student.
+
+*(Behind the scenes we also restored the demo's DNS and auto-deploy pipeline, so future fixes
+ship to the demo automatically — nothing to test there.)*
+
+---
+
+## 3. What to test next + accounts
+
+### A. Please re-verify these fixes
+| # | How to verify |
+|---|---|
+| #437 | Students → **Bulk enrol by email** → paste 1+ emails (comma/newline) → should enrol, no error |
+| #438 | Students → **Add a student** → use a bad email but a valid grade → error should mention the **email**, not the grade |
+| #440 | Teachers → **Add a teacher** → enter a junk/invalid email → should show an inline message, **not** "This page couldn't load" |
+| #442 | School → **Catalog** → open a package → subjects show **Ready/Pending**, not empty radio circles |
+| #445 | Visual Asset Library → try a junk Curriculum ID (e.g. `====`) → should be rejected |
+| #446 | Reports → **Alert Inbox → Configure thresholds** → opens the settings page (no 404) |
+| #447 | Visit any bad URL → **Go home** → lands on your portal dashboard (still logged in) |
+| #448 | Any portal → top bar shows your **role badge** |
+| #450 | Top bar → **Administration** menu → items are indented under "Curriculum"/"User Management" |
+| #451 | Reports → **Export CSV → Trends** → `week start` dates are **Mondays** |
+| #452 | Reports → **Export CSV → Overview/Trends** → headers use **%**, not `pct` |
+| #453 | Reports → **Export CSV → Unit performance** → opens cleanly in Excel (no `ï»¿`), with headers even when empty |
+
+### B. Exercise these new/changed areas
+- **Alert thresholds page** (#446 / feature) — change each threshold and Save; confirm it saves.
+- **Role badge** (#448) — sign in as different account types and confirm the badge matches.
+
+### C. Accounts to use (demo — <https://demo.usestudybuddy.com>)
+> Demo-only credentials — not real data. **Password for all accounts: `StudyBuddyDemo2026!`**
+> (All active demo accounts were reset to this on 2026-06-13.)
+
+| Login | Role | School / grade |
+|---|---|---|
+| `siva.mambakkam@gmail.com` | School Admin | MilfordWaterford *(the school in your screenshots)* |
+| `venki.kt@gmail.com` | School Admin | ABC School |
+| `callmds@gmail.com` | Student | MilfordWaterford, Grade 8 |
+| `kt.shanvenki@gmail.com` | Student | ABC School, Grade 10 |
+
+*(Other demo teachers/students exist and share the same password — ask if you need a specific one.)*
+
+### D. Known open / not in this build (no need to re-report)
+- **#441** — bulk-enrol help text wording (copy tweak).
+- **#443** — optional relabel of the first-login "Current password" field (the account login itself works now).
+- **#444** — self-serve "forgot password" for school accounts (planned feature; we reset accounts on request meanwhile).
+- **#449** — clearer "where do uploaded visuals appear" guidance.
+
+### E. How to report what you find
+- One item per finding is ideal. A **screenshot + the steps + which account you used** makes
+  it fast to reproduce. We'll log each as a `[Feedback]` issue and it'll show up in the next
+  cycle report.

--- a/docs/test-cycles/README.md
+++ b/docs/test-cycles/README.md
@@ -1,0 +1,57 @@
+# Test Cycle Reports — Process
+
+After each QA / test cycle we produce **one Markdown report** to hand back to the
+tester (e.g. Venki) and keep as project history. Every report has the same three
+sections:
+
+1. **Issues reported & their fixes** — everything the tester raised, and what we did.
+2. **Additional features added** — anything new shipped this cycle beyond the reported bugs.
+3. **What to test next + accounts** — the regression checklist, new things to exercise,
+   and the demo logins to use.
+
+Reports live in [`docs/test-cycles/<YYYY-MM-DD>.md`](.) (one per cycle), generated from
+[`TEMPLATE.md`](TEMPLATE.md). The latest is the most recent dated file.
+
+---
+
+## Conventions (do these during the cycle so the report assembles itself)
+
+- **One GitHub issue per reported item**, titled `[Feedback] <summary>`. This title prefix is
+  what the generator searches for.
+- Optionally tag each issue with a per-cycle label `cycle:<YYYY-MM-DD>` or a **milestone** —
+  this lets the generator scope a single cycle precisely instead of "all `[Feedback]` issues".
+- **Fixes land via PRs to `main`** that use a closing keyword per issue
+  (`Closes #437`, `Closes #438`, …). GitHub then auto-closes the issue on merge and the
+  issue ↔ PR link is recorded automatically. (Note: `Closes #437, #438` only closes the
+  **first** number — repeat the keyword: `Closes #437, closes #438`.)
+- Items that turn out **not** to be defects are closed as *not planned* with a one-line
+  rationale comment — they still appear in the report (status: "Not a bug").
+
+## Producing a report
+
+1. **Draft section 1** from GitHub:
+   ```bash
+   scripts/test_cycle_report.sh              # all [Feedback] issues + state
+   scripts/test_cycle_report.sh cycle:2026-06-13   # scoped to one cycle label/milestone
+   ```
+   This prints a Markdown table of issues + open/closed state. Add the fixing **PR #** to
+   each row (find it on the closed issue, or via
+   `gh pr list --state merged --search "merged:>=<cycle-start>"`).
+2. **Copy the template** to a dated file and fill all three sections:
+   ```bash
+   cp docs/test-cycles/TEMPLATE.md docs/test-cycles/$(date +%F).md   # run in a real shell
+   ```
+3. **Section 3 accounts** come from the demo environment. Keep them in sync with the
+   account roster (the team's secure note / the demo-credentials reference). Treat the
+   shared demo password as **demo-only** — fine to put in this report, but rotate it if the
+   demo ever holds real student data.
+4. **Commit** on a `docs/test-cycle-<date>` branch → PR → merge (docs-only, CI is fast).
+5. **Send** the rendered Markdown to the tester.
+
+## Definition of done for a cycle report
+
+- Every `[Feedback]` issue from the cycle appears in section 1 with a status and (if fixed)
+  a PR link.
+- Section 3 lists a concrete re-verify step for each fix and the exact accounts to use.
+- Still-open items are listed under "Known open / not in this build" so the tester doesn't
+  re-report them.

--- a/docs/test-cycles/TEMPLATE.md
+++ b/docs/test-cycles/TEMPLATE.md
@@ -1,0 +1,58 @@
+# StudyBuddy — Test Cycle Report — <YYYY-MM-DD>
+
+**Build under test:** `<git sha / "latest main">` on <https://demo.usestudybuddy.com>
+**Prepared for:** <tester name>
+**Prepared by:** <author> · **Date:** <YYYY-MM-DD>
+
+> Short 1–2 line summary of the cycle (e.g. "N issues reported, M fixed and live, K
+> deferred. Two new surfaces to exercise.").
+
+---
+
+## 1. Issues reported & fixes
+
+| # | Issue | Status | Fix / Notes |
+|---|---|---|---|
+| #NNN | <short summary> | ✅ Fixed | <what changed> (PR #NN) |
+| #NNN | <short summary> | ⚠️ Not a bug | <why> |
+| #NNN | <short summary> | 🟡 Open | <reason deferred> |
+
+Legend: ✅ Fixed & live · ⚠️ Not a defect (closed) · 🟡 Open (not in this build).
+
+---
+
+## 2. Additional features added
+
+Anything new this cycle beyond the reported bugs — worth a look even though nobody
+asked for it.
+
+- **<feature>** — <one line: what it is + where to find it>.
+- _(If the cycle was purely fixes, say so.)_
+
+---
+
+## 3. What to test next + accounts
+
+### A. Re-verify these fixes
+| # | How to verify |
+|---|---|
+| #NNN | <concrete steps to confirm the fix> |
+
+### B. Exercise these new/changed areas
+- <area> — <what to try>.
+
+### C. Accounts to use (demo — `https://demo.usestudybuddy.com`)
+> Demo-only credentials. Not real data.
+
+| Login | Role | Notes |
+|---|---|---|
+| <email> | <role> | <school / grade> |
+
+Password for all: `<shared demo password>`
+
+### D. Known open / not in this build (please don't re-report)
+- #NNN — <summary> (<why deferred>).
+
+### E. How to report what you find
+- File one item per finding, or send a doc and we'll log them as `[Feedback]` issues.
+- A screenshot + the steps + which account you used is ideal.

--- a/scripts/test_cycle_report.sh
+++ b/scripts/test_cycle_report.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Draft section 1 of a test-cycle report — a Markdown table of [Feedback] issues
+# and their state. Add the fixing PR # to each row by hand (see the closed issue).
+#
+# Usage:
+#   scripts/test_cycle_report.sh                 # all [Feedback] issues
+#   scripts/test_cycle_report.sh cycle:2026-06-13  # scoped to a cycle label or milestone
+#
+# Requires: gh (authenticated). See docs/test-cycles/README.md for the full process.
+set -euo pipefail
+
+REPO="${REPO:-wegofwd2020-hub/StudyBuddy_OnDemand}"
+SCOPE="${1:-}"
+
+# Build the gh search query: always match the [Feedback] title prefix; optionally
+# AND a label/milestone scope (e.g. cycle:2026-06-13 or milestone:"Cycle 2026-06-13").
+SEARCH='[Feedback] in:title'
+if [ -n "$SCOPE" ]; then
+  case "$SCOPE" in
+    label:*|milestone:*) SEARCH="$SEARCH $SCOPE" ;;
+    *)                   SEARCH="$SEARCH label:$SCOPE" ;;
+  esac
+fi
+
+echo "<!-- generated from: gh issue list --search \"$SEARCH\" -->"
+echo
+echo "| # | Status | Issue | Fix / Notes |"
+echo "|---|---|---|---|"
+gh issue list --repo "$REPO" --state all --search "$SEARCH" --limit 300 \
+  --json number,state,title \
+  -q 'sort_by(.number)[]
+      | "| #\(.number) | \(if .state=="CLOSED" then "✅/⚠️ CLOSED" else "🟡 OPEN" end) | \(.title | sub("^\\[Feedback\\] ";"")) | _(fill in: PR # / why)_ |"'


### PR DESCRIPTION
## What

A repeatable process for producing a **test-cycle hand-off report** after each QA pass, plus the filled report for the 2026-06-13 cycle (ready to send to Venki).

Every report has 3 sections: **(1)** issues reported & fixes, **(2)** additional features added, **(3)** what to test next + accounts.

| File | Purpose |
|---|---|
| `docs/test-cycles/README.md` | The process + conventions (one `[Feedback]` issue per item, optional per-cycle label/milestone, `Closes #NNN` in fixing PRs) |
| `docs/test-cycles/TEMPLATE.md` | Blank template for future cycles |
| `docs/test-cycles/2026-06-13.md` | Filled report for this cycle (#437–#453): 12 fixed, 1 not-a-bug, 4 deferred; new alert-thresholds page + role badge; demo accounts + re-verify checklist |
| `scripts/test_cycle_report.sh` | Drafts section 1 (Markdown table of `[Feedback]` issues + state) via `gh` |

## Notes
- The 2026-06-13 report includes the **demo-only** shared password for the tester. The repo is private and it's a throwaway demo credential; rotate if the demo ever holds real data.
- Generator currently scopes by the `[Feedback]` title prefix; for precise per-cycle scoping, tag issues with a `cycle:<date>` label or milestone (documented in the README).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)