### PR TITLE
test(web): fix quiz-page + account-settings unit tests (#363)

### DIFF
--- a/web/tests/unit/account-settings-page.test.tsx
+++ b/web/tests/unit/account-settings-page.test.tsx
@@ -23,6 +23,17 @@ vi.mock("next-intl", () => ({
   useTranslations: vi.fn(() => (key: string) => key),
 }));
 
+// SettingsPage calls useRouter() (next/navigation), which throws outside an app
+// router context. Stub it so the component renders under jsdom.
+const mockRouterPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({
+    push: mockRouterPush,
+    replace: mockRouterPush,
+    refresh: vi.fn(),
+  })),
+}));
+
 const mockGetAccountSettings = vi.fn();
 const mockSaveAccountSettings = vi.fn();
 

--- a/web/tests/unit/quiz-page.test.tsx
+++ b/web/tests/unit/quiz-page.test.tsx
@@ -41,6 +41,16 @@ vi.mock("@/lib/api/progress", () => ({
   endSession: (...args: unknown[]) => mockEndSession(...args),
 }));
 
+// QuizPlayer calls useQueryClient().invalidateQueries() after the session ends;
+// stub it so the component renders without a QueryClientProvider.
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQueryClient: vi.fn(() => ({ invalidateQueries: vi.fn() })),
+  };
+});
+
 // ---------------------------------------------------------------------------
 // STU-19 — Quiz question renders with options
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Fixes the 42 failing frontend unit tests (`quiz-page.test.tsx`, `account-settings-page.test.tsx`) that have been the standing red in the **Frontend — Unit Tests** CI job. Test-only — no component changes.

## Why
Both components grew new hooks the tests never stubbed:
- **quiz-page** — `QuizPlayer` calls `useQueryClient().invalidateQueries(["stats"|"progress"])` after a session ends, which throws (`No QueryClient set`) when rendered without a `QueryClientProvider`. Now mocks `useQueryClient` (same pattern as `at-risk-page.test.tsx`).
- **account-settings** — `SettingsPage` uses `useRouter()` and calls `router.refresh()` on save. The test had no `next/navigation` mock (`invariant expected app router to be mounted`); once mocked, two save tests still failed because the stub omitted `refresh`, so the save handler threw into its `catch` and rendered the error state. Mock now provides `push`/`replace`/`refresh`.

## Risk
None — only adds `vi.mock` stubs in two test files.

## Test plan
- Both files: 42/42 pass.
- Full frontend unit suite: **65 files / 835 tests green**.
- `prettier --check`, `eslint`, `tsc --noEmit` all clean.

Refs #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)