### PR TITLE
fix(deps): bump pydantic-settings to 2.14.2 (GHSA-4xgf-cpjx-pc3j)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,7 +6,7 @@ asyncpg==0.29.0
 redis==6.4.0
 python-jose[cryptography]==3.5.0
 bcrypt==5.0.0
-pydantic-settings==2.13.1
+pydantic-settings==2.14.2
 pydantic[email]>=2.3.0
 httpx==0.27.2
 celery[redis]==5.6.3


### PR DESCRIPTION
## Summary
Fixes the failing **Backend — Lint & Security** check. `pip-audit` was flagging one un-ignored vulnerability:

| Package | Version | Advisory | Fix |
| --- | --- | --- | --- |
| `pydantic-settings` | 2.13.1 | GHSA-4xgf-cpjx-pc3j | **2.14.2** |

Bumps `backend/requirements.txt` to the fix version. `ruff`, `ruff format`, and `bandit` already passed — this was the sole failing step.

## Why it matters
**Backend — Tests** `needs: backend-lint`, so while pip-audit failed the entire backend test suite was **skipping** on every PR (no real test gating). This unblocks it.

## Compatibility
`pydantic-settings 2.14.2` requires `pydantic>=2.7.0`, satisfied by the existing `pydantic[email]>=2.3.0` floor (resolves to 2.12.x). Verified locally: install succeeds and the `config` module (pydantic-settings-backed) imports cleanly.

## Test plan
- pip-audit: the only un-ignored finding is resolved → job goes green.
- With backend-lint green, Backend — Tests runs again on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)