### PR TITLE
fix(feedback): guide local-auth users on password reset (#444)

### DIFF
--- a/web/app/(public)/signin/page.tsx
+++ b/web/app/(public)/signin/page.tsx
@@ -187,14 +187,30 @@ export default function SignInPage() {
           </form>
 
           <div className="space-y-2 text-center text-sm text-gray-500">
-            <p>
-              <Link
-                href="/reset-password"
-                className="text-gray-500 hover:text-gray-900 hover:underline"
-              >
+            {/*
+              School-provisioned (local-auth) accounts are NOT in Auth0, so the
+              /reset-password email flow (POST /auth/forgot-password → Auth0) can
+              never send them a link. Until self-serve reset exists for local
+              users (issue #444), direct them to the path that actually works —
+              an admin reset — instead of promising an email that never arrives.
+            */}
+            <details className="text-gray-500">
+              <summary className="cursor-pointer hover:text-gray-900 hover:underline">
                 Forgot your password?
-              </Link>
-            </p>
+              </summary>
+              <p className="mt-2 text-left text-gray-500">
+                Students and teachers: ask your school administrator to reset your
+                password from their portal. School administrators: contact StudyBuddy
+                support at{" "}
+                <a
+                  href="mailto:support@usestudybuddy.com?subject=Password%20reset%20request"
+                  className="text-blue-600 hover:underline"
+                >
+                  support@usestudybuddy.com
+                </a>
+                .
+              </p>
+            </details>
             <p>
               New school?{" "}
               <Link href="/school/register" className="text-blue-600 hover:underline">


### PR DESCRIPTION
## What
Replaces the dead-end **"Forgot your password?"** link on the public sign-in page (`web/app/(public)/signin/page.tsx`) with an expandable `<details>` that gives working guidance:
- **Students & teachers** → ask your school administrator to reset your password from their portal.
- **School administrators** → contact `support@usestudybuddy.com`.

## Why
Per #444: school-provisioned (local-auth) accounts are **not** in Auth0, so the old link's flow (`POST /auth/forgot-password` → `trigger_auth0_password_reset()`) can never deliver a reset email to them — it silently does nothing for local users. The link promised an email that never arrives, producing the "Incorrect email or password" dead-end Vneki hit during testing.

This is the **short-term** fix (direct users to the paths that actually work today). The **medium-term** follow-up — a real local-user self-serve reset (token flow) — remains tracked in #444.

## Alternatives
- *Implement real local self-serve reset now* — larger backend change (new endpoint + token + email template); deferred as the medium-term item in #444.
- *Hide the link entirely* — rejected; users still need to know how to recover access.

## Risk
Low — single public page, copy/UI-only change. No backend, no auth-path changes. Auth0-backed (self-registered) users were the only ones the old link ever helped, and they can still recover via their IdP; this copy doesn't remove any working path for them.

## Test plan
- `npx prettier --check` ✅
- `npm run typecheck` ✅
- Manual: open `/signin`, expand "Forgot your password?", confirm guidance + `mailto:` render.

Refs #444 (short-term portion; medium-term self-serve reset still open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)