### PR TITLE
chore: fix ruff format drift in analytics/content routers

### DIFF
--- a/backend/src/analytics/router.py
+++ b/backend/src/analytics/router.py
@@ -237,9 +237,7 @@ async def student_stats(
             """,
             student_id,
         )
-        subject_labels = await resolve_subject_labels(
-            conn, [r["unit_id"] for r in unit_subj_rows]
-        )
+        subject_labels = await resolve_subject_labels(conn, [r["unit_id"] for r in unit_subj_rows])
 
     session_dates = [str(r["session_date"]) for r in rows]
     total_sessions = sum(r["sessions"] for r in rows)

--- a/backend/src/content/router.py
+++ b/backend/src/content/router.py
@@ -72,6 +72,7 @@ async def _subject_display_name(pool, unit_id: str, fallback: str | None) -> str
         labels = await resolve_subject_labels(conn, [unit_id])
     return display_subject(labels, unit_id, fallback)
 
+
 _GRADE_RE = re.compile(r"^G(\d+)-")
 
 


### PR DESCRIPTION
## What
Runs `ruff format` on the two files that were failing CI's **Backend — Lint & Security** (`ruff format --check src/`) job: `src/analytics/router.py` and `src/content/router.py`.

## Why
These two files had pre-existing format drift on `main`, reddening the lint job on every PR (surfaced while merging #489). No behaviour change — line-length reflow in `analytics/router.py` and a missing blank line before a module-level constant in `content/router.py`.

## Risk
None. Formatting only; `ruff format --check src/` now reports all 143 files clean.

## Test plan
- `ruff format --check src/` → clean
- `git diff` confirms whitespace/reflow only

🤖 Generated with [Claude Code](https://claude.com/claude-code)