### PR TITLE
fix(feedback): correct per-unit lesson time + persist durations on unload (#464)

### DIFF
--- a/backend/src/analytics/service.py
+++ b/backend/src/analytics/service.py
@@ -155,13 +155,23 @@ async def get_student_metrics(
                 FILTER (WHERE s.completed AND s.score IS NOT NULL
                               AND s.total_questions > 0)            AS best_score_pct,
             BOOL_OR(s.passed)                                       AS passed,
-            COALESCE(SUM(lv.duration_s), 0)::int                    AS total_time_s,
-            COUNT(DISTINCT lv.view_id)                              AS lessons_viewed
+            -- Aggregate lesson time per unit in a subquery FIRST (issue #464):
+            -- joining lesson_views directly multiplied each view by the number
+            -- of quiz sessions, so SUM(duration) over-counted total time
+            -- (e.g. one 5-minute view with two quiz attempts reported 10m).
+            COALESCE(lv.total_time_s, 0)                            AS total_time_s,
+            COALESCE(lv.views, 0)                                   AS lessons_viewed
         FROM progress_sessions s
-        LEFT JOIN lesson_views lv
-            ON lv.student_id = s.student_id AND lv.unit_id = s.unit_id
+        LEFT JOIN (
+            SELECT unit_id,
+                   COALESCE(SUM(duration_s), 0)::int AS total_time_s,
+                   COUNT(*)                          AS views
+            FROM lesson_views
+            WHERE student_id = $1
+            GROUP BY unit_id
+        ) lv ON lv.unit_id = s.unit_id
         WHERE s.student_id = $1
-        GROUP BY s.unit_id, s.subject
+        GROUP BY s.unit_id, s.subject, lv.total_time_s, lv.views
         ORDER BY s.unit_id
         """,
         student_id,

--- a/backend/tests/test_feedback_464.py
+++ b/backend/tests/test_feedback_464.py
@@ -1,0 +1,98 @@
+"""
+tests/test_feedback_464.py
+
+Regression test for feedback #464 — Unit Progress "Time".
+
+The per-unit lesson-time aggregation joined lesson_views directly to
+progress_sessions, so each lesson view was multiplied by the number of quiz
+sessions for that unit and SUM(duration) over-counted (one 5-minute view with
+two quiz attempts reported 10m). Pre-aggregating lesson_views per unit fixes it.
+
+(The "always 0m" reported on the demo is a separate instrumentation issue —
+lesson_views.duration_s is NULL when the fire-and-forget lesson-end write never
+lands. These tests cover the aggregation correctness, which is what the backend
+controls; the third case documents the NULL-duration behaviour.)
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from src.analytics.service import get_student_metrics
+
+
+async def _student(db_conn, sid: uuid.UUID) -> None:
+    await db_conn.execute(
+        "INSERT INTO students (student_id, external_auth_id, name, email, grade, locale, account_status) "
+        "VALUES ($1, $2, $3, $4, 8, 'en', 'active')",
+        sid,
+        f"auth0|test-{sid.hex[:18]}",
+        "Time Tester",
+        f"time-{sid.hex[:8]}@test.invalid",
+    )
+
+
+async def _view(db_conn, sid: uuid.UUID, unit_id: str, duration_s: int | None) -> None:
+    await db_conn.execute(
+        "INSERT INTO lesson_views (student_id, unit_id, curriculum_id, duration_s, ended_at) "
+        "VALUES ($1, $2, 'default-2026-g8', $3, NOW())",
+        sid,
+        unit_id,
+        duration_s,
+    )
+
+
+async def _session(db_conn, sid: uuid.UUID, unit_id: str, attempt: int) -> None:
+    await db_conn.execute(
+        "INSERT INTO progress_sessions "
+        "(student_id, unit_id, curriculum_id, grade, subject, attempt_number, score, total_questions, completed, passed) "
+        "VALUES ($1, $2, 'default-2026-g8', 8, 'G8-MATH', $3, 6, 8, TRUE, TRUE)",
+        sid,
+        unit_id,
+        attempt,
+    )
+
+
+@pytest.mark.asyncio
+async def test_per_unit_time_not_multiplied_by_session_count(db_conn):
+    """One 300s lesson view + two quiz attempts → 5m, not 10m (no double-count)."""
+    sid = uuid.uuid4()
+    await _student(db_conn, sid)
+    await _view(db_conn, sid, "G8-MATH-001", 300)
+    await _session(db_conn, sid, "G8-MATH-001", attempt=1)
+    await _session(db_conn, sid, "G8-MATH-001", attempt=2)
+
+    result = await get_student_metrics(db_conn, str(sid))
+    unit = next(u for u in result["per_unit"] if u["unit_id"] == "G8-MATH-001")
+    assert unit["total_time_minutes"] == 5.0
+    assert unit["lessons_viewed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_per_unit_time_sums_multiple_views(db_conn):
+    """Two distinct views (180s + 120s) over one unit → 5m total."""
+    sid = uuid.uuid4()
+    await _student(db_conn, sid)
+    await _view(db_conn, sid, "G8-MATH-002", 180)
+    await _view(db_conn, sid, "G8-MATH-002", 120)
+    await _session(db_conn, sid, "G8-MATH-002", attempt=1)
+
+    result = await get_student_metrics(db_conn, str(sid))
+    unit = next(u for u in result["per_unit"] if u["unit_id"] == "G8-MATH-002")
+    assert unit["total_time_minutes"] == 5.0
+    assert unit["lessons_viewed"] == 2
+
+
+@pytest.mark.asyncio
+async def test_per_unit_time_zero_when_duration_unrecorded(db_conn):
+    """A lesson view whose duration was never written (NULL) contributes 0m."""
+    sid = uuid.uuid4()
+    await _student(db_conn, sid)
+    await _view(db_conn, sid, "G8-MATH-003", None)
+    await _session(db_conn, sid, "G8-MATH-003", attempt=1)
+
+    result = await get_student_metrics(db_conn, str(sid))
+    unit = next(u for u in result["per_unit"] if u["unit_id"] == "G8-MATH-003")
+    assert unit["total_time_minutes"] == 0.0

--- a/web/app/(student)/lesson/[unit_id]/page.tsx
+++ b/web/app/(student)/lesson/[unit_id]/page.tsx
@@ -9,7 +9,7 @@ import { OfflineBanner } from "@/components/student/OfflineBanner";
 import { LinkButton } from "@/components/ui/link-button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { startSession } from "@/lib/api/progress";
-import { startLessonView, endLessonView } from "@/lib/api/analytics";
+import { startLessonView, endLessonViewBeacon } from "@/lib/api/analytics";
 import { AIContentDisclosure } from "@/components/content/AIContentDisclosure";
 import { FlaskConical, FileQuestion } from "lucide-react";
 
@@ -25,11 +25,13 @@ export default function LessonPage({ params }: PageProps) {
   const viewIdRef = useRef<string | null>(null);
   const startTimeRef = useRef<number>(0);
   const audioPlayedRef = useRef(false);
+  const endedRef = useRef(false);
 
   // Start session + analytics view on mount
   useEffect(() => {
     if (!lesson) return;
     const curriculumId = "default"; // resolved from JWT in production
+    endedRef.current = false;
     startSession(unit_id, curriculumId)
       .then((r) => {
         sessionIdRef.current = r.session_id;
@@ -42,14 +44,22 @@ export default function LessonPage({ params }: PageProps) {
       .catch(() => {});
     startTimeRef.current = Date.now();
 
+    // Record elapsed time exactly once — whether the student navigates within
+    // the app (effect cleanup) or closes/refreshes the tab (pagehide). The
+    // beacon uses a keepalive fetch so the write survives page unload, fixing
+    // the lost lesson durations that made "Time" show 0m (#464).
+    const flushEnd = () => {
+      if (endedRef.current || !viewIdRef.current) return;
+      endedRef.current = true;
+      const duration = Math.round((Date.now() - startTimeRef.current) / 1000);
+      endLessonViewBeacon(viewIdRef.current, duration, audioPlayedRef.current, false);
+    };
+
+    window.addEventListener("pagehide", flushEnd);
+
     return () => {
-      // Fire-and-forget on unmount
-      if (viewIdRef.current) {
-        const duration = Math.round((Date.now() - startTimeRef.current) / 1000);
-        endLessonView(viewIdRef.current, duration, audioPlayedRef.current, false).catch(
-          () => {},
-        );
-      }
+      window.removeEventListener("pagehide", flushEnd);
+      flushEnd();
     };
   }, [lesson, unit_id]);
 

--- a/web/lib/api/analytics.ts
+++ b/web/lib/api/analytics.ts
@@ -26,6 +26,43 @@ export async function endLessonView(
   });
 }
 
+/**
+ * Reliable variant of {@link endLessonView} for page-unload paths (issue #464).
+ *
+ * Lesson-time records were lost when a student closed the tab or refreshed: the
+ * end-write fired from a React unmount cleanup via axios, which the browser
+ * cancels as the page goes away — so `lesson_views.duration_s` stayed NULL and
+ * "Time" showed 0m.
+ *
+ * `keepalive: true` lets the request outlive the page. We use `fetch` rather
+ * than `navigator.sendBeacon` because the analytics endpoint requires the
+ * `Authorization` header, which sendBeacon cannot set. Same-origin (`/api/v1`).
+ * Fire-and-forget — never throws into the caller.
+ */
+export function endLessonViewBeacon(
+  viewId: string,
+  durationSeconds: number,
+  audioPlayed: boolean,
+  experimentViewed: boolean,
+): void {
+  if (typeof window === "undefined") return;
+  const token = localStorage.getItem("sb_token");
+  void fetch("/api/v1/analytics/lesson/end", {
+    method: "POST",
+    keepalive: true,
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({
+      view_id: viewId,
+      duration_s: durationSeconds,
+      audio_played: audioPlayed,
+      experiment_viewed: experimentViewed,
+    }),
+  }).catch(() => {});
+}
+
 export async function getStudentStats(
   period: "7d" | "30d" | "all" = "30d",
 ): Promise<StudentStats> {


### PR DESCRIPTION
Addresses #464 (Unit Progress "Time" always 0m).

> **Stacked on #476** (base = `fix/feedback-463-best-score-pct`) because it edits the same `get_student_metrics` per-unit query. Auto-retargets up the stack as the parents merge.

## What I found (with a probe)
```
1 lesson view @300s + 2 quiz sessions, same unit:
  summary total time   = 5.0m   ✓
  per-unit total time  = 10.0m  ✗ double-counted (300s × 2 sessions)
lesson view with NULL duration:
  per-unit time        = 0.0m   ← the reported "always 0m"
```
So "0m" is **two** things, and the backend aggregation is *correct* when a duration exists.

## Fixes
**1. Backend over-count (real bug, testable).** `get_student_metrics` joined `lesson_views` straight onto `progress_sessions`, multiplying each view by the unit's quiz-session count → `SUM(duration)` over-counted. Now pre-aggregates `lesson_views` per unit in a subquery before the join. (`get_student_report` uses `AVG`/`COUNT(DISTINCT)` and was already correct — left unchanged.)

**2. Lost durations on unload (the "always 0m" client cause).** `lesson_views.duration_s` is written by the end-write, which fired from a React unmount cleanup via axios — the browser **cancels** that as the page goes away (tab close / refresh), leaving `duration_s` NULL. New `endLessonViewBeacon()` uses a **`keepalive` fetch** (not `navigator.sendBeacon`, which can't set the `Authorization` header) and the lesson page flushes the end **exactly once** on either unmount or `pagehide`.

## ⚠️ Operational dependency (please verify on the demo)
Durations only persist if the **`io` Celery worker** processes `/analytics/lesson/end`. If that worker is down on the demo, durations stay NULL regardless of the client fix. The backend correctness + client reliability are fixed here; the worker is environmental — worth confirming it's running (`celery -A src.auth.tasks worker -Q io,default`).

## Test plan
`backend/tests/test_feedback_464.py`: no double-count (5m not 10m), sums multiple views (180s+120s → 5m), NULL-duration → 0m. analytics + #463 suites green — **14 passed**. Web `typecheck`/`prettier`/`eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)