### PR TITLE
fix(feedback): Unit Progress "Best score" is a percentage, not raw score (#463)

### DIFF
--- a/backend/src/analytics/service.py
+++ b/backend/src/analytics/service.py
@@ -149,7 +149,11 @@ async def get_student_metrics(
             s.unit_id,
             s.subject,
             MAX(s.attempt_number)                                   AS quiz_attempts,
-            MAX(s.score) FILTER (WHERE s.completed)                 AS best_score_pct,
+            -- best_score_pct is a PERCENTAGE (issue #463): score is a raw
+            -- question count, so divide by total_questions.
+            MAX((s.score::float / NULLIF(s.total_questions, 0)) * 100)
+                FILTER (WHERE s.completed AND s.score IS NOT NULL
+                              AND s.total_questions > 0)            AS best_score_pct,
             BOOL_OR(s.passed)                                       AS passed,
             COALESCE(SUM(lv.duration_s), 0)::int                    AS total_time_s,
             COUNT(DISTINCT lv.view_id)                              AS lessons_viewed
@@ -171,7 +175,7 @@ async def get_student_metrics(
             "unit_id": r["unit_id"],
             "subject": display_subject(subject_labels, r["unit_id"], r["subject"]),
             "quiz_attempts": r["quiz_attempts"] or 0,
-            "best_score_pct": float(r["best_score_pct"])
+            "best_score_pct": min(100.0, round(float(r["best_score_pct"]), 1))
             if r["best_score_pct"] is not None
             else None,
             "passed": bool(r["passed"]),

--- a/backend/src/reports/service.py
+++ b/backend/src/reports/service.py
@@ -509,7 +509,11 @@ async def get_student_report(
             ps.unit_id,
             ps.subject,
             MAX(ps.attempt_number)                               AS quiz_attempts,
-            MAX(ps.score) FILTER (WHERE ps.completed)            AS best_score,
+            -- best_score is a PERCENTAGE (issue #463): score is a raw question
+            -- count, so divide by total_questions. NULLIF guards divide-by-zero.
+            MAX((ps.score::float / NULLIF(ps.total_questions, 0)) * 100)
+                FILTER (WHERE ps.completed AND ps.score IS NOT NULL
+                              AND ps.total_questions > 0)          AS best_score,
             BOOL_OR(ps.passed)                                   AS passed,
             COUNT(DISTINCT lv.view_id) > 0                       AS lesson_viewed,
             ROUND(AVG(lv.duration_s)::numeric, 1)                AS avg_duration_s
@@ -542,7 +546,9 @@ async def get_student_report(
             "subject": display_subject(subject_labels, r["unit_id"], r["subject"]),
             "lesson_viewed": bool(r["lesson_viewed"]),
             "quiz_attempts": r["quiz_attempts"] or 0,
-            "best_score": float(r["best_score"]) if r["best_score"] is not None else None,
+            "best_score": min(100.0, round(float(r["best_score"]), 1))
+            if r["best_score"] is not None
+            else None,
             "passed": bool(r["passed"]),
             "avg_duration_s": float(r["avg_duration_s"] or 0),
         }
@@ -554,7 +560,7 @@ async def get_student_report(
     for r in unit_rows:
         s = display_subject(subject_labels, r["unit_id"], r["subject"])
         if r["best_score"] is not None:
-            subj_scores.setdefault(s, []).append(float(r["best_score"]))
+            subj_scores.setdefault(s, []).append(min(100.0, float(r["best_score"])))
     subj_avg = {s: sum(v) / len(v) for s, v in subj_scores.items() if v}
     strongest = max(subj_avg, key=subj_avg.__getitem__) if subj_avg else None
     needs_att = min(subj_avg, key=subj_avg.__getitem__) if len(subj_avg) > 1 else None

--- a/backend/tests/test_feedback_463.py
+++ b/backend/tests/test_feedback_463.py
@@ -1,0 +1,93 @@
+"""
+tests/test_feedback_463.py
+
+Regression test for feedback #463 — Unit Progress "Best score" must be a real
+percentage, not the raw question count rendered with a "%" sign (e.g. score 6
+shown as "6%"). best_score_pct = MAX(score / total_questions * 100), clamped to
+100 to defend against legacy score > total rows (see #460).
+
+Exercises analytics.get_student_metrics directly; reports.get_student_report
+uses the identical SQL/clamp.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from src.analytics.service import get_student_metrics
+
+
+async def _student(db_conn, sid: uuid.UUID) -> None:
+    await db_conn.execute(
+        "INSERT INTO students (student_id, external_auth_id, name, email, grade, locale, account_status) "
+        "VALUES ($1, $2, $3, $4, 8, 'en', 'active')",
+        sid,
+        f"auth0|test-{sid.hex[:18]}",
+        "Best Score Tester",
+        f"bs-{sid.hex[:8]}@test.invalid",
+    )
+
+
+async def _session(
+    db_conn,
+    sid: uuid.UUID,
+    unit_id: str,
+    score: int,
+    total: int,
+    *,
+    attempt: int = 1,
+    passed: bool = True,
+) -> None:
+    await db_conn.execute(
+        """
+        INSERT INTO progress_sessions
+            (student_id, unit_id, curriculum_id, grade, subject,
+             attempt_number, score, total_questions, completed, passed)
+        VALUES ($1, $2, 'default-2026-g8', 8, 'G8-MATH', $3, $4, $5, TRUE, $6)
+        """,
+        sid,
+        unit_id,
+        attempt,
+        score,
+        total,
+        passed,
+    )
+
+
+@pytest.mark.asyncio
+async def test_best_score_is_percentage(db_conn):
+    """score 6 of 8 → 75%, not 6."""
+    sid = uuid.uuid4()
+    await _student(db_conn, sid)
+    await _session(db_conn, sid, "G8-MATH-001", score=6, total=8)
+
+    result = await get_student_metrics(db_conn, str(sid))
+    unit = next(u for u in result["per_unit"] if u["unit_id"] == "G8-MATH-001")
+    assert unit["best_score_pct"] == 75.0
+
+
+@pytest.mark.asyncio
+async def test_best_score_clamped_to_100(db_conn):
+    """Legacy score > total (9 of 5 = 180%) is clamped to 100, not shown as 180%."""
+    sid = uuid.uuid4()
+    await _student(db_conn, sid)
+    await _session(db_conn, sid, "G8-MATH-002", score=9, total=5)
+
+    result = await get_student_metrics(db_conn, str(sid))
+    unit = next(u for u in result["per_unit"] if u["unit_id"] == "G8-MATH-002")
+    assert unit["best_score_pct"] == 100.0
+
+
+@pytest.mark.asyncio
+async def test_best_score_takes_max_across_attempts(db_conn):
+    """Best = highest percentage across attempts (25% then 87.5% → 87.5)."""
+    sid = uuid.uuid4()
+    await _student(db_conn, sid)
+    await _session(db_conn, sid, "G8-MATH-003", score=2, total=8, attempt=1, passed=False)
+    await _session(db_conn, sid, "G8-MATH-003", score=7, total=8, attempt=2, passed=True)
+
+    result = await get_student_metrics(db_conn, str(sid))
+    unit = next(u for u in result["per_unit"] if u["unit_id"] == "G8-MATH-003")
+    assert unit["best_score_pct"] == 87.5


### PR DESCRIPTION
Re-targeted to `main` (replaces #476, which GitHub auto-closed when the parent #474 branch was deleted during the stack merge). Same commit, now based on main. Closes #463.