### PR TITLE
fix(feedback): Subject Breakdown shows real subjects + period filter (#473)

### DIFF
--- a/backend/src/analytics/router.py
+++ b/backend/src/analytics/router.py
@@ -181,21 +181,42 @@ async def student_metrics(
 # ── GET /analytics/student/stats ─────────────────────────────────────────────
 
 
+_PERIOD_DAYS: dict[str, int | None] = {"7d": 7, "30d": 30, "all": None}
+
+
 @router.get("/analytics/student/stats")
 async def student_stats(
     request: Request,
     student: Annotated[dict, Depends(get_current_student)],
+    period: str = "30d",
 ) -> dict:
     """
     Return streak, session dates, and summary stats for the student dashboard.
 
-    streak_days     — consecutive days with at least one completed session (ending today)
-    session_dates   — ISO date strings (YYYY-MM-DD) for the last 30 days that had sessions
+    period          — "7d" | "30d" | "all": scopes the charts and totals
+                      (session_dates, quiz counts, subject breakdown). Previously
+                      this query param was sent by the web client but ignored,
+                      so the selector did nothing.
+    streak_days     — consecutive days with at least one completed session
+                      (ending today), computed over a fixed window so it is never
+                      truncated by a short selected period.
     """
     student_id = str(student["student_id"])
+    days = _PERIOD_DAYS.get(period, 30)
+
+    # Period-scoped time filter shared by the charts/totals queries. "all" → no
+    # filter. days is bound as $2 only when present, so the parameter numbering
+    # stays consistent across all three queries.
+    if days is None:
+        period_clause = ""
+        period_params: list[int] = []
+    else:
+        period_clause = "AND started_at >= NOW() - make_interval(days => $2)"
+        period_params = [days]
+
     async with get_db(request) as conn:
         rows = await conn.fetch(
-            """
+            f"""
             SELECT DATE(started_at AT TIME ZONE 'UTC') AS session_date,
                    COUNT(*) AS sessions,
                    AVG(score::float / NULLIF(total_questions, 0) * 100) FILTER (WHERE score IS NOT NULL) AS avg_score,
@@ -203,55 +224,71 @@ async def student_stats(
                    COUNT(*) FILTER (WHERE score IS NOT NULL) AS scored_count
             FROM progress_sessions
             WHERE student_id = $1
-              AND started_at >= NOW() - INTERVAL '30 days'
+              {period_clause}
             GROUP BY 1
             ORDER BY 1 DESC
             """,
             student_id,
+            *period_params,
         )
 
-        # Lesson views + audio in last 30 days
+        # Lesson views + audio in the selected period
         view_rows = await conn.fetch(
-            """
+            f"""
             SELECT COUNT(*) AS lessons_viewed,
                    SUM(CASE WHEN audio_played THEN 1 ELSE 0 END) AS audio_sessions
             FROM lesson_views
             WHERE student_id = $1
-              AND started_at >= NOW() - INTERVAL '30 days'
+              {period_clause}
             """,
             student_id,
+            *period_params,
         )
 
-        # Subject breakdown (last 30 days). Grouped per unit so we can resolve
+        # Subject breakdown (selected period). Grouped per unit so we can resolve
         # human-readable subject names (issue #462) before aggregating — the raw
         # progress_sessions.subject column holds codes / "unknown".
         unit_subj_rows = await conn.fetch(
-            """
+            f"""
             SELECT unit_id, subject,
                    COUNT(*) AS lessons,
                    SUM(CASE WHEN passed THEN 1 ELSE 0 END) AS passed_count
             FROM progress_sessions
             WHERE student_id = $1
-              AND started_at >= NOW() - INTERVAL '30 days'
+              {period_clause}
             GROUP BY unit_id, subject
             """,
             student_id,
+            *period_params,
         )
         subject_labels = await resolve_subject_labels(conn, [r["unit_id"] for r in unit_subj_rows])
+
+        # Streak is independent of the selected period: pull distinct active days
+        # over a generous fixed window so picking "7d" never truncates a longer
+        # current streak.
+        streak_rows = await conn.fetch(
+            """
+            SELECT DISTINCT DATE(started_at AT TIME ZONE 'UTC') AS d
+            FROM progress_sessions
+            WHERE student_id = $1
+              AND started_at >= NOW() - INTERVAL '400 days'
+            """,
+            student_id,
+        )
 
     session_dates = [str(r["session_date"]) for r in rows]
     total_sessions = sum(r["sessions"] for r in rows)
     total_scored = sum(r["scored_count"] for r in rows)
     total_passed = sum(r["passed_count"] for r in rows)
 
-    # Compute streak from today backwards
+    # Compute streak from today backwards over the fixed-window active days.
     from datetime import date, timedelta
 
     today = date.today()
-    date_set = set(session_dates)
+    streak_dates = {str(r["d"]) for r in streak_rows}
     streak = 0
     check = today
-    while str(check) in date_set:
+    while str(check) in streak_dates:
         streak += 1
         check -= timedelta(days=1)
 

--- a/backend/src/core/subjects.py
+++ b/backend/src/core/subjects.py
@@ -21,9 +21,50 @@ unit_id the map doesn't cover.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
 
 import asyncpg
+
+# Subject-code → display name, keyed by the code embedded in a unit_id prefix
+# (e.g. "G8-SCI-001" → "SCI" → "Science"). Derived from the canonical names in
+# data/grade*_stem.json. Used as a last-resort fallback so progress reports show
+# a real subject instead of "Unknown" when a unit has no curriculum_units row.
+_SUBJECT_CODE_NAMES: dict[str, str] = {
+    "MATH": "Mathematics",
+    "SCI": "Science",
+    "PHYS": "Physics",
+    "CHEM": "Chemistry",
+    "BIO": "Biology",
+    "TECH": "Technology",
+    "ENG": "English",
+    "CS": "Computer Science",
+    "ACC": "Accountancy",
+    "BUS": "Business Studies",
+    "ECON": "Economics",
+    "COMM": "Commerce",
+    "HIST": "History",
+    "GEO": "Geography",
+    "POL": "Political Science",
+    "PSY": "Psychology",
+    "SOC": "Sociology",
+}
+
+_UNIT_ID_SUBJECT_RE = re.compile(r"^G\d+-([A-Z]+)-")
+
+
+def subject_from_unit_id(unit_id: str | None) -> str | None:
+    """
+    Derive a friendly subject name from a unit_id prefix ("G8-SCI-001" →
+    "Science"), or None if the code is unrecognised / the id doesn't match the
+    G{grade}-{CODE}-{n} shape. Pure helper — no DB.
+    """
+    if not unit_id:
+        return None
+    m = _UNIT_ID_SUBJECT_RE.match(unit_id)
+    if not m:
+        return None
+    return _SUBJECT_CODE_NAMES.get(m.group(1))
 
 
 async def resolve_subject_labels(
@@ -75,4 +116,7 @@ def display_subject(
         return label
     if stored_subject and stored_subject.lower() != "unknown":
         return stored_subject
-    return "Unknown"
+    # Last resort: derive the subject from the unit_id prefix so the chart shows
+    # a real subject (and groups into separate bars) instead of collapsing every
+    # unresolved unit into a single "Unknown" bar (#473).
+    return subject_from_unit_id(unit_id) or "Unknown"

--- a/backend/tests/test_feedback_460_462.py
+++ b/backend/tests/test_feedback_460_462.py
@@ -151,13 +151,31 @@ async def test_resolve_subject_labels_empty_input(db_conn):
 
 
 def test_display_subject_resolution_order():
-    """Pure-function fallback chain: map → stored (non-sentinel) → 'Unknown'."""
+    """Pure-function fallback chain: map → stored (non-sentinel) → unit_id → 'Unknown'."""
     label_map = {"u1": "Physics"}
     # curriculum label wins even when the stored value is the 'unknown' sentinel
     assert display_subject(label_map, "u1", "unknown") == "Physics"
     # no map entry → fall back to a meaningful stored code
     assert display_subject({}, "u2", "G8-SCI") == "G8-SCI"
-    # no map entry and stored is the sentinel → 'Unknown'
+    # no map entry and stored is the sentinel, unit_id not parseable → 'Unknown'
     assert display_subject({}, "u2", "unknown") == "Unknown"
     assert display_subject({}, "u2", "UNKNOWN") == "Unknown"
     assert display_subject({}, "u2", None) == "Unknown"
+
+
+def test_display_subject_falls_back_to_unit_id_prefix():
+    """When the curriculum label is missing and the stored subject is the
+    'unknown' sentinel, a real subject is derived from the unit_id prefix so
+    the breakdown chart never collapses to a single 'Unknown' bar (#473)."""
+    from src.core.subjects import subject_from_unit_id
+
+    assert display_subject({}, "G8-SCI-001", "unknown") == "Science"
+    assert display_subject({}, "G11-PHYS-002", None) == "Physics"
+    assert display_subject({}, "G12-MATH-005", "unknown") == "Mathematics"
+    # Unrecognised code or non-matching id → still 'Unknown'.
+    assert display_subject({}, "G9-ZZZ-001", "unknown") == "Unknown"
+
+    # Direct helper coverage.
+    assert subject_from_unit_id("G8-SCI-001") == "Science"
+    assert subject_from_unit_id("not-a-unit-id") is None
+    assert subject_from_unit_id(None) is None

--- a/backend/tests/test_feedback_473.py
+++ b/backend/tests/test_feedback_473.py
@@ -1,0 +1,77 @@
+"""
+tests/test_feedback_473.py
+
+Integration tests for the student Subject Breakdown chart data (#473):
+
+1. Subjects resolve to real names derived from the unit_id prefix when the
+   stored subject is the "unknown" sentinel and no curriculum_units row exists,
+   so the chart no longer collapses every session into one "Unknown" bar.
+2. The `period` query param (previously ignored) actually scopes the breakdown.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.helpers.token_factory import make_student_token
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _insert_student(pool, student_id: str) -> None:
+    await pool.execute(
+        """
+        INSERT INTO students (student_id, external_auth_id, name, email, grade, locale, account_status)
+        VALUES ($1, $2, $3, $4, 8, 'en', 'active')
+        ON CONFLICT (student_id) DO NOTHING
+        """,
+        uuid.UUID(student_id),
+        f"auth0|fb473-{student_id[:8]}",
+        f"Student {student_id[:6]}",
+        f"fb473-{student_id[:6]}@test.invalid",
+    )
+
+
+async def _insert_session(pool, student_id: str, unit_id: str, days_ago: int) -> None:
+    # subject stored as the "unknown" sentinel — mirrors a session created when
+    # the unit could not be resolved; the fix derives the subject from unit_id.
+    await pool.execute(
+        """
+        INSERT INTO progress_sessions
+            (student_id, unit_id, curriculum_id, subject, grade,
+             attempt_number, score, total_questions, completed, passed, started_at)
+        VALUES ($1, $2, 'default-2026-g8', 'unknown', 8,
+                1, 80, 10, true, true, NOW() - make_interval(days => $3))
+        """,
+        uuid.UUID(student_id),
+        unit_id,
+        days_ago,
+    )
+
+
+@pytest.mark.asyncio
+async def test_subject_breakdown_resolves_names_and_respects_period(client, db_conn):
+    student_id = str(uuid.uuid4())
+    token = make_student_token(student_id=student_id, grade=8)
+    pool = client._transport.app.state.pool
+
+    await _insert_student(pool, student_id)
+    await _insert_session(pool, student_id, "G8-SCI-001", days_ago=1)  # recent
+    await _insert_session(pool, student_id, "G8-MATH-001", days_ago=20)  # older
+
+    # period=all → both sessions; subjects resolved from unit_id, never "Unknown".
+    r = await client.get("/api/v1/analytics/student/stats?period=all", headers=_auth(token))
+    assert r.status_code == 200, r.text
+    subjects = {b["subject"] for b in r.json()["subject_breakdown"]}
+    assert subjects == {"Science", "Mathematics"}
+    assert "Unknown" not in subjects
+
+    # period=7d → only the recent (1-day-old) Science session is in scope.
+    r = await client.get("/api/v1/analytics/student/stats?period=7d", headers=_auth(token))
+    assert r.status_code == 200, r.text
+    subjects_7d = {b["subject"] for b in r.json()["subject_breakdown"]}
+    assert subjects_7d == {"Science"}

--- a/web/app/(student)/stats/page.tsx
+++ b/web/app/(student)/stats/page.tsx
@@ -145,7 +145,9 @@ export default function StatsPage() {
                         formatter={(value) => [Number(value ?? 0), "Lessons"]}
                         labelStyle={{ fontSize: 12 }}
                       />
-                      <Bar dataKey="lessons" radius={[4, 4, 0, 0]}>
+                      {/* Cap width so a single subject renders as a normal bar
+                          rather than one block spanning the whole chart (#473). */}
+                      <Bar dataKey="lessons" radius={[4, 4, 0, 0]} maxBarSize={64}>
                         {stats.subject_breakdown.map((_, i) => (
                           <Cell
                             key={i}

--- a/web/lib/api/types.gen.ts
+++ b/web/lib/api/types.gen.ts
@@ -1172,8 +1172,13 @@ export interface paths {
          * Student Stats
          * @description Return streak, session dates, and summary stats for the student dashboard.
          *
-         *     streak_days     — consecutive days with at least one completed session (ending today)
-         *     session_dates   — ISO date strings (YYYY-MM-DD) for the last 30 days that had sessions
+         *     period          — "7d" | "30d" | "all": scopes the charts and totals
+         *                       (session_dates, quiz counts, subject breakdown). Previously
+         *                       this query param was sent by the web client but ignored,
+         *                       so the selector did nothing.
+         *     streak_days     — consecutive days with at least one completed session
+         *                       (ending today), computed over a fixed window so it is never
+         *                       truncated by a short selected period.
          */
         get: operations["student_stats_api_v1_analytics_student_stats_get"];
         put?: never;
@@ -12426,7 +12431,9 @@ export interface operations {
     };
     student_stats_api_v1_analytics_student_stats_get: {
         parameters: {
-            query?: never;
+            query?: {
+                period?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -12442,6 +12449,15 @@ export interface operations {
                     "application/json": {
                         [key: string]: unknown;
                     };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -2363,27 +2363,49 @@
           "analytics"
         ],
         "summary": "Student Stats",
-        "description": "Return streak, session dates, and summary stats for the student dashboard.\n\nstreak_days     \u2014 consecutive days with at least one completed session (ending today)\nsession_dates   \u2014 ISO date strings (YYYY-MM-DD) for the last 30 days that had sessions",
+        "description": "Return streak, session dates, and summary stats for the student dashboard.\n\nperiod          \u2014 \"7d\" | \"30d\" | \"all\": scopes the charts and totals\n                  (session_dates, quiz counts, subject breakdown). Previously\n                  this query param was sent by the web client but ignored,\n                  so the selector did nothing.\nstreak_days     \u2014 consecutive days with at least one completed session\n                  (ending today), computed over a fixed window so it is never\n                  truncated by a short selected period.",
         "operationId": "student_stats_api_v1_analytics_student_stats_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "30d",
+              "title": "Period"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
+                  "additionalProperties": true,
                   "title": "Response Student Stats Api V1 Analytics Student Stats Get"
                 }
               }
             }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
           }
-        },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/analytics/school/{school_id}/class": {


### PR DESCRIPTION
## What
Closes #473. The student **Subject Breakdown** chart rendered a single full-width bar labelled **"unknown"** (~26), with no per-subject separation. Two underlying problems:
1. Every session whose subject couldn't be resolved collapsed into one **"Unknown"** category.
2. The period selector (7d/30d/all) did nothing — the web client sent `?period=`, the endpoint ignored it.

## Why
`progress_sessions.subject` stores `"unknown"` when a unit couldn't be resolved at session-create time, and the demo student's units have no `curriculum_units` rows, so the #462 `resolve_subject_labels()` lookup found nothing → `display_subject()` returned `"Unknown"` for everything. Separately, `GET /analytics/student/stats` hard-coded a 30-day window.

## Changes
- **`core/subjects.py`**: new pure helper `subject_from_unit_id()` derives a friendly subject from the unit_id prefix (`"G8-SCI-001"` → `"Science"`), using a code→name map built from the canonical names in `data/grade*_stem.json`. `display_subject()` uses it as a **last resort** (after the curriculum label and a meaningful stored code) so reports never collapse to `"Unknown"`. Existing resolution order is unchanged.
- **`analytics/router.py`**: `/analytics/student/stats` now honours `period` (7d/30d/all) for `session_dates`, quiz counts and the subject breakdown. **Streak** is computed from a separate fixed 400-day window so a short selected period never truncates a longer current streak.
- **`web/stats`**: cap bar width (`maxBarSize`) so a single subject renders as a normal bar rather than a full-width block.

## Risk
Low. The subject fallback only fires where the result would otherwise be `"Unknown"`. Period filtering is additive (default `30d` preserves prior behaviour); streak is decoupled so it can't regress.

## Test plan
- `test_feedback_460_462.py` — extended `display_subject` chain incl. the unit_id fallback; existing assertions (raw stored code preserved, true "Unknown" cases) still hold.
- `test_feedback_473.py` — end-to-end: two sessions with `subject='unknown'` resolve to "Science"/"Mathematics" (never "Unknown"); `period=7d` excludes the 20-day-old session.
- `ruff`, web `tsc`/`eslint`/`prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)