### PR TITLE
fix(feedback): quiz score clamp (#460) + subject-name resolution (#462)

### DIFF
--- a/backend/src/analytics/router.py
+++ b/backend/src/analytics/router.py
@@ -41,6 +41,7 @@ from src.analytics.service import (
 )
 from src.auth.dependencies import get_current_student, get_current_teacher
 from src.core.db import get_db
+from src.core.subjects import display_subject, resolve_subject_labels
 from src.utils.logger import get_logger
 
 log = get_logger("analytics")
@@ -221,17 +222,23 @@ async def student_stats(
             student_id,
         )
 
-        # Subject breakdown (last 30 days) — grouped by subject column on progress_sessions
-        subj_rows = await conn.fetch(
+        # Subject breakdown (last 30 days). Grouped per unit so we can resolve
+        # human-readable subject names (issue #462) before aggregating — the raw
+        # progress_sessions.subject column holds codes / "unknown".
+        unit_subj_rows = await conn.fetch(
             """
-            SELECT subject, COUNT(*) AS lessons,
-                   AVG(CASE WHEN passed THEN 100.0 ELSE 0.0 END) AS pass_rate
+            SELECT unit_id, subject,
+                   COUNT(*) AS lessons,
+                   SUM(CASE WHEN passed THEN 1 ELSE 0 END) AS passed_count
             FROM progress_sessions
             WHERE student_id = $1
               AND started_at >= NOW() - INTERVAL '30 days'
-            GROUP BY 1
+            GROUP BY unit_id, subject
             """,
             student_id,
+        )
+        subject_labels = await resolve_subject_labels(
+            conn, [r["unit_id"] for r in unit_subj_rows]
         )
 
     session_dates = [str(r["session_date"]) for r in rows]
@@ -257,6 +264,22 @@ async def student_stats(
 
     vr = dict(view_rows[0]) if view_rows else {}
 
+    # Aggregate the per-unit rows into per-(display)-subject totals.
+    breakdown: dict[str, dict[str, int]] = {}
+    for r in unit_subj_rows:
+        label = display_subject(subject_labels, r["unit_id"], r["subject"])
+        agg = breakdown.setdefault(label, {"lessons": 0, "passed": 0})
+        agg["lessons"] += int(r["lessons"])
+        agg["passed"] += int(r["passed_count"] or 0)
+    subject_breakdown = [
+        {
+            "subject": label,
+            "lessons": agg["lessons"],
+            "pass_rate": round(agg["passed"] / agg["lessons"], 4) if agg["lessons"] else 0.0,
+        }
+        for label, agg in sorted(breakdown.items())
+    ]
+
     return {
         "streak_days": streak,
         "session_dates": session_dates,
@@ -265,14 +288,7 @@ async def student_stats(
         "pass_rate": round(total_passed / total_scored, 4) if total_scored else 0.0,
         "avg_score": round(avg_score / 100, 4),
         "audio_sessions": int(vr.get("audio_sessions") or 0),
-        "subject_breakdown": [
-            {
-                "subject": r["subject"],
-                "lessons": int(r["lessons"]),
-                "pass_rate": round(float(r["pass_rate"] or 0), 4),
-            }
-            for r in subj_rows
-        ],
+        "subject_breakdown": subject_breakdown,
     }
 
 

--- a/backend/src/analytics/service.py
+++ b/backend/src/analytics/service.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncpg
 
+from src.core.subjects import display_subject, resolve_subject_labels
 from src.utils.logger import get_logger
 
 log = get_logger("analytics")
@@ -162,10 +163,13 @@ async def get_student_metrics(
         student_id,
     )
 
+    # Resolve human-readable subject names (issue #462).
+    subject_labels = await resolve_subject_labels(conn, [r["unit_id"] for r in unit_rows])
+
     per_unit = [
         {
             "unit_id": r["unit_id"],
-            "subject": r["subject"],
+            "subject": display_subject(subject_labels, r["unit_id"], r["subject"]),
             "quiz_attempts": r["quiz_attempts"] or 0,
             "best_score_pct": float(r["best_score_pct"])
             if r["best_score_pct"] is not None

--- a/backend/src/core/subjects.py
+++ b/backend/src/core/subjects.py
@@ -1,0 +1,78 @@
+"""
+backend/src/core/subjects.py
+
+Subject-label resolution shared across the read paths (progress history, student
+metrics, student stats, teacher student-report).
+
+Why this exists — feedback issue #462 ("Subject shows 'Unknown' everywhere"):
+`progress_sessions.subject` stores a subject *code* (e.g. "G8-SCI"), or the
+literal "unknown" when the unit could not be resolved at session-create time.
+The human-readable name (e.g. "Natural Sciences") lives in
+`content_subject_versions.subject_name` (CLAUDE.md pitfall #32). Reporting
+queries that surface `progress_sessions.subject` directly therefore show codes
+or "unknown" instead of real names.
+
+`resolve_subject_labels()` maps a set of unit_ids → display name by joining
+`curriculum_units` (the authoritative code per unit) to
+`content_subject_versions` (the display name), independent of whatever is stored
+on the session row. Callers fall back to their stored value / "Unknown" for any
+unit_id the map doesn't cover.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import asyncpg
+
+
+async def resolve_subject_labels(
+    conn: asyncpg.Connection,
+    unit_ids: Iterable[str],
+) -> dict[str, str]:
+    """
+    Return {unit_id: subject_display_name} for the given unit_ids.
+
+    Prefers `content_subject_versions.subject_name`; falls back to the raw
+    `curriculum_units.subject` code. unit_ids with no curriculum_units row are
+    omitted (the caller decides the fallback). The DISTINCT ON keeps one label
+    per unit_id even when multiple content versions exist, so this never fans
+    out a caller's aggregate counts.
+    """
+    ids = [u for u in dict.fromkeys(unit_ids) if u]  # dedupe, drop falsy
+    if not ids:
+        return {}
+
+    rows = await conn.fetch(
+        """
+        SELECT DISTINCT ON (cu.unit_id)
+               cu.unit_id,
+               COALESCE(csv.subject_name, cu.subject) AS subject_label
+        FROM curriculum_units cu
+        LEFT JOIN content_subject_versions csv
+            ON  csv.curriculum_id = cu.curriculum_id
+            AND csv.subject       = cu.subject
+            AND csv.subject_name IS NOT NULL
+        WHERE cu.unit_id = ANY($1::text[])
+        ORDER BY cu.unit_id, csv.version_number DESC NULLS LAST
+        """,
+        ids,
+    )
+    return {r["unit_id"]: r["subject_label"] for r in rows if r["subject_label"]}
+
+
+def display_subject(
+    label_map: dict[str, str],
+    unit_id: str,
+    stored_subject: str | None,
+) -> str:
+    """
+    Resolve the best display name for one row: the curriculum-derived label,
+    else the stored subject (unless it's the "unknown" sentinel), else "Unknown".
+    """
+    label = label_map.get(unit_id)
+    if label:
+        return label
+    if stored_subject and stored_subject.lower() != "unknown":
+        return stored_subject
+    return "Unknown"

--- a/backend/src/progress/service.py
+++ b/backend/src/progress/service.py
@@ -17,6 +17,7 @@ from datetime import UTC, datetime
 
 import asyncpg
 
+from src.core.subjects import display_subject, resolve_subject_labels
 from src.utils.logger import get_logger
 
 log = get_logger("progress")
@@ -187,9 +188,16 @@ async def end_session(
 ) -> dict:
     """
     Mark a session as completed.  Computes passed flag.
+
+    Score and total are clamped server-side so a malformed client payload (or a
+    quiz whose question count differs from the supplied total) can never persist
+    an impossible result such as 8/5 = 160%.  See feedback issue #460.
     Returns the updated session.
     """
-    passed = (score / total_questions) >= QUIZ_PASS_THRESHOLD if total_questions > 0 else False
+    total_questions = max(1, total_questions)
+    # A student can never score more than the number of questions, nor below zero.
+    score = max(0, min(score, total_questions))
+    passed = (score / total_questions) >= QUIZ_PASS_THRESHOLD
 
     row = await conn.fetchrow(
         """
@@ -258,6 +266,10 @@ async def get_raw_history(
         student_id,
     )
 
+    # Resolve human-readable subject names (issue #462) instead of surfacing the
+    # raw code / "unknown" stored on the session row.
+    subject_labels = await resolve_subject_labels(conn, [s["unit_id"] for s in sessions])
+
     result_sessions = []
     for s in sessions:
         answers = await conn.fetch(
@@ -275,7 +287,7 @@ async def get_raw_history(
                 "unit_id": s["unit_id"],
                 "curriculum_id": s["curriculum_id"],
                 "grade": s["grade"],
-                "subject": s["subject"],
+                "subject": display_subject(subject_labels, s["unit_id"], s["subject"]),
                 "started_at": s["started_at"].isoformat(),
                 "ended_at": s["ended_at"].isoformat() if s["ended_at"] else None,
                 "score": s["score"],

--- a/backend/src/reports/service.py
+++ b/backend/src/reports/service.py
@@ -21,6 +21,7 @@ from datetime import UTC, datetime, timedelta
 
 import asyncpg
 
+from src.core.subjects import display_subject, resolve_subject_labels
 from src.utils.logger import get_logger
 
 log = get_logger("reports")
@@ -531,11 +532,14 @@ async def get_student_report(
         )
         unit_names = {r["unit_id"]: r["unit_name"] for r in name_rows if r["unit_name"]}
 
+    # Resolve human-readable subject names (issue #462).
+    subject_labels = await resolve_subject_labels(conn, unit_ids)
+
     per_unit = [
         {
             "unit_id": r["unit_id"],
             "unit_name": unit_names.get(r["unit_id"]),
-            "subject": r["subject"],
+            "subject": display_subject(subject_labels, r["unit_id"], r["subject"]),
             "lesson_viewed": bool(r["lesson_viewed"]),
             "quiz_attempts": r["quiz_attempts"] or 0,
             "best_score": float(r["best_score"]) if r["best_score"] is not None else None,
@@ -545,10 +549,10 @@ async def get_student_report(
         for r in unit_rows
     ]
 
-    # Strongest / needs-attention subject
+    # Strongest / needs-attention subject (keyed on the resolved display name)
     subj_scores: dict[str, list[float]] = {}
     for r in unit_rows:
-        s = r["subject"]
+        s = display_subject(subject_labels, r["unit_id"], r["subject"])
         if r["best_score"] is not None:
             subj_scores.setdefault(s, []).append(float(r["best_score"]))
     subj_avg = {s: sum(v) / len(v) for s, v in subj_scores.items() if v}

--- a/backend/tests/test_feedback_460_462.py
+++ b/backend/tests/test_feedback_460_462.py
@@ -1,0 +1,163 @@
+"""
+tests/test_feedback_460_462.py
+
+Regression tests for two QA-cycle feedback fixes (2026-06-14):
+
+  #460 — Quiz score must never exceed the number of questions. `end_session`
+         clamps score to [0, total] so impossible results (e.g. 8/5 = 160%)
+         can never be persisted.
+
+  #462 — Subject must resolve to a human-readable display name, not the raw
+         code or the literal "unknown" sentinel. `resolve_subject_labels` /
+         `display_subject` resolve via curriculum_units + content_subject_versions.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+
+from src.core.subjects import display_subject, resolve_subject_labels
+from tests.helpers.token_factory import make_student_token
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+async def _insert_student(client: AsyncClient, student_id: str) -> None:
+    pool = client._transport.app.state.pool
+    await pool.execute(
+        """
+        INSERT INTO students (student_id, external_auth_id, name, email, grade, locale, account_status)
+        VALUES ($1, $2, $3, $4, 8, 'en', 'active')
+        ON CONFLICT (student_id) DO NOTHING
+        """,
+        uuid.UUID(student_id),
+        f"auth0|test-{student_id.replace('-', '')[:20]}",
+        f"Test Student {student_id[:6]}",
+        f"test-{student_id[:6]}@test.invalid",
+    )
+
+
+async def _start_session(client: AsyncClient, token: str) -> dict:
+    r = await client.post(
+        "/api/v1/progress/session",
+        json={"unit_id": "G8-MATH-001", "curriculum_id": "default-2026-g8"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+# ── #460 — score clamp ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_end_session_clamps_score_above_total(client, db_conn):
+    """A score greater than total_questions is clamped to total (no 8/5=160%)."""
+    student_id = str(uuid.uuid4())
+    await _insert_student(client, student_id)
+    token = make_student_token(student_id=student_id, grade=8)
+    session = await _start_session(client, token)
+
+    # end_session dispatches streak/view-refresh Celery tasks via send_task.
+    with patch("src.auth.tasks.celery_app.send_task", return_value=None):
+        r = await client.post(
+            f"/api/v1/progress/session/{session['session_id']}/end",
+            json={"score": 8, "total_questions": 5},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["score"] == 5  # clamped from 8
+    assert data["total_questions"] == 5
+    assert data["passed"] is True
+
+
+@pytest.mark.asyncio
+async def test_end_session_valid_score_unchanged(client, db_conn):
+    """A normal score passes through untouched and computes passed correctly."""
+    student_id = str(uuid.uuid4())
+    await _insert_student(client, student_id)
+    token = make_student_token(student_id=student_id, grade=8)
+    session = await _start_session(client, token)
+
+    with patch("src.auth.tasks.celery_app.send_task", return_value=None):
+        r = await client.post(
+            f"/api/v1/progress/session/{session['session_id']}/end",
+            json={"score": 2, "total_questions": 8},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["score"] == 2
+    assert data["total_questions"] == 8
+    assert data["passed"] is False  # 2/8 = 25% < 60%
+
+
+# ── #462 — subject label resolution ───────────────────────────────────────────
+
+
+async def _seed_curriculum(db_conn, curriculum_id: str, subject_code: str, subject_name: str | None):
+    await db_conn.execute(
+        "INSERT INTO curricula (curriculum_id, grade, year, name) VALUES ($1, 8, 2026, $2)",
+        curriculum_id,
+        f"Test {curriculum_id}",
+    )
+    await db_conn.execute(
+        "INSERT INTO curriculum_units (unit_id, curriculum_id, subject, title, unit_name) "
+        "VALUES ($1, $2, $3, $4, $4)",
+        f"{subject_code}-005",
+        curriculum_id,
+        subject_code,
+        "Mechanical Systems",
+    )
+    await db_conn.execute(
+        """
+        INSERT INTO content_subject_versions (curriculum_id, subject, subject_name, version_number, status)
+        VALUES ($1, $2, $3, 1, 'published')
+        """,
+        curriculum_id,
+        subject_code,
+        subject_name,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_subject_labels_prefers_subject_name(db_conn):
+    """Display name from content_subject_versions wins over the raw code."""
+    cid = f"test-cur-{uuid.uuid4().hex[:8]}"
+    await _seed_curriculum(db_conn, cid, "G8-SCI", "Natural Sciences")
+
+    labels = await resolve_subject_labels(db_conn, ["G8-SCI-005"])
+    assert labels["G8-SCI-005"] == "Natural Sciences"
+
+
+@pytest.mark.asyncio
+async def test_resolve_subject_labels_falls_back_to_code(db_conn):
+    """With no subject_name, the curriculum_units code is used (never 'unknown')."""
+    cid = f"test-cur-{uuid.uuid4().hex[:8]}"
+    await _seed_curriculum(db_conn, cid, "G8-MATH", None)
+
+    labels = await resolve_subject_labels(db_conn, ["G8-MATH-005"])
+    assert labels["G8-MATH-005"] == "G8-MATH"
+
+
+@pytest.mark.asyncio
+async def test_resolve_subject_labels_empty_input(db_conn):
+    assert await resolve_subject_labels(db_conn, []) == {}
+
+
+def test_display_subject_resolution_order():
+    """Pure-function fallback chain: map → stored (non-sentinel) → 'Unknown'."""
+    label_map = {"u1": "Physics"}
+    # curriculum label wins even when the stored value is the 'unknown' sentinel
+    assert display_subject(label_map, "u1", "unknown") == "Physics"
+    # no map entry → fall back to a meaningful stored code
+    assert display_subject({}, "u2", "G8-SCI") == "G8-SCI"
+    # no map entry and stored is the sentinel → 'Unknown'
+    assert display_subject({}, "u2", "unknown") == "Unknown"
+    assert display_subject({}, "u2", "UNKNOWN") == "Unknown"
+    assert display_subject({}, "u2", None) == "Unknown"

--- a/web/app/(student)/progress/page.tsx
+++ b/web/app/(student)/progress/page.tsx
@@ -61,7 +61,10 @@ export default function ProgressPage() {
                           )}
                           {session.score !== null && (
                             <span className="text-sm font-medium text-gray-700">
-                              {session.score}/{session.total}
+                              {session.total !== null && session.total > 0
+                                ? Math.min(session.score, session.total)
+                                : session.score}
+                              /{session.total}
                             </span>
                           )}
                         </>

--- a/web/components/content/QuizPlayer.tsx
+++ b/web/components/content/QuizPlayer.tsx
@@ -102,7 +102,11 @@ export function QuizPlayer({ quiz, sessionId }: QuizPlayerProps) {
 
   // Score screen
   if (state.phase === "scoring" && state.result) {
-    const { score, total, passed, attempt_number } = state.result;
+    const { score: rawScore, total: rawTotal, passed, attempt_number } = state.result;
+    // Defensive clamp: never render an impossible result (e.g. 8/5 = 160%).
+    // The backend also clamps on write — this guards any legacy/stale data too.
+    const total = rawTotal > 0 ? rawTotal : 1;
+    const score = Math.max(0, Math.min(rawScore, total));
     const pct = Math.round((score / total) * 100);
     return (
       <div className="space-y-6 py-8 text-center">


### PR DESCRIPTION
Fixes two items from Venki's 2026-06-14 test cycle.

## #460 — Quiz score can exceed 100%
**Symptom:** quiz result showed `Score: 8/5 (160%)`, Progress History a `6/5` chip, and the School-Admin dashboard `Pass Rate (1st attempt) = 500%`.

**Root cause:** the live quiz flow always sends `score ≤ questions.length`, so this is **stale/seeded data** — `backend/scripts/setup_dev.py` hardcodes `total_questions=5` in progress rows while real pipeline quizzes have 8 questions, and nothing clamped score-vs-total.

**Fix (defense in depth):**
- `end_session` clamps `score` to `[0, total]` and `total ≥ 1` → impossible results can never be **persisted** going forward.
- `QuizPlayer` and Progress History clamp on **display** so any legacy/stale row never renders `>100%` / `8/5`.

## #462 — Subject shows "Unknown" everywhere
**Symptom:** `Unknown`/`unknown` on Unit Progress, the "Strongest" badge, Progress History, and the Subject Breakdown chart.

**Root cause (pitfall #32):** `progress_sessions.subject` holds a subject *code* (or the literal `"unknown"` sentinel); the display name lives in `content_subject_versions.subject_name`. Four read queries surfaced the raw value.

**Fix:** new shared resolver `backend/src/core/subjects.py` (`resolve_subject_labels` + `display_subject`) — resolves by `unit_id` via `curriculum_units → content_subject_versions` (uses `DISTINCT ON` so it never fans out aggregate counts), with a `subject_name → code → "Unknown"` fallback. Applied to all four read paths:
- `analytics/router.py` → student-stats **Subject Breakdown** (regrouped per-unit, aggregated by display name)
- `progress/service.py` → **Progress History**
- `analytics/service.py` → **student metrics / Unit Progress**
- `reports/service.py` → **Strongest subject** + per-unit table

The read-time resolver is more robust than the write path — it resolves units by `unit_id` even when the session stored `"unknown"`.

## Test plan
New `backend/tests/test_feedback_460_462.py` (score clamp + resolver). Verified locally against a pgvector Postgres test DB:
- `test_feedback_460_462.py` + `test_progress.py` → **16 passed**
- `test_analytics.py` + `test_analytics_extended.py` + `test_reports.py` → **33 passed** (exercise the analytics/reports read paths end-to-end)

`ruff` clean on backend; web `typecheck`/`prettier`/`eslint` clean.

## Out of scope / follow-ups
- Existing demo-DB rows aren't retroactively fixed — the bad `8/5` data and `"unknown"` codes on the demo box need a **re-seed**; this PR prevents new bad rows and clamps the display of old ones.
- Related siblings still open: #471 (admin 500% pass rate — same denominator family), #463 (Unit Progress "best score" shows raw score as %), #473 (Subject Breakdown plotting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)