### PR TITLE
fix(feedback): quiz "Try Again" now restarts the quiz (#459)

### DIFF
--- a/web/app/(student)/quiz/[unit_id]/page.tsx
+++ b/web/app/(student)/quiz/[unit_id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useEffect, useState } from "react";
+import { use, useCallback, useEffect, useState } from "react";
 import { useQuiz } from "@/lib/hooks/useQuiz";
 import { QuizPlayer } from "@/components/content/QuizPlayer";
 import { OfflineBanner } from "@/components/student/OfflineBanner";
@@ -17,12 +17,21 @@ export default function QuizPage({ params }: PageProps) {
   const { data: quiz, isLoading, isError } = useQuiz(unit_id);
   const [sessionId, setSessionId] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!quiz) return;
+  // Open a fresh quiz attempt. Used on first load and on "Try Again" — the
+  // latter previously navigated to this same URL, which never reset the player
+  // (#459). Clearing sessionId first unmounts the finished QuizPlayer; the new
+  // session id remounts it (also keyed below) so its state starts clean.
+  const startNew = useCallback(() => {
+    setSessionId(null);
     startSession(unit_id, "default")
       .then((r) => setSessionId(r.session_id))
       .catch(() => {});
-  }, [quiz, unit_id]);
+  }, [unit_id]);
+
+  useEffect(() => {
+    if (!quiz) return;
+    startNew();
+  }, [quiz, startNew]);
 
   if (isLoading || (quiz && !sessionId)) {
     return (
@@ -48,7 +57,13 @@ export default function QuizPage({ params }: PageProps) {
       <div className="max-w-2xl p-6">
         <h1 className="mb-6 text-xl font-bold text-gray-900">{quiz.title}</h1>
         {sessionId && (
-          <QuizPlayer quiz={quiz} sessionId={sessionId} curriculumId="default" />
+          <QuizPlayer
+            key={sessionId}
+            quiz={quiz}
+            sessionId={sessionId}
+            curriculumId="default"
+            onRetry={startNew}
+          />
         )}
         <AIContentDisclosure />
       </div>

--- a/web/components/content/QuizPlayer.tsx
+++ b/web/components/content/QuizPlayer.tsx
@@ -61,9 +61,12 @@ interface QuizPlayerProps {
   quiz: QuizContent;
   sessionId: string;
   curriculumId: string;
+  /** Restart the quiz with a fresh session. The score screen "Try Again" button
+   *  calls this instead of navigating to the same URL (which did nothing — #459). */
+  onRetry?: () => void;
 }
 
-export function QuizPlayer({ quiz, sessionId }: QuizPlayerProps) {
+export function QuizPlayer({ quiz, sessionId, onRetry }: QuizPlayerProps) {
   const t = useTranslations("result_screen");
   const queryClient = useQueryClient();
   const [state, dispatch] = useReducer(reducer, {
@@ -132,10 +135,10 @@ export function QuizPlayer({ quiz, sessionId }: QuizPlayerProps) {
           {t("attempt_label", { attempt: attempt_number })}
         </p>
         <div className="flex justify-center gap-3">
-          {!passed && (
-            <LinkButton variant="outline" href={`/quiz/${quiz.unit_id}`}>
+          {!passed && onRetry && (
+            <Button variant="outline" onClick={onRetry}>
               {t("try_again_btn")}
-            </LinkButton>
+            </Button>
           )}
           <LinkButton href="/curriculum">{t("back_to_curriculum_btn")}</LinkButton>
         </div>


### PR DESCRIPTION
Fixes #459 (Try Again does nothing).

> **Stacked on #479** (base = `fix/feedback-466-467-refresh`) because it edits `QuizPlayer.tsx`, which #479 also touched. Auto-retargets to `main` after its parents merge.

## Root cause
On the quiz score screen, **Try Again** was a `LinkButton` to `/quiz/{unit_id}` — the **same route the student is already on**. Navigating to the current URL doesn't remount the page, so `QuizPlayer` stayed in its `scoring` state and nothing happened.

## Fix
`QuizPlayer` gains an `onRetry` callback; the score screen's Try Again calls it instead of linking. The quiz page implements `onRetry` by clearing `sessionId` (unmounts the finished player) and opening a **fresh session** — and `QuizPlayer` is keyed by `sessionId`, so it remounts clean and the quiz restarts from question 1 (also a new attempt server-side).

## Test plan
Client-only interaction fix. `typecheck` / `prettier` / `eslint` clean. Best confirmed in-browser: fail a quiz → Try Again → quiz restarts at Q1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)