### PR TITLE
fix(feedback): gate units without content + honest load errors (#468, #469)

### DIFF
--- a/backend/src/curriculum/router.py
+++ b/backend/src/curriculum/router.py
@@ -21,6 +21,7 @@ Prefixed with /api/v1 in main.py.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from typing import Annotated
@@ -37,6 +38,7 @@ from src.core.cache import curriculum_cache
 from src.core.cache_keys import cur_key
 from src.core.db import get_db
 from src.core.redis_client import get_redis
+from src.core.storage import StorageBackend, get_storage
 from src.curriculum.schemas import (
     CurriculumActivateResponse,
     CurriculumUploadRequest,
@@ -85,6 +87,35 @@ def _load_grade(grade: int) -> dict:
 
 def _cid(request: Request) -> str:
     return getattr(request.state, "correlation_id", "")
+
+
+async def _has_content_map(
+    storage: StorageBackend, content_curriculum_id: str, unit_ids: list[str]
+) -> dict[str, bool]:
+    """
+    Return {unit_id: has_content} by probing the content store for each unit's
+    English lesson file (the canonical fallback every content endpoint serves —
+    see content/router.py, which tries lesson_{locale} then lesson_en).
+
+    Lets the student UI grey-out units with no generated content instead of
+    letting the click dead-end on a 404 "Could not load lesson" (#468/#469).
+    One storage probe per unit, run concurrently.
+    """
+    if not unit_ids:
+        return {}
+
+    async def _probe(unit_id: str) -> bool:
+        try:
+            return await storage.exists(
+                f"curricula/{content_curriculum_id}/{unit_id}/lesson_en.json"
+            )
+        except Exception:
+            # A storage hiccup must not blank the whole tree — default to
+            # "available" so we never hide content that actually exists.
+            return True
+
+    flags = await asyncio.gather(*(_probe(u) for u in unit_ids))
+    return dict(zip(unit_ids, flags, strict=True))
 
 
 # ── Grade tree (existing) ─────────────────────────────────────────────────────
@@ -549,6 +580,25 @@ async def get_curriculum_tree(
             curriculum_id=curriculum_id,
             grade=grade,
         )
+
+    # Per-unit content-availability flag (#468/#469) so the UI can grey-out
+    # units whose content has not been generated rather than dead-ending on a
+    # 404. Probe the content store for the canonical English lesson file.
+    #
+    # School forks (source_id present) serve unit content from teacher DB
+    # overrides, not (only) from files — probing the OOB files would wrongly
+    # hide overridden units. Skip the probe for forks and mark everything
+    # available; the OOB platform path is where the reported dead-ends occur.
+    all_units = [u for subj in subjects for u in subj["units"]]
+    if source_id:
+        content_map = {u["unit_id"]: True for u in all_units}
+    else:
+        storage = get_storage(request)
+        content_map = await _has_content_map(
+            storage, units_lookup_id, [u["unit_id"] for u in all_units]
+        )
+    for u in all_units:
+        u["has_content"] = content_map.get(u["unit_id"], True)
 
     return {"curriculum_id": curriculum_id, "grade": grade, "subjects": subjects}
 

--- a/backend/tests/test_curriculum_content_flag.py
+++ b/backend/tests/test_curriculum_content_flag.py
@@ -1,0 +1,54 @@
+"""
+tests/test_curriculum_content_flag.py
+
+Unit tests for the per-unit `has_content` probe that backs the student curriculum
+tree's content-availability gating (#468/#469). The probe greys out units whose
+content has not been generated so the click doesn't dead-end on a 404.
+"""
+
+from __future__ import annotations
+
+from src.curriculum.router import _has_content_map
+
+
+class _FakeStorage:
+    """Minimal StorageBackend stand-in: exists() is True for seeded paths."""
+
+    def __init__(self, present: set[str], raises: set[str] | None = None):
+        self._present = present
+        self._raises = raises or set()
+
+    async def exists(self, path: str) -> bool:
+        if path in self._raises:
+            raise OSError("storage unavailable")
+        return path in self._present
+
+
+async def test_has_content_map_flags_present_and_absent_units():
+    cid = "default-2026-g8"
+    storage = _FakeStorage(
+        present={f"curricula/{cid}/G8-MATH-001/lesson_en.json"},
+    )
+
+    result = await _has_content_map(storage, cid, ["G8-MATH-001", "G8-MATH-002"])
+
+    assert result == {"G8-MATH-001": True, "G8-MATH-002": False}
+
+
+async def test_has_content_map_empty_units_returns_empty():
+    storage = _FakeStorage(present=set())
+    assert await _has_content_map(storage, "default-2026-g8", []) == {}
+
+
+async def test_has_content_map_defaults_available_on_storage_error():
+    # A storage hiccup must never hide content that may actually exist — the
+    # probe defaults the unit to available rather than greying it out.
+    cid = "default-2026-g8"
+    storage = _FakeStorage(
+        present=set(),
+        raises={f"curricula/{cid}/G8-MATH-001/lesson_en.json"},
+    )
+
+    result = await _has_content_map(storage, cid, ["G8-MATH-001"])
+
+    assert result == {"G8-MATH-001": True}

--- a/web/app/(student)/curriculum/page.tsx
+++ b/web/app/(student)/curriculum/page.tsx
@@ -77,6 +77,7 @@ export default function CurriculumMapPage() {
                       subjectKey={subject.subject}
                       status={statusMap.get(unit.unit_id) ?? "not_started"}
                       hasLab={unit.has_lab}
+                      dim={unit.has_content === false}
                       isOpen={openUnitId === unit.unit_id}
                       onToggle={(id) => setOpenUnitId((cur) => (cur === id ? null : id))}
                     />
@@ -84,7 +85,14 @@ export default function CurriculumMapPage() {
                 </Shelf>
                 {open ? (
                   <BookOpen title={open.title} onClose={() => setOpenUnitId(null)}>
-                    <Toc unitId={open.unit_id} hasLab={open.has_lab} />
+                    {open.has_content === false ? (
+                      <p className="text-sm text-gray-500">
+                        This unit&apos;s content hasn&apos;t been published yet. Check
+                        back soon.
+                      </p>
+                    ) : (
+                      <Toc unitId={open.unit_id} hasLab={open.has_lab} />
+                    )}
                   </BookOpen>
                 ) : null}
               </Aisle>

--- a/web/app/(student)/experiment/[unit_id]/page.tsx
+++ b/web/app/(student)/experiment/[unit_id]/page.tsx
@@ -8,6 +8,7 @@ import { FeedbackWidget } from "@/components/feedback/FeedbackWidget";
 import { OfflineBanner } from "@/components/student/OfflineBanner";
 import { LinkButton } from "@/components/ui/link-button";
 import { AIContentDisclosure } from "@/components/content/AIContentDisclosure";
+import { contentErrorMessage } from "@/lib/content-error";
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface PageProps {
@@ -20,6 +21,7 @@ export default function ExperimentPage({ params }: PageProps) {
     data: experiment,
     isLoading,
     isError,
+    error,
   } = useQuery({
     queryKey: ["experiment", unit_id],
     queryFn: () => getExperiment(unit_id),
@@ -37,10 +39,11 @@ export default function ExperimentPage({ params }: PageProps) {
   }
 
   if (isError || !experiment) {
+    const { message, unavailable } = contentErrorMessage(error);
     return (
       <div className="p-6">
-        <p className="text-sm text-red-500">
-          Could not load experiment. Please try again.
+        <p className={`text-sm ${unavailable ? "text-gray-500" : "text-red-500"}`}>
+          {message}
         </p>
       </div>
     );

--- a/web/app/(student)/lesson/[unit_id]/page.tsx
+++ b/web/app/(student)/lesson/[unit_id]/page.tsx
@@ -10,6 +10,7 @@ import { LinkButton } from "@/components/ui/link-button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { startLessonView, endLessonViewBeacon } from "@/lib/api/analytics";
 import { AIContentDisclosure } from "@/components/content/AIContentDisclosure";
+import { contentErrorMessage } from "@/lib/content-error";
 import { FlaskConical, FileQuestion } from "lucide-react";
 
 interface PageProps {
@@ -18,7 +19,7 @@ interface PageProps {
 
 export default function LessonPage({ params }: PageProps) {
   const { unit_id } = use(params);
-  const { data: lesson, isLoading, isError } = useLesson(unit_id);
+  const { data: lesson, isLoading, isError, error } = useLesson(unit_id);
 
   const viewIdRef = useRef<string | null>(null);
   const startTimeRef = useRef<number>(0);
@@ -71,9 +72,12 @@ export default function LessonPage({ params }: PageProps) {
   }
 
   if (isError || !lesson) {
+    const { message, unavailable } = contentErrorMessage(error);
     return (
       <div className="p-6">
-        <p className="text-sm text-red-500">Could not load lesson. Please try again.</p>
+        <p className={`text-sm ${unavailable ? "text-gray-500" : "text-red-500"}`}>
+          {message}
+        </p>
       </div>
     );
   }

--- a/web/app/(student)/quiz/[unit_id]/page.tsx
+++ b/web/app/(student)/quiz/[unit_id]/page.tsx
@@ -6,6 +6,7 @@ import { QuizPlayer } from "@/components/content/QuizPlayer";
 import { OfflineBanner } from "@/components/student/OfflineBanner";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AIContentDisclosure } from "@/components/content/AIContentDisclosure";
+import { contentErrorMessage } from "@/lib/content-error";
 import { startSession } from "@/lib/api/progress";
 
 interface PageProps {
@@ -14,7 +15,7 @@ interface PageProps {
 
 export default function QuizPage({ params }: PageProps) {
   const { unit_id } = use(params);
-  const { data: quiz, isLoading, isError } = useQuiz(unit_id);
+  const { data: quiz, isLoading, isError, error } = useQuiz(unit_id);
   const [sessionId, setSessionId] = useState<string | null>(null);
 
   // Open a fresh quiz attempt. Used on first load and on "Try Again" — the
@@ -44,9 +45,12 @@ export default function QuizPage({ params }: PageProps) {
   }
 
   if (isError || !quiz) {
+    const { message, unavailable } = contentErrorMessage(error);
     return (
       <div className="p-6">
-        <p className="text-sm text-red-500">Could not load quiz. Please try again.</p>
+        <p className={`text-sm ${unavailable ? "text-gray-500" : "text-red-500"}`}>
+          {message}
+        </p>
       </div>
     );
   }

--- a/web/app/(student)/subjects/page.tsx
+++ b/web/app/(student)/subjects/page.tsx
@@ -8,7 +8,12 @@ import { FlaskConical } from "lucide-react";
 import { OfflineBanner } from "@/components/student/OfflineBanner";
 import { Shelf, BookSpine, BookOpen, deriveSubjectAccent } from "@/components/library";
 
-type SubjectUnit = { unit_id: string; title: string; has_lab?: boolean };
+type SubjectUnit = {
+  unit_id: string;
+  title: string;
+  has_lab?: boolean;
+  has_content?: boolean;
+};
 
 function SubjectUnitList({ units }: { units: SubjectUnit[] }) {
   if (units.length === 0) {
@@ -16,37 +21,57 @@ function SubjectUnitList({ units }: { units: SubjectUnit[] }) {
   }
   return (
     <ol role="list" className="divide-y divide-gray-100">
-      {units.map((unit) => (
-        <li key={unit.unit_id} className="flex items-center justify-between gap-3 py-2">
-          <div className="flex min-w-0 items-center gap-2">
-            <span className="truncate text-sm text-gray-700">{unit.title}</span>
-            {unit.has_lab && (
-              <FlaskConical
-                className="h-3.5 w-3.5 shrink-0 text-purple-500"
-                aria-hidden="true"
-              />
-            )}
-          </div>
-          <div className="flex shrink-0 items-center gap-1">
-            <LinkButton
-              href={`/lesson/${unit.unit_id}`}
-              variant="ghost"
-              size="sm"
-              className="h-7 text-xs"
-            >
-              Lesson
-            </LinkButton>
-            <LinkButton
-              href={`/quiz/${unit.unit_id}`}
-              variant="ghost"
-              size="sm"
-              className="h-7 text-xs"
-            >
-              Quiz
-            </LinkButton>
-          </div>
-        </li>
-      ))}
+      {units.map((unit) => {
+        // Only an explicit false disables selection — undefined means the
+        // backend didn't flag availability, so keep the unit clickable.
+        const unavailable = unit.has_content === false;
+        return (
+          <li key={unit.unit_id} className="flex items-center justify-between gap-3 py-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <span
+                className={`truncate text-sm ${unavailable ? "text-gray-400" : "text-gray-700"}`}
+              >
+                {unit.title}
+              </span>
+              {unit.has_lab && (
+                <FlaskConical
+                  className="h-3.5 w-3.5 shrink-0 text-purple-500"
+                  aria-hidden="true"
+                />
+              )}
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              {unavailable ? (
+                <span
+                  className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500"
+                  title="This unit's content hasn't been published yet."
+                >
+                  Coming soon
+                </span>
+              ) : (
+                <>
+                  <LinkButton
+                    href={`/lesson/${unit.unit_id}`}
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs"
+                  >
+                    Lesson
+                  </LinkButton>
+                  <LinkButton
+                    href={`/quiz/${unit.unit_id}`}
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs"
+                  >
+                    Quiz
+                  </LinkButton>
+                </>
+              )}
+            </div>
+          </li>
+        );
+      })}
     </ol>
   );
 }

--- a/web/app/(student)/tutorial/[unit_id]/page.tsx
+++ b/web/app/(student)/tutorial/[unit_id]/page.tsx
@@ -8,6 +8,7 @@ import { FeedbackWidget } from "@/components/feedback/FeedbackWidget";
 import { OfflineBanner } from "@/components/student/OfflineBanner";
 import { LinkButton } from "@/components/ui/link-button";
 import { AIContentDisclosure } from "@/components/content/AIContentDisclosure";
+import { contentErrorMessage } from "@/lib/content-error";
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface PageProps {
@@ -20,6 +21,7 @@ export default function TutorialPage({ params }: PageProps) {
     data: tutorial,
     isLoading,
     isError,
+    error,
   } = useQuery({
     queryKey: ["tutorial", unit_id],
     queryFn: () => getTutorial(unit_id),
@@ -38,9 +40,12 @@ export default function TutorialPage({ params }: PageProps) {
   }
 
   if (isError || !tutorial) {
+    const { message, unavailable } = contentErrorMessage(error);
     return (
       <div className="p-6">
-        <p className="text-sm text-red-500">Could not load tutorial. Please try again.</p>
+        <p className={`text-sm ${unavailable ? "text-gray-500" : "text-red-500"}`}>
+          {message}
+        </p>
       </div>
     );
   }

--- a/web/lib/content-error.ts
+++ b/web/lib/content-error.ts
@@ -1,0 +1,31 @@
+import { AxiosError } from "axios";
+
+/**
+ * Map a content-fetch error to student-facing, non-technical copy (Content
+ * Rule #5 — never expose status codes or internal identifiers to students).
+ *
+ * Distinguishes "not generated yet" (HTTP 404 from the content endpoints —
+ * unit not in the curriculum, subject unpublished, or the file is missing)
+ * from a genuine transient failure, so a student who opens an ungenerated
+ * unit sees "not available yet" instead of a misleading "try again" (#468).
+ */
+export function contentErrorMessage(error: unknown): {
+  message: string;
+  unavailable: boolean;
+} {
+  const status = error instanceof AxiosError ? error.response?.status : undefined;
+
+  // 404 = the content does not exist (yet). Retrying will never help, so don't
+  // imply it might. 402 (subscription required) is handled by the paywall flow.
+  if (status === 404) {
+    return {
+      message: "This isn't available yet. Please check back soon.",
+      unavailable: true,
+    };
+  }
+
+  return {
+    message: "Something went wrong loading this. Please try again.",
+    unavailable: false,
+  };
+}

--- a/web/lib/types/api.ts
+++ b/web/lib/types/api.ts
@@ -7,6 +7,13 @@ export interface Unit {
   grade: number;
   sort_order: number;
   has_lab: boolean;
+  /**
+   * Whether generated content exists for this unit. Absent (undefined) is
+   * treated as available — only an explicit `false` greys out / disables
+   * selection so the click doesn't dead-end on a "Could not load" 404
+   * (#468/#469).
+   */
+  has_content?: boolean;
 }
 
 export interface Subject {


### PR DESCRIPTION
## What
Closes #468 and #469 (Venki feedback, test cycle 2026-06-14).

Students could navigate to lessons/quizzes for units whose content was never generated. The result was a generic red **"Could not load lesson. Please try again."** that wrongly implied a transient error (#468), and there was nothing stopping the dead-end click in the first place (#469).

## Why
The content store is intentionally partial (not every unit is generated yet). The content endpoints correctly 404 for missing/unpublished content, but the UI collapsed every failure into one alarming, retry-implying message and let students select units that can only fail.

## Changes
- **Backend** (`curriculum/router.py`): `GET /curriculum/tree` now returns a per-unit `has_content` boolean. It probes the content store for the canonical `lesson_en.json` (the file every content endpoint falls back to), one concurrent probe per unit. School **forks** skip the probe and report `True` — their unit content is served from teacher DB overrides, not OOB files, so probing would wrongly hide overridden units. A storage error defaults a unit to *available* (never hide content that may exist).
- **Web — Subjects**: units with `has_content === false` are greyed out with a non-clickable **"Coming soon"** badge.
- **Web — Curriculum Map**: such units' spines are dimmed (`dim`) and the open panel shows a "hasn't been published yet" notice instead of the Lesson/Tutorial/Quiz/Experiment list.
- **Web — content pages** (lesson/quiz/tutorial/experiment): new `contentErrorMessage()` helper distinguishes a 404 "not available yet" (grey, no retry implication) from a genuine transient failure (red, "please try again"), keeping copy non-technical per Content Rule #5.

`undefined` `has_content` is treated as available, so any caller/endpoint not yet emitting the flag is unaffected.

## Risk
Low. Additive backend field; frontend only changes presentation. Forks explicitly opted out of the probe to avoid hiding teacher content.

## Test plan
- `backend/tests/test_curriculum_content_flag.py` — covers the `has_content` probe (present/absent units, empty input, storage-error → defaults available).
- Backend `ruff` clean; web `tsc --noEmit`, `eslint`, `prettier --check` clean on changed files.
- Manual: open Subjects/Curriculum Map as a student on a partially-generated curriculum → ungenerated units show "Coming soon"/dimmed; opening one directly by URL shows the calm "not available yet" copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)