### PR TITLE
fix(feedback): apply saved language to content immediately (#470)

### DIFF
--- a/backend/src/auth/router.py
+++ b/backend/src/auth/router.py
@@ -1170,7 +1170,22 @@ async def update_settings(
             )
 
     emit_event("auth", "settings_updated", student_id=str(student_id))
-    return {}
+
+    # Re-mint the student JWT when the locale changed. Content endpoints read
+    # the locale authoritatively from the JWT (never a query param), so without
+    # a fresh token the new language only takes effect after the next login —
+    # the student saves "Español" but keeps seeing English (#470). Carry over
+    # every existing claim, swapping in the new locale; drop the signed-token
+    # internal claims so create_internal_jwt issues fresh ones.
+    new_token: str | None = None
+    if "locale" in student_updates:
+        claims = {k: v for k, v in student.items() if k not in ("iat", "exp", "jti")}
+        claims["locale"] = student_updates["locale"]
+        new_token = create_internal_jwt(
+            claims, settings.JWT_SECRET, settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES
+        )
+
+    return {"token": new_token} if new_token else {}
 
 
 # ── Account deletion (GDPR) ───────────────────────────────────────────────────

--- a/backend/tests/test_settings_locale.py
+++ b/backend/tests/test_settings_locale.py
@@ -1,0 +1,71 @@
+"""
+tests/test_settings_locale.py
+
+Tests for PATCH /auth/settings locale propagation (#470).
+
+When a student changes their language the endpoint must re-mint the student
+JWT carrying the new locale — content endpoints read the locale authoritatively
+from the token, so without a fresh token the new language only takes effect
+after the next login. A non-locale change must NOT return a token.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from jose import jwt
+
+from tests.helpers.token_factory import JWT_ALGORITHM, TEST_JWT_SECRET, make_student_token
+
+
+@pytest.mark.asyncio
+async def test_locale_change_returns_reminted_token(client: AsyncClient, fake_redis):
+    student_id = str(uuid.uuid4())
+    token = make_student_token(student_id=student_id, grade=8, locale="en")
+
+    response = await client.patch(
+        "/api/v1/auth/settings",
+        json={"locale": "es"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200, response.text
+    new_token = response.json().get("token")
+    assert new_token, "expected a re-minted token on locale change"
+
+    decoded = jwt.decode(new_token, TEST_JWT_SECRET, algorithms=[JWT_ALGORITHM])
+    assert decoded["locale"] == "es"
+    assert decoded["student_id"] == student_id
+    assert decoded["role"] == "student"
+
+
+@pytest.mark.asyncio
+async def test_non_locale_change_returns_no_token(client: AsyncClient, fake_redis):
+    student_id = str(uuid.uuid4())
+    token = make_student_token(student_id=student_id, grade=8, locale="en")
+
+    response = await client.patch(
+        "/api/v1/auth/settings",
+        json={"display_name": "New Name"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json().get("token") is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_locale_ignored_no_token(client: AsyncClient, fake_redis):
+    student_id = str(uuid.uuid4())
+    token = make_student_token(student_id=student_id, grade=8, locale="en")
+
+    response = await client.patch(
+        "/api/v1/auth/settings",
+        json={"locale": "de"},  # unsupported — must be rejected, no re-mint
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json().get("token") is None

--- a/web/app/(student)/account/settings/page.tsx
+++ b/web/app/(student)/account/settings/page.tsx
@@ -58,12 +58,14 @@ function SettingsPageInner() {
     setSaved(false);
     setError(null);
     try {
-      const { token } = await saveAccountSettings(settings);
+      const result = await saveAccountSettings(settings);
       // Swap in the re-minted JWT so a locale change applies to content
       // immediately — content endpoints read the locale from the token, so a
       // stale token would keep serving the old language until logout (#470).
-      if (token && typeof window !== "undefined") {
-        localStorage.setItem("sb_token", token);
+      // Tolerate a void/undefined return (the endpoint only returns a token
+      // when the locale actually changed).
+      if (result?.token && typeof window !== "undefined") {
+        localStorage.setItem("sb_token", result.token);
       }
       // Reflect a display-name change in the header immediately instead of
       // waiting for the next login: update the SSR session cookie, then

--- a/web/app/(student)/account/settings/page.tsx
+++ b/web/app/(student)/account/settings/page.tsx
@@ -58,7 +58,13 @@ function SettingsPageInner() {
     setSaved(false);
     setError(null);
     try {
-      await saveAccountSettings(settings);
+      const { token } = await saveAccountSettings(settings);
+      // Swap in the re-minted JWT so a locale change applies to content
+      // immediately — content endpoints read the locale from the token, so a
+      // stale token would keep serving the old language until logout (#470).
+      if (token && typeof window !== "undefined") {
+        localStorage.setItem("sb_token", token);
+      }
       // Reflect a display-name change in the header immediately instead of
       // waiting for the next login: update the SSR session cookie, then
       // re-render the server layout (#467).
@@ -132,7 +138,8 @@ function SettingsPageInner() {
                 ))}
               </div>
               <p className="mt-2 text-xs text-gray-400">
-                Content is served in your selected language.
+                Lessons and quizzes appear in your selected language where a translation
+                is available, and in English otherwise.
               </p>
             </CardContent>
           </Card>

--- a/web/lib/api/settings.ts
+++ b/web/lib/api/settings.ts
@@ -17,8 +17,15 @@ export async function getAccountSettings(): Promise<AccountSettings> {
   return res.data;
 }
 
+/**
+ * Save account settings. When the locale changed the backend re-mints the
+ * student JWT (locale is authoritative from the token) and returns it here so
+ * the caller can swap the stale token — otherwise the new language wouldn't
+ * apply to content until the next login (#470).
+ */
 export async function saveAccountSettings(
   settings: Partial<AccountSettings>,
-): Promise<void> {
-  await api.patch("/auth/settings", settings);
+): Promise<{ token?: string }> {
+  const res = await api.patch<{ token?: string }>("/auth/settings", settings);
+  return res.data ?? {};
 }


### PR DESCRIPTION
## What
Closes #470. Selecting **Español** (or Français) and saving showed the active state and "saved", but lesson/quiz content kept rendering in **English** until logout/login.

## Why
`students.locale` was updated in the DB correctly, but **locale is authoritative from the student JWT** (content endpoints never accept `?lang=`). The token was never refreshed after the save, so every content request carried the stale `locale`. Unlike the teacher client, the student axios client has no silent-refresh, so the stale token persisted until the next login.

## Changes
- **Backend** (`PATCH /auth/settings`): when the locale changes, re-mint the student JWT carrying over all existing claims with the new `locale`, and return it as `{ token }`. Non-locale changes (display name, notifications) return no token.
- **Web**: `saveAccountSettings()` returns `{ token? }`; the settings page stores it as `sb_token`, so the next content request (the axios client reads the token per-request) serves the chosen language. No reload needed — content queries refetch on navigation.
- **Web copy**: replaced the over-promising "Content is served in your selected language." with an honest line — content appears in the selected language *where a translation is available, and in English otherwise.*

## Note on Spanish content
Separately from this bug, **no Spanish (`*_es.json`) content has been generated yet** (the store has 103 French files, 0 Spanish), so Spanish will still fall back to English at the content layer until a pipeline run produces it. Per product decision, this PR ships the honest UX now and defers the paid `es` generation. The locale-propagation fix here is real regardless — it also affects French, which *does* have content for some units.

## Risk
Low. Token is re-minted from already-verified claims (no privilege change); only `locale` is swapped. Falls back to no-token for non-locale edits.

## Test plan
- `backend/tests/test_settings_locale.py` — locale change returns a token decoding to the new locale; non-locale and invalid-locale changes return none.
- `ruff`, web `tsc`/`eslint`/`prettier` clean on changed files.
- Manual: set language to Français on a unit that has `lesson_fr.json`, save, open that lesson → renders in French without logout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)