### PR TITLE
feat(progress): add orchestration "in flight" section to PROGRESS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,9 @@ web/public/sample-visuals/
 # the dev backend is configured to write there directly; gitignored so
 # uploads don't land in commits.
 web/public/visuals/
+
+# Agent orchestration: keep workflow state (manifest + ledger) for the
+# PROGRESS.md "in flight" section, but ignore the regenerated task briefs.
+.orchestration/task-*.md
+!.orchestration/manifest.json
+!.orchestration/.orchestration.json

--- a/.orchestration/.orchestration.json
+++ b/.orchestration/.orchestration.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "tasks": {
+    "180": {
+      "status": "escalated",
+      "last_gate": "escalate",
+      "updated_at": "2026-06-22T18:00:03.914178+00:00",
+      "notes": ""
+    },
+    "192": {
+      "status": "escalated",
+      "last_gate": "",
+      "updated_at": "2026-06-22T18:04:09.022503+00:00",
+      "notes": "Pure product decision (continue/park/partial Epic 11 regen, ~$10-12 spend). No mechanical change; owner leans option (c). Guardrail: product decisions go to a human."
+    },
+    "214": {
+      "status": "escalated",
+      "last_gate": "",
+      "updated_at": "2026-06-22T18:05:29.588988+00:00",
+      "notes": "Umbrella tracking issue, not a single bug. Fast hooks already shipped (PR #227). 3 open boxes are decision-gated: OpenAPI hook = won't-do vs investigate-debounce; git-push tests = belongs in .git/hooks/pre-push (blast-radius/architecture call, separate PR); Stop hook = needs changed-modules helper first. Touches harness config (.claude/settings.json, git hooks) + needs human benchmarking. Product/architecture decisions -> human."
+    },
+    "217": {
+      "status": "approved",
+      "last_gate": "",
+      "updated_at": "2026-06-22T18:17:59.902134+00:00",
+      "notes": "Cloud routine 'studybuddy-project-critique' created (trig_01FhKoD5w2aBnQmqkXaH8B32), cron 0 13 * * 1 (Mon 9am Toronto), sources: StudyBuddy_OnDemand + project-critique. Created DISABLED pending GitHub connection. Manual follow-up: run /web-setup to connect GitHub, then enable the routine."
+    },
+    "306": {
+      "status": "escalated",
+      "last_gate": "",
+      "updated_at": "2026-06-22T18:23:16.686693+00:00",
+      "notes": "Implementable (migrations 0052/0053 + src/backup/storage.py ABC/S3/Local/factory) but acceptance requires RLS cross-tenant isolation (school A cannot read school B). Multi-tenancy is an explicit stop-and-escalate guardrail; wrong RLS = cross-tenant data leak. Defer to human per user decision."
+    }
+  }
+}

--- a/.orchestration/manifest.json
+++ b/.orchestration/manifest.json
@@ -1,0 +1,46 @@
+{
+  "repo": "wegofwd2020-hub/StudyBuddy_OnDemand",
+  "task_count": 5,
+  "tasks": [
+    {
+      "number": 180,
+      "file": "task-180.md",
+      "title": "feat(db): L-3 \u2014 retention_status='archived' value + index",
+      "type": "feature",
+      "severity": "medium",
+      "url": "https://github.com/wegofwd2020-hub/StudyBuddy_OnDemand/issues/180"
+    },
+    {
+      "number": 192,
+      "file": "task-192.md",
+      "title": "decision(product): Park Epic 11 C-5 regen, declare Commerce + G11 Science sufficient",
+      "type": "feature",
+      "severity": "medium",
+      "url": "https://github.com/wegofwd2020-hub/StudyBuddy_OnDemand/issues/192"
+    },
+    {
+      "number": 214,
+      "file": "task-214.md",
+      "title": "Hooks: PostToolUse ruff + alembic check + OpenAPI regen; PreToolUse git-push tests",
+      "type": "bug",
+      "severity": "medium",
+      "url": "https://github.com/wegofwd2020-hub/StudyBuddy_OnDemand/issues/214"
+    },
+    {
+      "number": 217,
+      "file": "task-217.md",
+      "title": "Schedule: bi-weekly project critique sub-agent",
+      "type": "feature",
+      "severity": "medium",
+      "url": "https://github.com/wegofwd2020-hub/StudyBuddy_OnDemand/issues/217"
+    },
+    {
+      "number": 306,
+      "file": "task-306.md",
+      "title": "BR-1 \u2014 DB + Storage Foundation (Epic 15)",
+      "type": "feature",
+      "severity": "medium",
+      "url": "https://github.com/wegofwd2020-hub/StudyBuddy_OnDemand/issues/306"
+    }
+  ]
+}

--- a/scripts/generate_progress.py
+++ b/scripts/generate_progress.py
@@ -15,6 +15,14 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
+# Optional add-on: an "in flight" section sourced from the orchestrator's ledger
+# in .orchestration/. Guarded so a missing add-on can never break the nightly
+# build; build_section itself never raises.
+try:
+    from progress_inflight import build_section
+except Exception:  # pragma: no cover - add-on is optional
+    build_section = None
+
 REPO = Path(__file__).resolve().parents[1]
 EPICS_DIR = REPO / "docs" / "epics"
 OUTPUT = REPO / "docs" / "PROGRESS.md"
@@ -225,7 +233,10 @@ def main() -> None:
     epics = parse_epics()
     commits = get_commits()
     attribute_commits(commits, epics)
-    OUTPUT.write_text(render(epics, commits))
+    document = render(epics, commits)
+    if build_section is not None:
+        document += "\n" + build_section(REPO / ".orchestration")
+    OUTPUT.write_text(document)
     print(f"Wrote {OUTPUT} — {len(epics)} epics, {len(commits)} commits scanned.")
 
 

--- a/scripts/progress_inflight.py
+++ b/scripts/progress_inflight.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Render an "agent orchestration — in flight" section for docs/PROGRESS.md.
+
+This is a self-contained, standard-library-only helper meant to be copied into
+the consuming project's ``scripts/`` directory, next to ``generate_progress.py``.
+It reads the orchestrator's state - the ``manifest.json`` taskforge wrote and the
+``.orchestration.json`` ledger the orchestrator maintains - and renders a
+Markdown section describing the agent work that is *currently in flight*
+(queued, in progress, in rework, or escalated).
+
+It intentionally has no dependency on the orchestrator package: the two JSON
+files are the contract between the tools, mirroring how the rest of the toolkit
+is decoupled.
+
+Why this complements PROGRESS.md: the existing generator reports on *merged
+history* (git log) and infers rework from "a ticket ID reappears in 2+
+commits". This section reports the orthogonal, forward-looking half - work that
+has not merged yet - and records rework *with its cause* (the gate verdict),
+rather than inferring it after the fact.
+
+Design rule: this helper must NEVER raise. A reporting add-on must not be able
+to fail the nightly build, so every error path degrades to a safe placeholder
+section.
+
+Usage (standalone):
+    python3 progress_inflight.py --tasks-dir .orchestration
+    python3 progress_inflight.py --tasks-dir .orchestration --out section.md
+
+Usage (imported by generate_progress.py):
+    from progress_inflight import build_section
+    document += build_section(Path(".orchestration"))
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_LEDGER_NAME = ".orchestration.json"
+_MANIFEST_NAME = "manifest.json"
+_HEADING = "## Agent orchestration \u2014 in flight"
+
+# Statuses that count as "open" agent work worth surfacing, most-attention-first.
+_INFLIGHT_ORDER: dict[str, int] = {
+    "escalated": 0,
+    "changes-requested": 1,
+    "in-progress": 2,
+    "pending": 3,
+}
+# Statuses that are done/parked - counted in the summary but not the table.
+_TERMINAL = {"approved", "skipped"}
+
+_SEVERITY_ORDER: dict[str, int] = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+
+@dataclass(frozen=True)
+class _Row:
+    """One merged task row (manifest title/severity + ledger status)."""
+
+    number: int
+    title: str
+    severity: str
+    status: str
+    last_gate: str
+
+
+def _read_json(path: Path) -> Any:
+    """Read and parse a JSON file, returning ``None`` on any failure.
+
+    Args:
+        path: The file to read.
+
+    Returns:
+        The parsed JSON, or ``None`` if the file is missing or invalid.
+    """
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _merge_rows(manifest: Any, ledger: Any) -> list[_Row]:
+    """Merge manifest task metadata with ledger status into rows.
+
+    Args:
+        manifest: Parsed ``manifest.json`` (expects a ``tasks`` array), or None.
+        ledger: Parsed ``.orchestration.json`` (expects a ``tasks`` map), or None.
+
+    Returns:
+        One :class:`_Row` per manifest task, with status taken from the ledger
+        (defaulting to ``"pending"`` when the ledger has no entry).
+    """
+    tasks = manifest.get("tasks") if isinstance(manifest, dict) else None
+    if not isinstance(tasks, list):
+        return []
+    ledger_tasks = ledger.get("tasks", {}) if isinstance(ledger, dict) else {}
+
+    rows: list[_Row] = []
+    for entry in tasks:
+        if not isinstance(entry, dict) or "number" not in entry:
+            continue
+        try:
+            number = int(entry["number"])
+        except (TypeError, ValueError):
+            continue
+        state = ledger_tasks.get(str(number), {}) if isinstance(ledger_tasks, dict) else {}
+        rows.append(_Row(
+            number=number,
+            title=str(entry.get("title", "")).strip() or "(untitled)",
+            severity=str(entry.get("severity", "")).strip() or "?",
+            status=str(state.get("status", "pending")).strip().lower() or "pending",
+            last_gate=str(state.get("last_gate", "")).strip(),
+        ))
+    return rows
+
+
+def _summary_line(rows: list[_Row], now: datetime) -> str:
+    """Build the one-line summary of counts by status."""
+    counts: dict[str, int] = {}
+    for row in rows:
+        counts[row.status] = counts.get(row.status, 0) + 1
+    open_count = sum(c for s, c in counts.items() if s not in _TERMINAL)
+    approved = counts.get("approved", 0)
+    parts = [f"{c} {s}" for s, c in sorted(counts.items()) if s not in _TERMINAL and c]
+    detail = f" ({', '.join(parts)})" if parts else ""
+    stamp = now.strftime("%Y-%m-%d %H:%M UTC")
+    return (f"_As of {stamp}: {open_count} agent task(s) in flight{detail}; "
+            f"{approved} approved._")
+
+
+def _table(rows: list[_Row]) -> list[str]:
+    """Build the Markdown table of in-flight tasks (excludes terminal ones)."""
+    inflight = [r for r in rows if r.status not in _TERMINAL]
+    if not inflight:
+        return ["_No agent tasks in flight._"]
+    inflight.sort(key=lambda r: (
+        _INFLIGHT_ORDER.get(r.status, 99),
+        _SEVERITY_ORDER.get(r.severity, 99),
+        r.number,
+    ))
+    lines = ["| # | status | sev | last gate | title |",
+             "| --- | --- | --- | --- | --- |"]
+    for r in inflight:
+        gate = r.last_gate or "\u2014"
+        title = r.title.replace("|", "\\|")
+        lines.append(f"| {r.number} | {r.status} | {r.severity} | {gate} | {title} |")
+    return lines
+
+
+def _escalation_callout(rows: list[_Row]) -> list[str]:
+    """Build a callout listing escalated tasks, if any."""
+    escalated = [r.number for r in rows if r.status == "escalated"]
+    if not escalated:
+        return []
+    nums = ", ".join(f"#{n}" for n in sorted(escalated))
+    return ["", f"> \u26a0\ufe0f {len(escalated)} task(s) escalated to human "
+                f"review: {nums}."]
+
+
+def build_section(tasks_dir: str | Path, now: datetime | None = None) -> str:
+    """Render the in-flight Markdown section for a tasks directory.
+
+    Never raises: any error degrades to a safe placeholder section so the
+    nightly progress build cannot fail because of this add-on.
+
+    Args:
+        tasks_dir: Directory holding ``manifest.json`` and ``.orchestration.json``.
+        now: Timestamp to stamp the summary with. Defaults to the current UTC time.
+
+    Returns:
+        A Markdown section beginning with the standard heading.
+    """
+    when = now or datetime.now(timezone.utc)
+    try:
+        directory = Path(tasks_dir)
+        manifest = _read_json(directory / _MANIFEST_NAME)
+        ledger = _read_json(directory / _LEDGER_NAME)
+
+        if manifest is None:
+            return (f"{_HEADING}\n\n_No agent orchestration data found at "
+                    f"`{directory}`._\n")
+
+        rows = _merge_rows(manifest, ledger)
+        if not rows:
+            return f"{_HEADING}\n\n_No agent tasks recorded._\n"
+
+        body = [_HEADING, "", _summary_line(rows, when), ""]
+        body += _table(rows)
+        body += _escalation_callout(rows)
+        return "\n".join(body).rstrip() + "\n"
+    except (OSError, ValueError, TypeError, KeyError) as exc:
+        # Degrade safely; surface the cause as a comment without breaking render.
+        return f"{_HEADING}\n\n<!-- in-flight section unavailable: {exc} -->\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: print (or write) the in-flight section.
+
+    Args:
+        argv: Argument vector excluding the program name.
+
+    Returns:
+        Always ``0`` - this helper does not fail.
+    """
+    parser = argparse.ArgumentParser(
+        description="Render the agent-orchestration in-flight section for PROGRESS.md.",
+    )
+    parser.add_argument("--tasks-dir", default=".orchestration",
+                        help="Directory with manifest.json and .orchestration.json "
+                             "(default: .orchestration).")
+    parser.add_argument("--out", default=None,
+                        help="Write to this file instead of stdout.")
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    section = build_section(args.tasks_dir)
+    if args.out:
+        try:
+            Path(args.out).write_text(section, encoding="utf-8")
+        except OSError as exc:
+            print(f"warning: could not write {args.out}: {exc}", file=sys.stderr)
+            print(section)
+    else:
+        print(section)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds a forward-looking **"in flight"** section to the nightly `docs/PROGRESS.md`: the agent tasks currently queued / in-progress / in-rework / escalated (with each rework's cause = the gate verdict), sourced from the orchestrator's ledger. The existing generator reports merged history; this reports what hasn't merged yet.

## What's included
- `scripts/progress_inflight.py` — standalone, stdlib-only renderer. Reads `.orchestration/manifest.json` + `.orchestration.json`, depends on nothing else, and **never raises** (any error degrades to a placeholder so it can't break the nightly build).
- `scripts/generate_progress.py` — guarded import + append of `build_section(...)` after the existing output. If the add-on is missing, the build is unaffected.
- `.orchestration/manifest.json` + `.orchestration.json` — committed workflow state so the `progress.yml` clone can read it. Regenerated `task-*.md` briefs are gitignored.
- `.gitignore` — track the manifest + ledger, ignore the briefs.

## No workflow change
`progress.yml` already checks out, runs `generate_progress.py`, and commits `docs/PROGRESS.md` on change — the new section rides along nightly. `docs/PROGRESS.md` is intentionally **not** in this PR (the bot owns it).

## Test plan
- `progress_inflight.py` ships with 10 offline tests (mock tasks dir; safe degradation on missing/corrupt state).
- Ran `python3 scripts/generate_progress.py` locally — the section renders the current orchestrator state (4 escalated in flight, 1 approved correctly excluded).

This is the project-side wiring of the `wegofwd-orchestration` integrations add-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)