### PR TITLE
fix(feedback): refresh My Stats after quiz (#466) + header name after profile save (#467)

### DIFF
--- a/web/app/(student)/account/settings/page.tsx
+++ b/web/app/(student)/account/settings/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import {
   getAccountSettings,
   saveAccountSettings,
   type AccountSettings,
 } from "@/lib/api/settings";
+import { updateSessionName } from "@/lib/session-cookie";
 import { useDyslexia } from "@/lib/hooks/useDyslexia";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -35,6 +37,7 @@ export default function SettingsPage() {
 
 function SettingsPageInner() {
   const t = useTranslations("settings_screen");
+  const router = useRouter();
   const [settings, setSettings] = useState<AccountSettings | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -56,6 +59,11 @@ function SettingsPageInner() {
     setError(null);
     try {
       await saveAccountSettings(settings);
+      // Reflect a display-name change in the header immediately instead of
+      // waiting for the next login: update the SSR session cookie, then
+      // re-render the server layout (#467).
+      updateSessionName(settings.display_name);
+      router.refresh();
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
     } catch {

--- a/web/components/content/QuizPlayer.tsx
+++ b/web/components/content/QuizPlayer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useReducer } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import type { QuizContent, AnswerResponse, SessionEndResponse } from "@/lib/types/api";
 import { Button } from "@/components/ui/button";
@@ -64,6 +65,7 @@ interface QuizPlayerProps {
 
 export function QuizPlayer({ quiz, sessionId }: QuizPlayerProps) {
   const t = useTranslations("result_screen");
+  const queryClient = useQueryClient();
   const [state, dispatch] = useReducer(reducer, {
     phase: "answering",
     questionIndex: 0,
@@ -94,6 +96,11 @@ export function QuizPlayer({ quiz, sessionId }: QuizPlayerProps) {
       const total = quiz.questions.length;
       const score = state.correctCount + (state.answerResult?.correct ? 1 : 0);
       const res = await endSession(sessionId, score, total);
+      // Session completion is written synchronously by endSession, so the
+      // stats/history reads are fresh — refresh them now instead of waiting for
+      // a manual browser reload (#466).
+      queryClient.invalidateQueries({ queryKey: ["stats"] });
+      queryClient.invalidateQueries({ queryKey: ["progress"] });
       dispatch({ type: "SCORE", result: res });
     } else {
       dispatch({ type: "NEXT" });

--- a/web/lib/session-cookie.ts
+++ b/web/lib/session-cookie.ts
@@ -1,0 +1,52 @@
+/**
+ * Client-side helpers for the SSR session cookies.
+ *
+ * The student/teacher portal layouts are server components that read the
+ * display name from a base64-encoded `{ name, email }` cookie set at login
+ * (see `(public)/signin/page.tsx` `persistSession`). A profile display-name
+ * change (PATCH /auth/settings) does not touch that cookie, so the header kept
+ * showing the old name until the user logged out and back in (#467).
+ *
+ * `updateSessionName()` rewrites the name in whichever local session cookie is
+ * present, preserving the email. Pair it with `router.refresh()` so the server
+ * layout re-reads the cookie and the header updates immediately.
+ *
+ * Note: this only covers the local (school-provisioned) and demo session
+ * cookies. Auth0 sessions are server-managed (httpOnly) and still require a
+ * re-login to reflect a name change.
+ */
+
+// Local-auth + demo session cookies that carry { name, email }. Keep in sync
+// with persistSession in (public)/signin/page.tsx and lib/dev-session.ts.
+const NAME_BEARING_SESSION_COOKIES = [
+  "sb_local_student_session",
+  "sb_dev_session",
+] as const;
+
+function readCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.split("; ").find((c) => c.startsWith(`${name}=`));
+  return match ? match.slice(name.length + 1) : null;
+}
+
+/**
+ * Update the `name` field in any present local/demo session cookie, keeping the
+ * existing email and cookie attributes. No-op on the server or when no such
+ * cookie exists. Malformed cookies are left untouched.
+ */
+export function updateSessionName(name: string): void {
+  if (typeof document === "undefined") return;
+  const secure = location.protocol === "https:" ? "; Secure" : "";
+
+  for (const cookieName of NAME_BEARING_SESSION_COOKIES) {
+    const raw = readCookie(cookieName);
+    if (!raw) continue;
+    try {
+      const data = JSON.parse(atob(raw)) as { name?: string; email?: string };
+      const payload = btoa(JSON.stringify({ name, email: data.email ?? "" }));
+      document.cookie = `${cookieName}=${payload}; path=/; SameSite=Strict; Max-Age=86400${secure}`;
+    } catch {
+      // Leave a malformed cookie alone rather than clobbering the session.
+    }
+  }
+}


### PR DESCRIPTION
Re-targeted to `main` (replaces #479, auto-closed when the #474 branch was deleted during the stack merge). Closes #466, closes #467.