### PR TITLE
feat(feedback): show the subject name on the quiz Score page (#461)

### DIFF
--- a/backend/src/content/router.py
+++ b/backend/src/content/router.py
@@ -56,12 +56,21 @@ from src.content.service import (
 )
 from src.core.redis_client import get_redis
 from src.core.storage import StorageBackend, get_storage
+from src.core.subjects import display_subject, resolve_subject_labels
 from src.utils.logger import get_logger
 
 log = get_logger("content")
 router = APIRouter(tags=["content"])
 
 _FREE_TIER_LESSON_LIMIT = 2
+
+
+async def _subject_display_name(pool, unit_id: str, fallback: str | None) -> str:
+    """Resolve a unit's human-readable subject name for the quiz result screen
+    (#461), falling back to whatever the content file stored (#462 semantics)."""
+    async with pool.acquire() as conn:
+        labels = await resolve_subject_labels(conn, [unit_id])
+    return display_subject(labels, unit_id, fallback)
 
 _GRADE_RE = re.compile(r"^G(\d+)-")
 
@@ -341,6 +350,9 @@ async def get_quiz(
                 set_number,
                 student_id,
             )
+            override["subject"] = await _subject_display_name(
+                pool, unit_id, override.get("subject")
+            )
             return QuizResponse(**override)
 
     curriculum_id, _subject = await _get_curriculum_and_check_published(
@@ -361,6 +373,7 @@ async def get_quiz(
                 detail={"error": "not_found", "detail": f"Quiz set {set_number} not found."},
             )
 
+    data["subject"] = await _subject_display_name(pool, unit_id, _subject or data.get("subject"))
     log.info("quiz_served unit_id=%s set=%d student_id=%s", unit_id, set_number, student_id)
     return QuizResponse(**data)
 

--- a/backend/src/content/schemas.py
+++ b/backend/src/content/schemas.py
@@ -60,6 +60,9 @@ class QuizResponse(BaseModel):
     generated_at: str
     model: str
     content_version: int
+    # Human-readable subject name for the result screen (#461). Optional so the
+    # teacher-authored override path (which may omit it) stays valid.
+    subject: str | None = None
 
 
 # ── Tutorial ──────────────────────────────────────────────────────────────────

--- a/backend/tests/test_content.py
+++ b/backend/tests/test_content.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import AsyncClient
@@ -195,6 +195,9 @@ async def test_quiz_rotates_sets(client: AsyncClient, fake_redis):
                 headers={"Authorization": f"Bearer {token}"},
             )
             assert response.status_code == 200, response.text
+            # The quiz response carries a subject for the result screen (#461);
+            # with no subject_name seeded it falls back to the resolved code.
+            assert response.json()["subject"] == "G8-SCI"
 
     assert sets_served == [1, 2, 3, 1], f"Expected rotation 1→2→3→1, got {sets_served}"
 
@@ -340,7 +343,6 @@ async def test_content_rate_limit(client: AsyncClient, fake_redis):
     unit_id = "G8-SCI-001"
 
     # Simulate a 429 by patching the lesson endpoint directly to raise 429
-    from fastapi import Request
 
     original_get_lesson = None
 
@@ -492,7 +494,8 @@ async def test_get_entitlement_school_student_uses_school_subscription():
     NOT from student_entitlements.plan.  student_entitlements is only used for
     the lessons_accessed counter.
     """
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from unittest.mock import AsyncMock, patch
+
     from src.content.service import get_entitlement
 
     school_id = "d3000000-0000-0000-0000-000000000001"
@@ -537,7 +540,8 @@ async def test_get_entitlement_no_school_subscription_falls_back_to_free():
     A school-enrolled student whose school has no active subscription is treated
     as free tier (plan='free').  student_entitlements is queried as the fallback.
     """
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from unittest.mock import AsyncMock, patch
+
     from src.content.service import get_entitlement
 
     school_id = "d3000000-0000-0000-0000-000000000001"
@@ -574,7 +578,8 @@ async def test_get_entitlement_unaffiliated_student_uses_student_entitlements():
     A student without a school_id (no school_id from JWT) uses student_entitlements
     directly — the school path is bypassed entirely.
     """
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from unittest.mock import AsyncMock, patch
+
     from src.content.service import get_entitlement
 
     student_id = "d1000000-0000-0000-0000-000000000001"
@@ -606,8 +611,8 @@ async def test_get_entitlement_unaffiliated_student_uses_student_entitlements():
 @pytest.mark.asyncio
 async def test_get_entitlement_returns_cached_value():
     """Cache hit returns immediately — no DB queries made."""
-    import json
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from unittest.mock import AsyncMock, MagicMock
+
     from src.content.service import get_entitlement
 
     cached = {"plan": "starter", "lessons_accessed": 3, "valid_until": None}

--- a/web/components/content/QuizPlayer.tsx
+++ b/web/components/content/QuizPlayer.tsx
@@ -130,6 +130,11 @@ export function QuizPlayer({ quiz, sessionId, onRetry }: QuizPlayerProps) {
         <h2 className="text-2xl font-bold text-gray-900">
           {passed ? t("passed_heading") : t("try_again_heading")}
         </h2>
+        {quiz.subject && (
+          <p className="text-xs font-medium tracking-wide text-gray-400 uppercase">
+            {quiz.subject}
+          </p>
+        )}
         <p className="text-gray-500">{t("score_label", { score, total, pct })}</p>
         <p className="text-sm text-gray-400">
           {t("attempt_label", { attempt: attempt_number })}

--- a/web/lib/api/content.ts
+++ b/web/lib/api/content.ts
@@ -43,6 +43,7 @@ interface BackendQuizResponse {
   generated_at: string;
   model: string;
   content_version: number;
+  subject: string | null;
 }
 
 const OPTION_IDS = ["A", "B", "C", "D"];
@@ -54,6 +55,7 @@ export async function getQuiz(unitId: string): Promise<QuizContent> {
     unit_id: raw.unit_id,
     title: `Quiz — Set ${raw.set_number}`,
     pass_threshold: raw.passing_score,
+    subject: raw.subject ?? undefined,
     questions: raw.questions.map((q, index) => ({
       index,
       question: q.question_text,

--- a/web/lib/types/api.ts
+++ b/web/lib/types/api.ts
@@ -56,6 +56,7 @@ export interface QuizContent {
   title: string;
   pass_threshold: number;
   questions: QuizQuestion[];
+  subject?: string;
 }
 
 export interface VisualItem {


### PR DESCRIPTION
Implements #461.

> **Stacked on #481** (base = `fix/feedback-459-try-again`) because it edits `QuizPlayer.tsx`. Reuses #462's `resolve_subject_labels` (available via the #474 ancestry). Auto-retargets to `main` as parents merge.

## Change
The quiz result screen showed only "Quiz — Set N" + score. Now it shows the **subject**:
- **Backend:** `QuizResponse` gains an optional `subject`; `get_quiz` resolves the unit's human-readable subject name via the shared `resolve_subject_labels`/`display_subject` helpers (so it shows e.g. "Natural Sciences", not "G8-SCI"), falling back to the stored code. Applied on both the normal and teacher-override return paths.
- **Web:** `subject` threaded through `getQuiz` → `QuizContent`; the `QuizPlayer` score screen renders it under the heading.

## Test plan
`test_content` quiz test now asserts the response carries the subject (falls back to the resolved code when no `subject_name` is seeded) — **19 passed**. Web `typecheck`/`prettier`/`eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)