### PR TITLE
feat(auth): self-serve password reset for local (school-provisioned) users (#444)

### DIFF
--- a/backend/src/auth/router.py
+++ b/backend/src/auth/router.py
@@ -8,7 +8,8 @@ Routes:
   POST /auth/teacher/exchange      — Auth0 id_token → internal JWT (teacher)
   POST /auth/refresh               — refresh token → new JWT
   POST /auth/logout                — invalidate refresh token
-  POST /auth/forgot-password       — trigger Auth0 password reset (always 200)
+  POST /auth/forgot-password       — local token email or Auth0 reset (always 200)
+  POST /auth/reset-password        — consume one-time token, set new password (local)
   PATCH /student/profile           — update student name/locale/grade
   GET   /auth/settings             — get display_name, locale, notification preferences
   PATCH /auth/settings             — update display_name, locale, notification preferences
@@ -20,6 +21,8 @@ All prefixed with /api/v1 in main.py.
 from __future__ import annotations
 
 import hashlib
+import secrets
+import uuid
 from datetime import UTC, datetime
 from typing import Annotated
 
@@ -36,6 +39,7 @@ from src.auth.schemas import (
     LogoutRequest,
     RefreshRequest,
     RefreshResponse,
+    ResetPasswordRequest,
     StudentProfileUpdate,
     StudentPublic,
     TeacherPublic,
@@ -48,9 +52,11 @@ from src.auth.service import (
     _TIMING_SENTINEL_HASH,
     _hash_refresh_token,
     create_internal_jwt,
+    find_local_user_by_email,
     generate_refresh_token,
     hash_password,
     login_local_user,
+    set_local_user_password,
     trigger_auth0_password_reset,
     upsert_student,
     upsert_teacher,
@@ -63,6 +69,7 @@ from src.core.events import emit_event, write_audit_log
 from src.core.observability import auth_exchanges_total, auth_failures_total
 from src.core.rate_limit import ip_auth_rate_limit
 from src.core.redis_client import get_redis
+from src.email.service import send_local_reset_link_email
 from src.school.enrolment_service import link_student
 from src.utils.logger import get_logger
 
@@ -74,6 +81,9 @@ _REFRESH_TTL = settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 86400  # seconds
 # Per-email forgot-password rate limit (Redis, prevents email flooding via proxies).
 _FORGOT_PW_LIMIT = 5
 _FORGOT_PW_TTL = 3600  # 1 hour
+
+# One-time self-serve reset token TTL (local school-provisioned users, issue #444).
+_RESET_TOKEN_TTL = 3600  # 1 hour
 
 
 # ── Student exchange ──────────────────────────────────────────────────────────
@@ -391,14 +401,19 @@ async def forgot_password(
     _: None = Depends(ip_auth_rate_limit),
 ):
     """
-    Trigger Auth0 password reset email.
+    Trigger a password reset for the given email.
 
-    Always returns HTTP 200 regardless of whether the email is registered.
-    Different responses would leak registered email addresses.
+    Local (school-provisioned) users are not in Auth0, so the Auth0 reset email
+    never reaches them (issue #444). For those, issue a one-time token, stash it
+    in Redis, and email a self-serve reset link. Self-registered users with no
+    local account fall back to the Auth0 hosted reset flow.
 
-    Per-email Redis guard (5/hour): suppresses the Auth0 call once the limit is
-    exceeded so a single email address cannot be flooded even from rotating IPs.
-    The 200 response is always returned to preserve the non-enumeration guarantee.
+    Always returns HTTP 200 regardless of whether the email is registered or which
+    track it belongs to — different responses would leak registered email addresses.
+
+    Per-email Redis guard (5/hour): suppresses the work once the limit is exceeded
+    so a single email address cannot be flooded even from rotating IPs. The 200
+    response is always returned to preserve the non-enumeration guarantee.
     """
     redis = get_redis(request)
 
@@ -414,12 +429,82 @@ async def forgot_password(
         pipe.incr(fp_key)
         pipe.expire(fp_key, _FORGOT_PW_TTL)
         await pipe.execute()
-        try:
-            await trigger_auth0_password_reset(str(body.email))
-        except Exception:
-            pass
+
+        local_user = await find_local_user_by_email(request.app.state.pool, str(body.email))
+        if local_user is not None:
+            # Self-serve token flow for school-provisioned users.
+            token = secrets.token_urlsafe(32)
+            await redis.set(
+                f"local_pw_reset:{token}",
+                f"{local_user['user_type']}:{local_user['user_id']}",
+                ex=_RESET_TOKEN_TTL,
+            )
+            try:
+                await send_local_reset_link_email(local_user["email"], local_user["name"], token)
+            except Exception as exc:
+                # Never surface failures — preserve the always-200 contract. Do
+                # not log the token or the email address.
+                log.error("local_reset_email_failed", error=str(exc))
+        else:
+            try:
+                await trigger_auth0_password_reset(str(body.email))
+            except Exception:
+                pass
 
     emit_event("auth", "forgot_password_requested")
+    return {}
+
+
+# ── Self-serve reset: consume one-time token (local users, issue #444) ────────
+
+
+@router.post("/auth/reset-password")
+async def reset_password(
+    body: ResetPasswordRequest,
+    request: Request,
+    _: None = Depends(ip_auth_rate_limit),
+):
+    """
+    Complete a self-serve password reset for a local (school-provisioned) user.
+
+    Consumes the one-time token issued by POST /auth/forgot-password, sets the new
+    password, clears first_login, and invalidates the token (single-use). Returns
+    400 on an invalid or expired token. Auth0 users never reach this path — their
+    reset happens entirely within Auth0's hosted flow.
+    """
+    cid = getattr(request.state, "correlation_id", "")
+    redis = get_redis(request)
+
+    key = f"local_pw_reset:{body.token}"
+    stored = await redis.get(key)
+    invalid = HTTPException(
+        status_code=400,
+        detail={
+            "error": "bad_request",
+            "detail": "This reset link is invalid or has expired.",
+            "correlation_id": cid,
+        },
+    )
+    if not stored:
+        raise invalid
+
+    stored_str = stored.decode() if isinstance(stored, (bytes, bytearray)) else str(stored)
+    user_type, _, user_id = stored_str.partition(":")
+    if user_type not in ("teacher", "student") or not user_id:
+        await redis.delete(key)
+        raise invalid
+
+    new_hash = await hash_password(body.new_password)
+    updated = await set_local_user_password(request.app.state.pool, user_type, user_id, new_hash)
+
+    # Single-use: burn the token whether or not the row still exists.
+    await redis.delete(key)
+
+    if not updated:
+        raise invalid
+
+    emit_event("auth", "password_reset_completed", user_type=user_type)
+    write_audit_log("auth.password_reset_completed", user_type, uuid.UUID(user_id))
     return {}
 
 

--- a/backend/src/auth/schemas.py
+++ b/backend/src/auth/schemas.py
@@ -51,6 +51,27 @@ class ForgotPasswordRequest(BaseModel):
         return v.strip().lower()
 
 
+class ResetPasswordRequest(BaseModel):
+    """
+    POST /auth/reset-password
+
+    Completes a self-serve password reset for a local (school-provisioned) user
+    using the one-time token mailed by POST /auth/forgot-password.
+    """
+
+    token: str
+    new_password: str
+
+    @field_validator("new_password")
+    @classmethod
+    def password_length(cls, v: str) -> str:
+        if len(v) < 12:
+            raise ValueError("Password must be at least 12 characters.")
+        if len(v.encode()) > 72:
+            raise ValueError("Password must be 72 bytes or fewer.")
+        return v
+
+
 class StudentProfileUpdate(BaseModel):
     """PATCH /student/profile"""
 

--- a/backend/src/auth/service.py
+++ b/backend/src/auth/service.py
@@ -456,6 +456,77 @@ async def login_local_user(
     return result
 
 
+async def find_local_user_by_email(pool: asyncpg.Pool, email: str) -> dict | None:
+    """
+    Look up a local (school-provisioned) user by email for the self-serve reset
+    flow. Checks teachers first, then students. Returns a dict with keys
+    user_type / user_id / name / email, or None if no local user matches.
+
+    Stamps app.current_school_id='bypass' (pitfall #23) so RLS does not hide the
+    row — this is called from the unauthenticated forgot-password endpoint.
+    """
+    async with pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        try:
+            row = await conn.fetchrow(
+                """
+                SELECT teacher_id::text AS user_id, name, email, 'teacher' AS user_type
+                FROM teachers
+                WHERE email = $1 AND auth_provider = 'local'
+                """,
+                email,
+            )
+            if row is None:
+                row = await conn.fetchrow(
+                    """
+                    SELECT student_id::text AS user_id, name, email, 'student' AS user_type
+                    FROM students
+                    WHERE email = $1 AND auth_provider = 'local'
+                    """,
+                    email,
+                )
+        finally:
+            await conn.execute("SELECT set_config('app.current_school_id', '', false)")
+
+    return dict(row) if row is not None else None
+
+
+async def set_local_user_password(
+    pool: asyncpg.Pool, user_type: str, user_id: str, new_hash: str
+) -> bool:
+    """
+    Set a local user's password_hash and clear first_login. Returns True if a row
+    was updated. A self-serve reset is a deliberate password choice by the user,
+    so first_login is set FALSE (unlike admin provisioning/reset, which sets it
+    TRUE to force a change on next login).
+
+    Stamps app.current_school_id='bypass' (pitfall #23) — called from the
+    unauthenticated reset-password endpoint.
+    """
+    if user_type not in ("teacher", "student"):
+        raise ValueError(f"unexpected user_type: {user_type!r}")
+    table, id_col = (
+        ("teachers", "teacher_id") if user_type == "teacher" else ("students", "student_id")
+    )
+    async with pool.acquire() as conn:
+        await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+        try:
+            status = await conn.execute(
+                f"""
+                UPDATE {table}
+                   SET password_hash = $1, first_login = FALSE
+                 WHERE {id_col} = $2::uuid AND auth_provider = 'local'
+                """,
+                new_hash,
+                user_id,
+            )
+        finally:
+            await conn.execute("SELECT set_config('app.current_school_id', '', false)")
+
+    # asyncpg returns e.g. "UPDATE 1" / "UPDATE 0".
+    return status.rsplit(" ", 1)[-1] != "0"
+
+
 # ── Auth0 Management API ──────────────────────────────────────────────────────
 # Thin re-exports — implementation lives in src/auth/auth0_client.py where the
 # Redis-cached token logic and 401 retry are co-located.

--- a/backend/src/email/service.py
+++ b/backend/src/email/service.py
@@ -677,6 +677,67 @@ async def send_password_reset_email(to_email: str, name: str, password: str) -> 
     )
 
 
+_RESET_LINK_SUBJECT = "StudyBuddy — reset your password"
+
+_RESET_LINK_TEXT = """\
+Hi {name},
+
+We received a request to reset the password for your StudyBuddy account.
+
+Reset your password here:
+{reset_url}
+
+This link expires in 1 hour and can only be used once. If you didn't request
+this, you can safely ignore this email — your password won't change.
+
+— The StudyBuddy Team
+"""
+
+_RESET_LINK_HTML = """\
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /></head>
+<body style="font-family:sans-serif;max-width:560px;margin:0 auto;padding:24px">
+  <h2 style="color:#1a56db">Reset your password</h2>
+  <p>Hi {name},</p>
+  <p>We received a request to reset the password for your StudyBuddy account.</p>
+  <p style="margin:24px 0">
+    <a href="{reset_url}"
+       style="background:#1a56db;color:#fff;padding:12px 20px;border-radius:6px;
+              text-decoration:none;font-weight:bold">Reset password</a>
+  </p>
+  <p style="color:#666;font-size:13px">
+    Or paste this link into your browser:<br />
+    <a href="{reset_url}" style="color:#1a56db">{reset_url}</a>
+  </p>
+  <p style="color:#666;font-size:13px">
+    This link expires in 1 hour and can only be used once. If you didn't request
+    this, you can safely ignore this email — your password won't change.
+  </p>
+  <p style="color:#666;font-size:13px">— The StudyBuddy Team</p>
+</body>
+</html>
+"""
+
+
+async def send_local_reset_link_email(to_email: str, name: str, token: str) -> None:
+    """
+    Send a self-serve password reset link to a local (school-provisioned) user.
+
+    Unlike send_password_reset_email (which mails a temporary password chosen by
+    an admin), this mails a one-time tokenised link the user follows to choose
+    their own password. Backs the self-serve flow added for issue #444.
+    """
+    reset_url = f"{settings.FRONTEND_URL}/reset-password?token={token}"
+    fmt = {"name": name, "reset_url": reset_url}
+    await _send(
+        to_email=to_email,
+        subject=_RESET_LINK_SUBJECT,
+        text_body=_RESET_LINK_TEXT.format(**fmt),
+        html_body=_RESET_LINK_HTML.format(**fmt),
+    )
+
+
 # ── Retention lifecycle emails ────────────────────────────────────────────────
 #
 # All five templates are sent to the school_admin contact email.

--- a/backend/tests/test_auth_local_reset.py
+++ b/backend/tests/test_auth_local_reset.py
@@ -1,0 +1,182 @@
+"""
+backend/tests/test_auth_local_reset.py
+
+Self-serve password reset for local (school-provisioned) users — issue #444.
+
+POST /auth/forgot-password now branches: for a local user it issues a one-time
+token (Redis, 1 hr TTL) and emails a reset link; for everyone else it falls back
+to the Auth0 hosted flow. POST /auth/reset-password consumes the token, sets the
+new password, clears first_login, and burns the token (single-use).
+
+Provisioning happy paths use real DB state via /schools/register +
+/schools/{id}/teachers|students (same strategy as test_auth_universal_login.py).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+_PW = "SecureTestPwd1!"
+_NEW_PW = "BrandNewPassword9!"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+async def _register_school(client: AsyncClient, name: str, email: str) -> dict:
+    r = await client.post(
+        "/api/v1/schools/register",
+        json={"school_name": name, "contact_email": email, "country": "CA", "password": _PW},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+async def _provision_teacher(
+    client: AsyncClient, school_id: str, token: str, name: str, email: str
+) -> str:
+    with patch("src.email.service.send_welcome_teacher_email", new_callable=AsyncMock) as m:
+        r = await client.post(
+            f"/api/v1/schools/{school_id}/teachers",
+            json={"name": name, "email": email},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 201, r.text
+    a = m.call_args
+    return a.args[2] if len(a.args) >= 3 else a.kwargs["password"]
+
+
+async def _provision_student(
+    client: AsyncClient, school_id: str, token: str, name: str, email: str
+) -> str:
+    with patch("src.email.service.send_welcome_student_email", new_callable=AsyncMock) as m:
+        r = await client.post(
+            f"/api/v1/schools/{school_id}/students",
+            json={"name": name, "email": email, "grade": 8},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 201, r.text
+    a = m.call_args
+    return a.args[2] if len(a.args) >= 3 else a.kwargs["password"]
+
+
+async def _forgot(client: AsyncClient, email: str):
+    """Trigger forgot-password with both downstream senders patched.
+
+    Returns (response, local_email_mock, auth0_mock). When the email belongs to a
+    local user the reset token is local_email_mock.call_args.args[2].
+    """
+    with (
+        patch("src.auth.router.send_local_reset_link_email", new_callable=AsyncMock) as local_mock,
+        patch("src.auth.router.trigger_auth0_password_reset", new_callable=AsyncMock) as auth0_mock,
+    ):
+        r = await client.post("/api/v1/auth/forgot-password", json={"email": email})
+    return r, local_mock, auth0_mock
+
+
+# ── Forgot-password branching ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_forgot_password_local_user_issues_token_and_emails_link(
+    client: AsyncClient, fake_redis
+):
+    """A local teacher gets a tokenised reset link, not the dead-end Auth0 flow."""
+    school = await _register_school(client, "Reset School A", "admin-a@reset-test.example.com")
+    email = "teach-a@reset-test.example.com"
+    await _provision_teacher(client, school["school_id"], school["access_token"], "Tay", email)
+
+    r, local_mock, auth0_mock = await _forgot(client, email)
+
+    assert r.status_code == 200
+    local_mock.assert_awaited_once()
+    auth0_mock.assert_not_awaited()  # local users never hit the Auth0 path
+
+    token = local_mock.call_args.args[2]
+    stored = await fake_redis.get(f"local_pw_reset:{token}")
+    assert stored is not None
+    assert stored.decode().startswith("teacher:")
+
+
+@pytest.mark.asyncio
+async def test_forgot_password_unknown_email_falls_back_to_auth0(client: AsyncClient):
+    """No local account → Auth0 hosted flow, still always 200, no local email."""
+    r, local_mock, auth0_mock = await _forgot(client, "nobody@nowhere.invalid")
+
+    assert r.status_code == 200
+    local_mock.assert_not_awaited()
+    auth0_mock.assert_awaited_once()
+
+
+# ── Reset-password ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_password_completes_and_allows_login(client: AsyncClient):
+    """End-to-end: forgot → reset → log in with the new password (old one fails)."""
+    school = await _register_school(client, "Reset School B", "admin-b@reset-test.example.com")
+    email = "stud-b@reset-test.example.com"
+    old_pw = await _provision_student(
+        client, school["school_id"], school["access_token"], "Sam", email
+    )
+
+    _, local_mock, _ = await _forgot(client, email)
+    token = local_mock.call_args.args[2]
+
+    rp = await client.post(
+        "/api/v1/auth/reset-password", json={"token": token, "new_password": _NEW_PW}
+    )
+    assert rp.status_code == 200, rp.text
+
+    # New password works...
+    ok = await client.post("/api/v1/auth/login", json={"email": email, "password": _NEW_PW})
+    assert ok.status_code == 200, ok.text
+    # ...and self-serve reset clears first_login (deliberate password choice).
+    assert ok.json()["first_login"] is False
+
+    # Old emailed password no longer works.
+    bad = await client.post("/api/v1/auth/login", json={"email": email, "password": old_pw})
+    assert bad.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_reset_password_invalid_token(client: AsyncClient):
+    """An unknown/expired token is rejected with 400."""
+    r = await client.post(
+        "/api/v1/auth/reset-password",
+        json={"token": "definitely-not-a-real-token", "new_password": _NEW_PW},
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_reset_password_token_is_single_use(client: AsyncClient):
+    """A token works once; a replay is rejected."""
+    school = await _register_school(client, "Reset School C", "admin-c@reset-test.example.com")
+    email = "teach-c@reset-test.example.com"
+    await _provision_teacher(client, school["school_id"], school["access_token"], "Cee", email)
+
+    _, local_mock, _ = await _forgot(client, email)
+    token = local_mock.call_args.args[2]
+
+    first = await client.post(
+        "/api/v1/auth/reset-password", json={"token": token, "new_password": _NEW_PW}
+    )
+    assert first.status_code == 200, first.text
+
+    replay = await client.post(
+        "/api/v1/auth/reset-password", json={"token": token, "new_password": "AnotherPass123!"}
+    )
+    assert replay.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_reset_password_rejects_short_password(client: AsyncClient):
+    """Schema enforces the ≥12 char policy before any token lookup."""
+    r = await client.post(
+        "/api/v1/auth/reset-password", json={"token": "whatever", "new_password": "short"}
+    )
+    assert r.status_code == 422

--- a/web/app/(public)/reset-password/page.tsx
+++ b/web/app/(public)/reset-password/page.tsx
@@ -20,7 +20,7 @@ const requestSchema = z.object({
 
 const resetSchema = z
   .object({
-    password: z.string().min(8, "At least 8 characters"),
+    password: z.string().min(12, "At least 12 characters"),
     confirm: z.string(),
   })
   .refine((d) => d.password === d.confirm, {


### PR DESCRIPTION
## What
Implements real self-serve password reset for **local (school-provisioned)** users — the medium-term fix tracked in #488, root cause in #444.

- **`POST /auth/forgot-password`** now branches on the account:
  - **Local user** → mint a one-time token (`local_pw_reset:{token}` in Redis, 1 hr TTL) and email a reset link.
  - **No local account** → fall back to the existing Auth0 hosted reset flow (self-registered users).
  - Still **always 200** (no email enumeration) and still per-email rate limited.
- **`POST /auth/reset-password`** (new) → consume the token, set `password_hash`, clear `first_login`, burn the token (single-use). `400` on invalid/expired token. Auth0 users never reach this path.
- **service**: `find_local_user_by_email` / `set_local_user_password`, both stamping `app.current_school_id='bypass'` (pitfall #23) for the unauthenticated lookups.
- **email**: `send_local_reset_link_email` — a tokenised `/reset-password?token=…` link, distinct from the admin temp-password email, with expiry + "ignore if not you" copy.

## Why
School-provisioned accounts aren't in Auth0, so the old Auth0-only `forgot-password` never reached them — there was **no** self-serve recovery, only an admin reset. Per #444 this affected every local user who tried the link. `first_login` is set **FALSE** on reset because choosing a password via the emailed link is a deliberate set (unlike admin provisioning, which forces a change on next login).

## Frontend
The `/reset-password` page already drives both endpoints (request form + tokenised set-new-password form). Only change: aligned its min-password rule **8 → 12** to match the backend policy (avoids a confusing 422).

## Alternatives
- *Hide "Forgot password" for local users* (the #487 short-term mitigation) — superseded by this real flow. See note below.
- *Reuse the admin temp-password reset* — rejected; that requires an admin and re-forces `first_login`, which is the exact dead-end #444 describes.

## Risk
Medium-low. New endpoint + a branch in `forgot-password`. Security-sensitive invariants preserved and tested: always-200 contract, per-email rate limit, single-use + TTL-bounded tokens, no token/email in logs, RLS bypass scoped to the lookups. No migration.

## Test plan
`backend/tests/test_auth_local_reset.py` (6 tests):
- local token issuance + Redis key shape; Auth0 fallback for unknown emails
- full forgot → reset → login (old password rejected, `first_login` cleared)
- invalid token → 400; single-use replay → 400; short password → 422

All pass; `tests/test_auth.py`, `test_auth_universal_login.py`, `test_auth_rate_limit.py`, `test_phase_a_provisioning.py` (57 tests) still green. Ruff + Prettier + tsc clean.

## Relationship to #487
This **supersedes** the #487 short-term mitigation (sign-in page guidance copy). Recommend closing #487 once this merges — restoring a working "Forgot your password?" link for everyone is the better end state. This branch is off `main`, so it keeps the original working `/reset-password` link.

Refs #444. Closes #488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)