### PR TITLE
fix(feedback): eliminate duplicate "Attempt #N" in Progress History (#465)

### DIFF
--- a/backend/src/progress/service.py
+++ b/backend/src/progress/service.py
@@ -199,15 +199,30 @@ async def end_session(
     score = max(0, min(score, total_questions))
     passed = (score / total_questions) >= QUIZ_PASS_THRESHOLD
 
+    # Assign the attempt number at COMPLETION, not at session start (#465).
+    # attempt_number was computed in create_session as "completed sessions + 1",
+    # but sessions are opened eagerly (one per quiz-page load), so several
+    # never-completed sessions for a unit all received the same number — Progress
+    # History then showed duplicate "Attempt #2" cards. Numbering completed
+    # sessions in completion order makes each finished attempt uniquely sequential.
     row = await conn.fetchrow(
         """
-        UPDATE progress_sessions
+        UPDATE progress_sessions ps
         SET score           = $1,
             total_questions = $2,
             completed       = TRUE,
             passed          = $3,
-            ended_at        = NOW()
-        WHERE session_id = $4
+            ended_at        = NOW(),
+            attempt_number  = (
+                SELECT COUNT(*) + 1
+                FROM progress_sessions prior
+                WHERE prior.student_id   = ps.student_id
+                  AND prior.unit_id      = ps.unit_id
+                  AND prior.curriculum_id = ps.curriculum_id
+                  AND prior.completed     = TRUE
+                  AND prior.session_id <> ps.session_id
+            )
+        WHERE ps.session_id = $4
         RETURNING session_id, score, total_questions, passed, attempt_number, ended_at
         """,
         score,

--- a/backend/tests/test_feedback_465.py
+++ b/backend/tests/test_feedback_465.py
@@ -1,0 +1,79 @@
+"""
+tests/test_feedback_465.py
+
+Regression test for feedback #465 — Progress History showed duplicate
+"Attempt #2" cards.
+
+attempt_number was assigned at session start ("completed sessions + 1"), but
+sessions are opened eagerly (one per quiz-page load, and the lesson page used
+to open one too), so several never-completed sessions for a unit all received
+the same number. end_session now numbers sessions in COMPLETION order, so each
+finished attempt is uniquely sequential regardless of how many incomplete
+sessions exist.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from src.progress.service import create_session, end_session
+
+_CID = "default-2026-g8"
+
+
+async def _student(db_conn, sid: uuid.UUID) -> None:
+    await db_conn.execute(
+        "INSERT INTO students (student_id, external_auth_id, name, email, grade, locale, account_status) "
+        "VALUES ($1, $2, $3, $4, 8, 'en', 'active')",
+        sid,
+        f"auth0|test-{sid.hex[:18]}",
+        "Attempt Tester",
+        f"att-{sid.hex[:8]}@test.invalid",
+    )
+
+
+@pytest.mark.asyncio
+async def test_completed_attempts_numbered_sequentially(db_conn):
+    """Two completed attempts on the same unit get attempt 1 then 2 (no dupes)."""
+    sid = uuid.uuid4()
+    await _student(db_conn, sid)
+
+    s1 = await create_session(db_conn, str(sid), "G8-MATH-001", _CID)
+    e1 = await end_session(db_conn, s1["session_id"], 6, 8)
+    assert e1["attempt_number"] == 1
+
+    s2 = await create_session(db_conn, str(sid), "G8-MATH-001", _CID)
+    e2 = await end_session(db_conn, s2["session_id"], 7, 8)
+    assert e2["attempt_number"] == 2
+
+
+@pytest.mark.asyncio
+async def test_incomplete_sessions_do_not_inflate_attempt_number(db_conn):
+    """Abandoned (never-completed) sessions don't bump the next attempt number."""
+    sid = uuid.uuid4()
+    await _student(db_conn, sid)
+
+    # Two sessions opened but never completed (e.g. quiz page loaded + left).
+    await create_session(db_conn, str(sid), "G8-MATH-002", _CID)
+    await create_session(db_conn, str(sid), "G8-MATH-002", _CID)
+
+    # The first genuinely completed attempt is still #1.
+    s = await create_session(db_conn, str(sid), "G8-MATH-002", _CID)
+    e = await end_session(db_conn, s["session_id"], 5, 8)
+    assert e["attempt_number"] == 1
+
+
+@pytest.mark.asyncio
+async def test_attempt_number_is_per_unit(db_conn):
+    """Completing an attempt on one unit doesn't affect another unit's count."""
+    sid = uuid.uuid4()
+    await _student(db_conn, sid)
+
+    s1 = await create_session(db_conn, str(sid), "G8-MATH-003", _CID)
+    await end_session(db_conn, s1["session_id"], 6, 8)
+
+    s2 = await create_session(db_conn, str(sid), "G8-SCI-003", _CID)
+    e2 = await end_session(db_conn, s2["session_id"], 6, 8)
+    assert e2["attempt_number"] == 1

--- a/web/app/(student)/lesson/[unit_id]/page.tsx
+++ b/web/app/(student)/lesson/[unit_id]/page.tsx
@@ -8,7 +8,6 @@ import { FeedbackWidget } from "@/components/feedback/FeedbackWidget";
 import { OfflineBanner } from "@/components/student/OfflineBanner";
 import { LinkButton } from "@/components/ui/link-button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { startSession } from "@/lib/api/progress";
 import { startLessonView, endLessonViewBeacon } from "@/lib/api/analytics";
 import { AIContentDisclosure } from "@/components/content/AIContentDisclosure";
 import { FlaskConical, FileQuestion } from "lucide-react";
@@ -21,22 +20,19 @@ export default function LessonPage({ params }: PageProps) {
   const { unit_id } = use(params);
   const { data: lesson, isLoading, isError } = useLesson(unit_id);
 
-  const sessionIdRef = useRef<string | null>(null);
   const viewIdRef = useRef<string | null>(null);
   const startTimeRef = useRef<number>(0);
   const audioPlayedRef = useRef(false);
   const endedRef = useRef(false);
 
-  // Start session + analytics view on mount
+  // Record a lesson VIEW on mount. We deliberately do NOT open a progress
+  // session here — a session is a quiz attempt, created by the quiz page. The
+  // lesson page used to call startSession, producing phantom never-completed
+  // sessions that cluttered Progress History with bogus/duplicate attempts (#465).
   useEffect(() => {
     if (!lesson) return;
     const curriculumId = "default"; // resolved from JWT in production
     endedRef.current = false;
-    startSession(unit_id, curriculumId)
-      .then((r) => {
-        sessionIdRef.current = r.session_id;
-      })
-      .catch(() => {});
     startLessonView(unit_id, curriculumId)
       .then((r) => {
         viewIdRef.current = r.view_id;


### PR DESCRIPTION
Fixes #465 (duplicate / mismatched "Attempt #2" cards).

> **Stacked on #478** (base = `fix/feedback-464-lesson-time`) because it edits the lesson page, which #478 also touched. Auto-retargets up the stack as parents merge.

## Two causes
1. **Phantom sessions from lesson views.** The lesson page opened a `progress_session` on every view (`startSession`) but never used or completed it — so just *reading a lesson* created a never-completed "attempt" that showed up in Progress History. Lessons are tracked via `lesson_views`; only the quiz page should open a session. Removed the `startSession` call (and its unused `sessionIdRef`) from the lesson page.

2. **Start-time attempt numbering.** `attempt_number` was assigned at session *start* (`completed sessions + 1`). Sessions open eagerly (one per quiz-page load), so several never-completed sessions for a unit all got the **same** number → duplicate "Attempt #2". `end_session` now numbers sessions in **completion order** (count of other completed sessions for the unit + 1), so each finished attempt is uniquely sequential.

## Test plan
`backend/tests/test_feedback_465.py`: sequential numbering (1 then 2), incomplete sessions don't inflate the count, numbering is per-unit. progress suite green — **13 passed**. Web `typecheck`/`prettier`/`eslint` clean.

## Note
Incomplete sessions still appear in Progress History (the endpoint intentionally includes in-progress sessions — the existing contract/test asserts that). With the phantom lesson-view sessions gone, the only remaining incomplete sessions are genuinely-opened-then-abandoned quizzes, which are correctly distinct from completed attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)