### PR TITLE
feat(feedback): gate subjects with no published content (#469)

### DIFF
--- a/backend/src/curriculum/router.py
+++ b/backend/src/curriculum/router.py
@@ -495,6 +495,10 @@ async def get_curriculum_tree(
             """
             SELECT cu.unit_id, cu.title, cu.subject,
                    COALESCE(MAX(csv.subject_name), cu.subject) AS subject_display,
+                   -- Whether the subject has published content (#469): used to
+                   -- gate selection so students don't open a subject that would
+                   -- 404. Mirrors the check_content_published serve-time guard.
+                   BOOL_OR(csv.status = 'published') AS has_content,
                    cu.has_lab, cu.sort_order
             FROM curriculum_units cu
             LEFT JOIN content_subject_versions csv
@@ -510,10 +514,14 @@ async def get_curriculum_tree(
     if rows:
         # Build subjects dict preserving subject order from first encounter
         subjects_map: dict[str, list[dict]] = {}
+        subject_has_content: dict[str, bool] = {}
         for row in rows:
             subj = row["subject_display"]
             if subj not in subjects_map:
                 subjects_map[subj] = []
+            subject_has_content[subj] = subject_has_content.get(subj, False) or bool(
+                row["has_content"]
+            )
             subjects_map[subj].append(
                 {
                     "unit_id": row["unit_id"],
@@ -524,7 +532,10 @@ async def get_curriculum_tree(
                     "has_lab": row["has_lab"],
                 }
             )
-        subjects = [{"subject": s, "units": u} for s, u in subjects_map.items()]
+        subjects = [
+            {"subject": s, "units": u, "has_content": subject_has_content.get(s, False)}
+            for s, u in subjects_map.items()
+        ]
         log.info("curriculum_tree_from_db", curriculum_id=curriculum_id, unit_count=len(rows))
     else:
         # Fallback: STEM default curricula may not have curriculum_units rows yet
@@ -543,7 +554,9 @@ async def get_curriculum_tree(
                 }
                 for idx, u in enumerate(subj.get("units", []))
             ]
-            subjects.append({"subject": subject_name, "units": units})
+            # JSON fallback (default STEM curricula): content readiness can't be
+            # determined from the DB here, so don't over-gate — assume available.
+            subjects.append({"subject": subject_name, "units": units, "has_content": True})
         log.info(
             "curriculum_tree_from_json",
             curriculum_id=curriculum_id,

--- a/backend/tests/test_curriculum.py
+++ b/backend/tests/test_curriculum.py
@@ -155,3 +155,23 @@ async def test_curriculum_l1_cache(client: AsyncClient):
     assert r1.status_code == 200
     assert r2.status_code == 200
     assert r1.json() == r2.json()
+
+
+@pytest.mark.asyncio
+async def test_curriculum_tree_includes_has_content_flag(client: AsyncClient):
+    """
+    /curriculum/tree carries a per-subject has_content flag (#469) so the client
+    can gate selection. On the JSON-fallback path (no DB units) content
+    availability is unknown, so it defaults to True (don't over-gate).
+    """
+    token = make_student_token(grade=8)
+    response = await client.get(
+        "/api/v1/curriculum/tree",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200, response.text
+    subjects = response.json()["subjects"]
+    assert len(subjects) >= 1
+    for subj in subjects:
+        assert "has_content" in subj
+        assert subj["has_content"] is True

--- a/web/app/(student)/subjects/page.tsx
+++ b/web/app/(student)/subjects/page.tsx
@@ -10,44 +10,64 @@ import { Shelf, BookSpine, BookOpen, deriveSubjectAccent } from "@/components/li
 
 type SubjectUnit = { unit_id: string; title: string; has_lab?: boolean };
 
-function SubjectUnitList({ units }: { units: SubjectUnit[] }) {
+function SubjectUnitList({
+  units,
+  hasContent,
+}: {
+  units: SubjectUnit[];
+  hasContent: boolean;
+}) {
   if (units.length === 0) {
     return <p className="text-xs text-gray-400 italic">No units in this subject yet.</p>;
   }
   return (
-    <ol role="list" className="divide-y divide-gray-100">
-      {units.map((unit) => (
-        <li key={unit.unit_id} className="flex items-center justify-between gap-3 py-2">
-          <div className="flex min-w-0 items-center gap-2">
-            <span className="truncate text-sm text-gray-700">{unit.title}</span>
-            {unit.has_lab && (
-              <FlaskConical
-                className="h-3.5 w-3.5 shrink-0 text-purple-500"
-                aria-hidden="true"
-              />
-            )}
-          </div>
-          <div className="flex shrink-0 items-center gap-1">
-            <LinkButton
-              href={`/lesson/${unit.unit_id}`}
-              variant="ghost"
-              size="sm"
-              className="h-7 text-xs"
-            >
-              Lesson
-            </LinkButton>
-            <LinkButton
-              href={`/quiz/${unit.unit_id}`}
-              variant="ghost"
-              size="sm"
-              className="h-7 text-xs"
-            >
-              Quiz
-            </LinkButton>
-          </div>
-        </li>
-      ))}
-    </ol>
+    <>
+      {!hasContent && (
+        <p className="mb-3 rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-700">
+          Content for this subject is coming soon — lessons and quizzes aren&apos;t
+          available yet.
+        </p>
+      )}
+      <ol role="list" className="divide-y divide-gray-100">
+        {units.map((unit) => (
+          <li key={unit.unit_id} className="flex items-center justify-between gap-3 py-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="truncate text-sm text-gray-700">{unit.title}</span>
+              {unit.has_lab && (
+                <FlaskConical
+                  className="h-3.5 w-3.5 shrink-0 text-purple-500"
+                  aria-hidden="true"
+                />
+              )}
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              {hasContent ? (
+                <>
+                  <LinkButton
+                    href={`/lesson/${unit.unit_id}`}
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs"
+                  >
+                    Lesson
+                  </LinkButton>
+                  <LinkButton
+                    href={`/quiz/${unit.unit_id}`}
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs"
+                  >
+                    Quiz
+                  </LinkButton>
+                </>
+              ) : (
+                <span className="text-xs text-gray-400 italic">Coming soon</span>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </>
   );
 }
 
@@ -100,10 +120,17 @@ export default function SubjectsPage() {
             {open ? (
               <BookOpen
                 title={open.subject}
-                subheading={`${open.units.length} unit${open.units.length !== 1 ? "s" : ""}`}
+                subheading={
+                  open.has_content === false
+                    ? "Coming soon"
+                    : `${open.units.length} unit${open.units.length !== 1 ? "s" : ""}`
+                }
                 onClose={() => setOpenSubject(null)}
               >
-                <SubjectUnitList units={open.units} />
+                <SubjectUnitList
+                  units={open.units}
+                  hasContent={open.has_content !== false}
+                />
               </BookOpen>
             ) : null}
           </>

--- a/web/lib/types/api.ts
+++ b/web/lib/types/api.ts
@@ -12,6 +12,9 @@ export interface Unit {
 export interface Subject {
   subject: string;
   units: Unit[];
+  /** False when the subject has no published content yet — used to gate
+   *  selection so students don't open something that would 404 (#469). */
+  has_content?: boolean;
 }
 
 export interface CurriculumTree {


### PR DESCRIPTION
Implements #469 with a **recommended default: subject-level gating**.

## Problem
Students could open a subject / lesson / quiz that had no content yet and hit a 404 ("Could not load lesson" — the #468 dead-end). #469 asks to prevent that selection.

## Default chosen
Gate at the **subject** level — a subject is selectable only if it has **published content**, which is exactly what the serve-time `check_content_published` guard enforces. This stops the click that would otherwise 404, using a signal that already exists in the DB.

## Changes
- **Backend:** `/curriculum/tree` returns a per-subject `has_content` flag — `BOOL_OR(content_subject_versions.status = 'published')`. The JSON-fallback path (default STEM, no DB rows) can't determine readiness, so it defaults to `True` (don't over-gate).
- **Web:** the Subjects page greys out content-less subjects — the opened panel shows a "coming soon" notice and the per-unit Lesson/Quiz links become a muted "Coming soon" label, so the dead-end click can't happen.

## Scope / deferred
- **Per-unit** gating is deferred: content is published **per subject**, so there's no per-unit publish flag to gate on yet. Subject-level covers the reported dead-ends.
- Applied to the **Subjects** page (primary browse surface). The Curriculum Map page can get the same treatment as a follow-up.

## Test plan
`test_curriculum` asserts `/curriculum/tree` carries `has_content` (fallback → True) — **12 passed**. Web `typecheck`/`prettier`/`eslint` clean. The DB-path `BOOL_OR` is a straightforward published-status check (a committed DB-seed test was skipped to avoid the platform-RLS write-guard + shared-test-DB pollution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)