### PR TITLE
QA feedback (2026-07-11): server-side quiz grading, demo content, placeholder gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -454,7 +454,12 @@ Migrations live in `backend/alembic/versions/` and are numbered `0001_…` → `
 - **Never skip a migration.** Run `alembic upgrade head` after pulling new code before restarting the API.
 - **Naming convention:** `{NNNN}_{short_description}.py` — e.g. `0015_subject_name.py`
 - **In Docker:** migrations run automatically via the `migrate` service in `docker-compose.yml` on `./dev_start.sh`
-- **Manual run:** `docker compose exec api alembic upgrade head`
+- **Manual run:** `docker compose exec -e TEST_DB_URL= api alembic upgrade head`
+  ⚠️ The `-e TEST_DB_URL=` is **required**. The `api` service has `TEST_DB_URL` set, and
+  `alembic/env.py` prefers it — so a plain `docker compose exec api alembic upgrade head`
+  migrates **`studybuddy_test`**, prints "success", and leaves the dev database untouched
+  (→ pitfall #18, `UndefinedColumnError` *after* you migrated). Alembic now prints which
+  database it is targeting on every run; read that line.
 - If the API starts throwing `UndefinedColumnError`, a migration is almost certainly missing.
 
 Current migrations (as of last commit):
@@ -500,6 +505,7 @@ Current migrations (as of last commit):
 | 0058 | Demo request — `name` column on demo lead requests |
 | 0059 | Epic/#358 — `teacher_capabilities` table (RLS): additive `curriculum.commission` / `curriculum.review` / `curriculum_mgmt` grants |
 | 0060 | Authoring Studio (PR-A) — `authoring_projects`, `authoring_topic_versions`, `authoring_active_versions`, `authoring_snapshots` (platform/admin-scoped, no tenant RLS); extends `curricula.source_type` CHECK with `admin_authored`. Downgrade deletes `source_type='admin_authored'` curricula before reverting the CHECK |
+| 0061 | Server-side quiz grading — `progress_sessions.quiz_set` (SMALLINT, nullable, CHECK 1–3). Records which quiz set a session is graded against; `question_id` is `q1…qN` in every set with different answers, so the set must be pinned per session. See pitfall #35 |
 
 ---
 
@@ -764,8 +770,9 @@ docker compose build celery-pipeline && docker compose up -d celery-pipeline
 # Rebuild web frontend (e.g. after npm install of a new package)
 docker compose build web && docker compose up -d web
 
-# Apply pending migrations manually
-docker compose exec api alembic upgrade head
+# Apply pending migrations manually.
+# -e TEST_DB_URL= is required: without it env.py targets studybuddy_test, not dev.
+docker compose exec -e TEST_DB_URL= api alembic upgrade head
 
 # Check logs for a specific service
 docker compose logs celery-pipeline --since 10m -f
@@ -908,6 +915,9 @@ See [AGENTS.md](https://github.com/wegofwd2020-hub/studybuddy-docs/blob/main/AGE
 31. **`get_curriculum_tree` must use the full 3-step resolver and load units from DB** — the original implementation called `_load_grade(grade)` which reads `grade{N}_stem.json` and ignores the resolved `curriculum_id`. Stream students (G11 Science, G11 Commerce, G12 Science, G12 Commerce) saw STEM subjects/units instead of their actual stream content. Fix: use the same 3-step resolver (school-owned → classroom packages RLS bypass → STEM fallback) as `content/service.py::resolve_curriculum_id`, then query `curriculum_units` WHERE `curriculum_id = $resolved`. JOIN `content_subject_versions` for the human-readable `subject_name`.
 32. **`curriculum_units.subject` stores subject codes, not display names for stream curricula** — platform stream curricula (G11-science, G12-commerce, etc.) seed `subject` as abbreviated codes (`G11-PHYS`, `G12-ACC`). The human-readable names (`Physics`, `Accountancy`) live in `content_subject_versions.subject_name`. In `get_curriculum_tree`, use `COALESCE(MAX(csv.subject_name), cu.subject)` joined on `(curriculum_id, subject)` to get display names; fall back to the raw code for newly-seeded curricula with no CSV rows.
 33. **`build_lesson_prompt` must generate a `sections` array** — the old schema produced only `synopsis`/`learning_objectives`/`reading_level` (3 sparse fields). Students saw "Overview and Learning Objectives but no lesson body." The new schema requires `sections` (Introduction, Core Concepts, Worked Examples, Real-World Applications, Summary) and `key_points`. `_normalize_lesson` handles three formats: old-format (has `title`), new rich (has `sections`), and legacy minimal (pre-C5-regen content that has only `synopsis`). Do not run C-5 regen until the new prompt is in place.
+34. **`docker compose exec api alembic upgrade head` migrates the TEST database, not dev** — the `api` service sets `TEST_DB_URL`, and `alembic/env.py` prefers it over `DATABASE_URL`. The command reports success, `alembic current` says `head`, and the dev DB is untouched — a nastier variant of pitfall #18, because it strikes *after* you ran the migration. Always pass `-e TEST_DB_URL=`. `env.py` now prints the target database on every run; read that line before trusting the result. (`docker-compose.yml` already blanks the var for the `migrate` service, which is why `./dev_start.sh` is unaffected.)
+35. **Never trust the client for quiz grading** — `POST /progress/answer` and `/end` once accepted `correct: bool` and `score: int` and stored them verbatim, while the quiz payload shipped `correct_option` for every question: a student could read the answers from the network tab and post themselves a perfect score. Grading is now server-side (`get_quiz_answer_key` → the content store), the answer key is stripped from the served quiz (`_strip_answer_key`), and the score is a Redis tally of server-graded answers. Two consequences to preserve: (a) `question_id` is `q1…qN` in **every** quiz set with **different** answers per set, so the graded set must be pinned per session (`quizset:{session_id}`, `progress_sessions.quiz_set`) — resolving it from the per-unit rotation pointer at answer time grades later answers against the wrong key; (b) answer writes are fire-and-forget, so `end_session` **cannot** count `progress_answers` (rows may not exist yet) — that race is why the score is tallied in Redis.
+36. **Placeholder content must never reach a student** — `scripts/seed_dev_content.py` and `scripts/setup_dev.py` backfill missing units with stub lessons/quizzes ("Sample question 1 about X?", options "Option A"…"Option D", correct answer always "A") tagged `model: "dev-placeholder"`. They only write where a file is *absent*, so any unit the pipeline hasn't generated keeps its stub indefinitely and used to be served as if real — students were graded on fiction. `get_content_file` now refuses `dev-placeholder` content on both the store and cache paths, so an ungenerated unit 404s honestly. Do not "fix" a 404 by re-running the seeder.
 
 ---
 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -10,25 +10,48 @@ the application itself uses asyncpg at runtime.
 
 from __future__ import annotations
 
-import sys
 import os
+import sys
 
 # Ensure the backend package is importable when running alembic from backend/.
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
 
 # Pull DATABASE_URL from our settings (reads .env automatically).
 # TEST_DB_URL takes precedence when running the test suite so migrations
 # target studybuddy_test instead of the dev database.
 from config import settings
+from sqlalchemy import engine_from_config, pool
 
-_raw_url = os.environ.get("TEST_DB_URL") or settings.DATABASE_URL
+_test_db_url = os.environ.get("TEST_DB_URL")
+_raw_url = _test_db_url or settings.DATABASE_URL
 # Strip +asyncpg driver suffix if present — alembic uses psycopg2.
 _db_url = _raw_url.replace("+asyncpg", "").replace("postgresql://", "postgresql+psycopg2://")
 if not _db_url.startswith("postgresql"):
     _db_url = _raw_url
+
+# Announce the target database, loudly, every time.
+#
+# TEST_DB_URL is set on the `api` service, so `docker compose exec api alembic
+# upgrade head` — the command the docs give for a manual migration — silently
+# migrates studybuddy_test and reports success while the dev database stays
+# behind. (`docker-compose.yml` blanks TEST_DB_URL for the `migrate` service for
+# exactly this reason, but nothing protects an interactive exec.) The failure
+# mode is pitfall #18 — UndefinedColumnError *after* you ran the migration.
+#
+# Rather than change the precedence, which the test harness depends on, say which
+# database is about to be touched so a wrong target is obvious rather than silent.
+_target_db = _db_url.rsplit("/", 1)[-1].split("?")[0]
+if _test_db_url:
+    print(
+        f"alembic: targeting TEST database '{_target_db}' (TEST_DB_URL is set).\n"
+        f"         To migrate the dev database instead, unset it:\n"
+        f"         docker compose exec -e TEST_DB_URL= api alembic upgrade head",
+        file=sys.stderr,
+    )
+else:
+    print(f"alembic: targeting database '{_target_db}'", file=sys.stderr)
 
 config = context.config
 config.set_main_option("sqlalchemy.url", _db_url)

--- a/backend/alembic/versions/0061_progress_sessions_quiz_set.py
+++ b/backend/alembic/versions/0061_progress_sessions_quiz_set.py
@@ -1,0 +1,48 @@
+"""Add quiz_set to progress_sessions for server-side grading.
+
+Quiz grading used to be done entirely by the client: `POST /progress/answer`
+accepted a `correct: bool` and `POST /progress/session/{id}/end` accepted a
+`score`, and the backend stored whatever the browser sent. A student could award
+themselves a perfect score from the devtools console.
+
+Grading server-side requires knowing WHICH quiz set the student is answering:
+`question_id` is `q1`…`qN` in every set, but the correct option differs per set,
+so the question id alone is not enough to look up the answer key. The server
+already picks the set (round-robin, `get_next_quiz_set`); this column records
+the choice on the session so the answer key can be resolved at grading time and
+so the session remains auditable after the Redis rotation key expires.
+
+Nullable: lesson/tutorial sessions have no quiz set.
+
+Revision ID: 0061
+Revises: 0060
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0061"
+down_revision = "0060"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "progress_sessions",
+        sa.Column("quiz_set", sa.SmallInteger(), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_progress_sessions_quiz_set",
+        "progress_sessions",
+        "quiz_set IS NULL OR quiz_set BETWEEN 1 AND 3",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_progress_sessions_quiz_set", "progress_sessions", type_="check"
+    )
+    op.drop_column("progress_sessions", "quiz_set")

--- a/backend/scripts/backfill_content_registry.py
+++ b/backend/scripts/backfill_content_registry.py
@@ -1,0 +1,319 @@
+"""
+backend/scripts/backfill_content_registry.py
+
+Register pipeline-generated content that exists on disk but has no DB rows.
+
+Why this exists
+---------------
+`pipeline/build_grade.py` writes content files to the Content Store FIRST, then
+performs its DB upserts inside a broad `except` that logs and continues. So when
+any of the known pipeline pitfalls fire — missing RLS bypass (#28), a str instead
+of a datetime bound to a TIMESTAMPTZ (#29), or the NOT NULL `unit_name` omitted
+(#30) — content generation still reports success while `curricula`,
+`curriculum_units`, and `content_subject_versions` are never written.
+
+Net effect: real, paid-for content sits on disk and is invisible to the app.
+A student clicking the lesson gets "This isn't available yet."
+
+This script reconciles the DB back to what is actually on disk. It is the repair
+tool; fixing the pipeline's silent-except is the separate root-cause fix.
+
+What it does, per `default-*` curriculum directory in the Content Store:
+  1. Skips units whose lesson is dev-placeholder (never register stub content)
+  2. Upserts the `curricula` row
+  3. Upserts `curriculum_units` (title/description/has_lab from data/*.json)
+  4. Upserts a published `content_subject_versions` row per subject
+
+Metadata (subject display names, unit titles, has_lab) comes from the
+authoritative `data/grade{N}_{stream}.json` files — the same source the pipeline
+reads — not from the generated content, which does not carry them.
+
+Idempotent. Dry-run by default.
+
+Usage (inside the api container):
+    python scripts/backfill_content_registry.py                 # dry run
+    python scripts/backfill_content_registry.py --commit
+    python scripts/backfill_content_registry.py --commit --only default-2026-g10
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+from datetime import UTC, datetime
+
+import asyncpg
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+# Connect directly to PostgreSQL, not PgBouncer: transaction-pooling mode drops
+# asyncpg prepared statements silently.
+_raw_url = os.environ.get(
+    "DATABASE_URL", "postgresql://studybuddy:studybuddy_dev@db:5432/studybuddy"
+)
+DATABASE_URL = _raw_url.replace("@pgbouncer:", "@db:")
+CONTENT_STORE_PATH = os.environ.get("CONTENT_STORE_PATH", "/data/content")
+
+DATA_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "data")
+)
+
+PLACEHOLDER_MODEL = "dev-placeholder"
+YEAR = 2026
+
+# default-2026-g11-science → grade=11, stream="science"
+# default-2026-g10         → grade=10, stream="stem"
+_CURRICULUM_RE = re.compile(r"^default-(\d{4})-g(\d+)(?:-([a-z]+))?$")
+
+
+# ── Disk inspection ───────────────────────────────────────────────────────────
+
+
+def parse_curriculum_id(curriculum_id: str) -> tuple[int, int, str] | None:
+    """(year, grade, stream) or None if the id doesn't match the default-* shape."""
+    m = _CURRICULUM_RE.match(curriculum_id)
+    if not m:
+        return None
+    year, grade, stream = m.groups()
+    return int(year), int(grade), stream or "stem"
+
+
+def load_source_metadata(grade: int, stream: str) -> dict | None:
+    """
+    Load data/grade{N}_{stream}.json — the pipeline's own source of truth for
+    subject display names and unit titles. Returns None if absent.
+    """
+    path = os.path.join(DATA_DIR, f"grade{grade}_{stream}.json")
+    if not os.path.exists(path):
+        return None
+    with open(path) as f:
+        return json.load(f)
+
+
+def real_units_on_disk(curriculum_id: str) -> set[str]:
+    """
+    Unit ids that have genuine generated content.
+
+    A unit counts only if it has a lesson_en.json that is NOT dev-placeholder —
+    registering a stub would let the seeder's fake quiz reach a student.
+    """
+    base = os.path.join(CONTENT_STORE_PATH, "curricula", curriculum_id)
+    if not os.path.isdir(base):
+        return set()
+
+    units: set[str] = set()
+    for unit_id in os.listdir(base):
+        lesson = os.path.join(base, unit_id, "lesson_en.json")
+        if not os.path.exists(lesson):
+            continue
+        try:
+            with open(lesson) as f:
+                data = json.load(f)
+        except (OSError, ValueError):
+            continue
+        if data.get("model") == PLACEHOLDER_MODEL:
+            continue
+        units.add(unit_id)
+    return units
+
+
+def discover() -> list[str]:
+    root = os.path.join(CONTENT_STORE_PATH, "curricula")
+    if not os.path.isdir(root):
+        return []
+    return sorted(c for c in os.listdir(root) if _CURRICULUM_RE.match(c))
+
+
+# ── Backfill ──────────────────────────────────────────────────────────────────
+
+
+async def backfill_curriculum(
+    conn: asyncpg.Connection, curriculum_id: str, commit: bool
+) -> dict:
+    """Register one curriculum. Returns a per-table count summary."""
+    stats = {"curricula": 0, "units": 0, "subject_versions": 0, "skipped_units": 0}
+
+    parsed = parse_curriculum_id(curriculum_id)
+    if not parsed:
+        print(f"  ! {curriculum_id}: unrecognised id shape — skipped")
+        return stats
+    _year, grade, stream = parsed
+
+    on_disk = real_units_on_disk(curriculum_id)
+    if not on_disk:
+        print(f"  - {curriculum_id}: no real content on disk (all stub/empty) — skipped")
+        return stats
+
+    source = load_source_metadata(grade, stream)
+    if not source:
+        print(
+            f"  ! {curriculum_id}: no data/grade{grade}_{stream}.json — "
+            f"cannot resolve titles/subject names — skipped"
+        )
+        return stats
+
+    label = f"Grade {grade}" + ("" if stream == "stem" else f" {stream.title()}")
+    name = f"Default {label} Curriculum {YEAR}"
+
+    # ── curricula ─────────────────────────────────────────────────────────────
+    # owner_type defaults to 'platform'; migration 0046 puts a RESTRICTIVE RLS
+    # policy on platform-owned rows, so the caller must have stamped
+    # app.current_school_id='bypass' (pitfall #28) — main() does.
+    if commit:
+        r = await conn.execute(
+            """
+            INSERT INTO curricula (curriculum_id, grade, year, name, is_default)
+            VALUES ($1, $2, $3, $4, TRUE)
+            ON CONFLICT (curriculum_id) DO NOTHING
+            """,
+            curriculum_id, grade, YEAR, name,
+        )
+        if r != "INSERT 0 0":
+            stats["curricula"] += 1
+    else:
+        exists = await conn.fetchval(
+            "SELECT 1 FROM curricula WHERE curriculum_id = $1", curriculum_id
+        )
+        if not exists:
+            stats["curricula"] += 1
+
+    # ── curriculum_units + content_subject_versions ───────────────────────────
+    subjects_with_content: dict[str, str] = {}  # subject_code -> display name
+
+    for subject in source["subjects"]:
+        subject_code = subject["subject_id"]      # e.g. G10-MATH
+        subject_name = subject["name"]            # e.g. Mathematics  (pitfall #32)
+
+        for sort_order, unit in enumerate(subject["units"]):
+            unit_id = unit["unit_id"]
+            if unit_id not in on_disk:
+                stats["skipped_units"] += 1       # never generated, or stub
+                continue
+
+            subjects_with_content[subject_code] = subject_name
+
+            if commit:
+                r = await conn.execute(
+                    """
+                    INSERT INTO curriculum_units
+                        (unit_id, curriculum_id, subject, title, unit_name,
+                         description, has_lab, sort_order)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                    ON CONFLICT (unit_id, curriculum_id) DO NOTHING
+                    """,
+                    unit_id,
+                    curriculum_id,
+                    subject_code,
+                    unit["title"],
+                    unit["title"],   # unit_name is NOT NULL — mirror title (pitfall #30)
+                    unit.get("description") or None,
+                    unit.get("has_lab", False),
+                    sort_order,
+                )
+                if r != "INSERT 0 0":
+                    stats["units"] += 1
+            else:
+                exists = await conn.fetchval(
+                    "SELECT 1 FROM curriculum_units WHERE unit_id = $1 AND curriculum_id = $2",
+                    unit_id, curriculum_id,
+                )
+                if not exists:
+                    stats["units"] += 1
+
+    # One published version row per subject that actually has content on disk.
+    for subject_code, subject_name in subjects_with_content.items():
+        existing = await conn.fetchval(
+            """
+            SELECT 1 FROM content_subject_versions
+            WHERE curriculum_id = $1 AND subject = $2 AND status = 'published'
+            """,
+            curriculum_id, subject_code,
+        )
+        if existing:
+            continue
+
+        if commit:
+            # published_at must be a datetime, never an ISO string — asyncpg
+            # rejects the bind and the pipeline's broad except swallows it (#29).
+            await conn.execute(
+                """
+                INSERT INTO content_subject_versions
+                    (curriculum_id, subject, subject_name, version_number,
+                     status, published_at)
+                VALUES ($1, $2, $3, 1, 'published', $4)
+                ON CONFLICT (curriculum_id, subject, version_number) DO UPDATE
+                    SET status       = 'published',
+                        subject_name = EXCLUDED.subject_name,
+                        published_at = EXCLUDED.published_at
+                """,
+                curriculum_id,
+                subject_code,
+                subject_name,
+                datetime.now(tz=UTC),
+            )
+        stats["subject_versions"] += 1
+
+    verb = "registered" if commit else "would register"
+    print(
+        f"  ✓ {curriculum_id}: {verb} "
+        f"{stats['curricula']} curriculum, {stats['units']} units, "
+        f"{stats['subject_versions']} subject versions "
+        f"({len(on_disk)} units with real content"
+        + (f", {stats['skipped_units']} not generated" if stats["skipped_units"] else "")
+        + ")"
+    )
+    return stats
+
+
+async def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--commit", action="store_true", help="persist (default: dry run)")
+    ap.add_argument("--only", help="restrict to a single curriculum_id")
+    args = ap.parse_args()
+
+    curricula = discover()
+    if args.only:
+        curricula = [c for c in curricula if c == args.only]
+        if not curricula:
+            print(f"ERROR: {args.only} not found in {CONTENT_STORE_PATH}/curricula")
+            sys.exit(1)
+
+    if not curricula:
+        print(f"No default-* curricula found in {CONTENT_STORE_PATH}/curricula")
+        sys.exit(1)
+
+    mode = "COMMIT" if args.commit else "DRY RUN (no writes — pass --commit to persist)"
+    print(f"Content registry backfill — {mode}")
+    print(f"  store: {CONTENT_STORE_PATH}/curricula")
+    print(f"  found: {len(curricula)} curricula\n")
+
+    conn = await asyncpg.connect(DATABASE_URL)
+    # RLS bypass — curricula carries a RESTRICTIVE write-guard policy on
+    # owner_type='platform' rows (migration 0046). Without this every INSERT is
+    # silently refused. See pitfall #28.
+    await conn.execute("SELECT set_config('app.current_school_id', 'bypass', false)")
+
+    totals = {"curricula": 0, "units": 0, "subject_versions": 0}
+    try:
+        for curriculum_id in curricula:
+            stats = await backfill_curriculum(conn, curriculum_id, args.commit)
+            for k in totals:
+                totals[k] += stats[k]
+    finally:
+        await conn.close()
+
+    verb = "Registered" if args.commit else "Would register"
+    print(
+        f"\n{verb}: {totals['curricula']} curricula, {totals['units']} units, "
+        f"{totals['subject_versions']} subject versions"
+    )
+    if not args.commit:
+        print("Dry run — nothing written. Re-run with --commit to apply.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/src/admin/demo_seed.py
+++ b/backend/src/admin/demo_seed.py
@@ -25,13 +25,14 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import json
-import os
 from datetime import UTC, datetime
-from pathlib import Path
 
 import asyncpg
 import bcrypt
+
+from src.utils.logger import get_logger
+
+log = get_logger("admin.demo_seed")
 
 # ── Sentinel IDs (e0-prefix block reserved for demo school) ──────────────────
 
@@ -101,13 +102,22 @@ _STUDENTS: list[dict] = [
     {"n": 30, "name": "Chloe Green", "grade": 10},
 ]
 
+# Demo classrooms point at the REAL platform curricula — the same ones the
+# pipeline generates into. They used to point at a private `demo-2026-g*`
+# namespace that this seeder created rows for but never generated content for,
+# so the Subjects tree rendered (it reads curriculum_units) while every
+# lesson/quiz 404'd with "This isn't available yet".
+#
+# Note the ids are not uniform: the STEM curricula for grades 5–9 carry a
+# `-stem` suffix, grades 10–12 do not. Take these from the content store, do not
+# infer them.
 _CLASSROOMS = [
     {
         "classroom_id": "e0000000-0000-0000-0002-000000000001",
         "name": "Grade 8 Mathematics & Technology",
         "grade": 8,
         "teacher_id": _TEACHER_MATH_ID,
-        "curriculum_id": "demo-2026-g8",
+        "curriculum_id": "default-2026-g8",
         "student_ns": range(1, 7),
     },
     {
@@ -115,7 +125,7 @@ _CLASSROOMS = [
         "name": "Grade 8 Science & Engineering",
         "grade": 8,
         "teacher_id": _TEACHER_SCI_ID,
-        "curriculum_id": "demo-2026-g8",
+        "curriculum_id": "default-2026-g8",
         "student_ns": range(7, 13),
     },
     {
@@ -123,7 +133,7 @@ _CLASSROOMS = [
         "name": "Grade 9 STEM",
         "grade": 9,
         "teacher_id": _TEACHER_MATH_ID,
-        "curriculum_id": "demo-2026-g9",
+        "curriculum_id": "default-2026-g9-stem",
         "student_ns": range(13, 23),
     },
     {
@@ -131,16 +141,15 @@ _CLASSROOMS = [
         "name": "Grade 10 Advanced STEM",
         "grade": 10,
         "teacher_id": _TEACHER_SCI_ID,
-        "curriculum_id": "demo-2026-g10",
+        "curriculum_id": "default-2026-g10",
         "student_ns": range(23, 31),
     },
 ]
 
-_DEMO_CURRICULA = [
-    ("demo-2026-g8", 8, "Grade 8 STEM"),
-    ("demo-2026-g9", 9, "Grade 9 STEM"),
-    ("demo-2026-g10", 10, "Grade 10 STEM"),
-]
+# Legacy ids this seeder used to create. Retained ONLY so teardown can clean up
+# rows left behind by older runs. Never add a `default-*` id here — teardown
+# DELETEs these, and the default-* curricula are real platform content.
+_LEGACY_DEMO_CURRICULA = ["demo-2026-g8", "demo-2026-g9", "demo-2026-g10"]
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -153,70 +162,6 @@ def _student_id(n: int) -> str:
 def _student_email(name: str) -> str:
     parts = name.lower().split()
     return f"{parts[0]}.{parts[-1]}@riverside.demo"
-
-
-def _find_data_dir() -> Path | None:
-    """Locate the project data/ directory containing gradeN_stem.json files."""
-    candidates = [
-        # Dev: backend/src/admin/demo_seed.py → up 3 levels → project root → data/
-        Path(__file__).resolve().parents[3] / "data",
-        # Docker with mounted data volume
-        Path("/data"),
-        # DATA_DIR env override
-        Path(os.environ["DATA_DIR"]) if "DATA_DIR" in os.environ else None,
-    ]
-    for p in candidates:
-        if p and p.is_dir() and (p / "grade8_stem.json").exists():
-            return p
-    return None
-
-
-def _load_grade_units(grade: int) -> list[dict]:
-    """
-    Return a list of unit dicts for the given grade.
-
-    Loads from data/gradeN_stem.json if available; falls back to a minimal
-    inline set so the seed works even without the data directory mounted.
-    """
-    data_dir = _find_data_dir()
-    if data_dir:
-        path = data_dir / f"grade{grade}_stem.json"
-        if path.exists():
-            with open(path) as f:
-                data = json.load(f)
-            units = []
-            for subj in data["subjects"]:
-                for i, unit in enumerate(subj["units"]):
-                    units.append(
-                        {
-                            "unit_id": unit["unit_id"],
-                            "subject": subj["name"],
-                            "title": unit["title"],
-                            "description": unit.get("description", ""),
-                            "has_lab": unit.get("has_lab", False),
-                            "sort_order": i,
-                        }
-                    )
-            return units
-
-    # Minimal fallback — enough for demo portal navigation
-    subjects = ["Mathematics", "Science", "Technology", "Engineering"]
-    abbrs = {"Mathematics": "MATH", "Science": "SCI", "Technology": "TECH", "Engineering": "ENG"}
-    units = []
-    for subj in subjects:
-        ab = abbrs[subj]
-        for i in range(1, 4):
-            units.append(
-                {
-                    "unit_id": f"G{grade}-{ab}-00{i}",
-                    "subject": subj,
-                    "title": f"G{grade} {subj} Unit {i}",
-                    "description": "",
-                    "has_lab": subj in ("Science", "Engineering") and i == 1,
-                    "sort_order": i - 1,
-                }
-            )
-    return units
 
 
 async def _hash_once(password: str) -> str:
@@ -243,9 +188,12 @@ async def wipe_demo(conn: asyncpg.Connection) -> None:
     """
     await conn.execute("DELETE FROM students WHERE school_id = $1", DEMO_SCHOOL_ID)
     await conn.execute("DELETE FROM teachers WHERE school_id = $1", DEMO_SCHOOL_ID)
+    # Only the legacy demo-owned curricula. The demo now points at real
+    # `default-*` platform curricula — deleting those would destroy the
+    # platform's content registry for every school.
     await conn.execute(
         "DELETE FROM curricula WHERE curriculum_id = ANY($1::text[])",
-        ["demo-2026-g8", "demo-2026-g9", "demo-2026-g10"],
+        _LEGACY_DEMO_CURRICULA,
     )
     # CASCADE removes: classrooms → classroom_students, classroom_packages
     # CASCADE removes: school_enrolments
@@ -340,41 +288,25 @@ async def seed_demo(conn: asyncpg.Connection) -> dict:
             s["grade"],
         )
 
-    # ── Curricula + units ─────────────────────────────────────────────────────
-    for curriculum_id, grade, name in _DEMO_CURRICULA:
-        r = await conn.execute(
+    # ── Curricula ─────────────────────────────────────────────────────────────
+    # The demo no longer creates its own curricula. It consumes the real platform
+    # ones, which the pipeline generates and `scripts/backfill_content_registry.py`
+    # registers. Verify they are present rather than silently seeding a classroom
+    # that points at nothing — an unregistered curriculum renders a Subjects tree
+    # whose every lesson and quiz 404s.
+    for curriculum_id in sorted({cl["curriculum_id"] for cl in _CLASSROOMS}):
+        published = await conn.fetchval(
             """
-            INSERT INTO curricula (curriculum_id, grade, year, name, is_default)
-            VALUES ($1, $2, 2026, $3, FALSE)
-            ON CONFLICT (curriculum_id) DO NOTHING
+            SELECT COUNT(*) FROM content_subject_versions
+            WHERE curriculum_id = $1 AND status = 'published'
             """,
             curriculum_id,
-            grade,
-            name,
         )
-        if r != "INSERT 0 0":
-            counts["curricula"] += 1
-
-        for unit in _load_grade_units(grade):
-            r2 = await conn.execute(
-                """
-                INSERT INTO curriculum_units
-                    (unit_id, curriculum_id, subject, title, unit_name,
-                     description, has_lab, sort_order)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-                ON CONFLICT (unit_id, curriculum_id) DO NOTHING
-                """,
-                unit["unit_id"],
-                curriculum_id,
-                unit["subject"],
-                unit["title"],
-                unit["title"],  # unit_name = title (Phase 8 requirement)
-                unit["description"] or None,
-                unit["has_lab"],
-                unit["sort_order"],
+        if not published:
+            log.warning(
+                "demo_seed_curriculum_has_no_published_content",
+                extra={"curriculum_id": curriculum_id},
             )
-            if r2 != "INSERT 0 0":
-                counts["units"] += 1
 
     # ── Classrooms ────────────────────────────────────────────────────────────
     for cl in _CLASSROOMS:
@@ -395,6 +327,19 @@ async def seed_demo(conn: asyncpg.Connection) -> dict:
             counts["classrooms"] += 1
 
         # Package assignment
+        # Evict any package this seeder attached previously that is no longer the
+        # intended one. Without this, re-seeding over an older demo leaves the
+        # classroom with two packages, and the curriculum resolver takes only the
+        # first (content/service.py) — so it can still land on the dead
+        # `demo-2026-*` curriculum and 404 every lesson.
+        await conn.execute(
+            """
+            DELETE FROM classroom_packages
+            WHERE classroom_id = $1 AND curriculum_id <> $2
+            """,
+            cl["classroom_id"],
+            cl["curriculum_id"],
+        )
         await conn.execute(
             """
             INSERT INTO classroom_packages (classroom_id, curriculum_id, sort_order)

--- a/backend/src/analytics/service.py
+++ b/backend/src/analytics/service.py
@@ -82,7 +82,11 @@ async def end_lesson_view(
     Close a lesson view row.
 
     Sets ended_at = NOW() and records duration/flags.
-    Returns {view_id, duration_s}.
+    Returns {view_id, duration_s, updated}.
+
+    `updated` is False when no row matched. That is a permanent condition, not a
+    transient one — the caller (write_lesson_end_task) retries on exception, and
+    retrying a view that does not exist can never succeed. Report it instead.
     """
     row = await conn.fetchrow(
         """
@@ -99,7 +103,15 @@ async def end_lesson_view(
         audio_played,
         experiment_viewed,
     )
-    return {"view_id": row["view_id"], "duration_s": row["duration_s"]}
+
+    if row is None:
+        log.warning(
+            "end_lesson_view_no_matching_row",
+            extra={"view_id": view_id, "duration_s": duration_s},
+        )
+        return {"view_id": view_id, "duration_s": duration_s, "updated": False}
+
+    return {"view_id": row["view_id"], "duration_s": row["duration_s"], "updated": True}
 
 
 # ── Phase 10: student self-service metrics ─────────────────────────────────────

--- a/backend/src/auth/tasks.py
+++ b/backend/src/auth/tasks.py
@@ -219,9 +219,13 @@ def write_progress_answer_task(
     correct: bool,
     ms_taken: int,
     event_id: str | None,
+    quiz_set: int | None = None,
 ) -> None:
     """
     Fire-and-forget task: write a progress answer to PostgreSQL.
+
+    `correct` / `correct_answer` are the SERVER's verdict, computed in the router
+    against the content store — not values supplied by the client.
 
     Uses ON CONFLICT DO NOTHING on event_id for mobile offline deduplication.
     """
@@ -244,6 +248,18 @@ def write_progress_answer_task(
                     ms_taken=ms_taken,
                     event_id=event_id,
                 )
+                # Persist which set was graded, so the session stays auditable
+                # after the Redis pin expires. First writer wins.
+                if quiz_set is not None:
+                    await conn.execute(
+                        """
+                        UPDATE progress_sessions
+                        SET quiz_set = $2
+                        WHERE session_id = $1 AND quiz_set IS NULL
+                        """,
+                        uuid.UUID(session_id),
+                        quiz_set,
+                    )
         finally:
             await pool.close()
 

--- a/backend/src/content/router.py
+++ b/backend/src/content/router.py
@@ -339,7 +339,9 @@ def _strip_answer_key(data: dict) -> dict:
 # exclude_none: the answer-key fields are stripped above, so they serialise as
 # null. Omit them entirely rather than shipping `"correct_option": null` — a null
 # there reads like an oversight and invites someone to "fix" it by populating it.
-@router.get("/content/{unit_id}/quiz", response_model=QuizResponse, response_model_exclude_none=True)
+@router.get(
+    "/content/{unit_id}/quiz", response_model=QuizResponse, response_model_exclude_none=True
+)
 async def get_quiz(
     unit_id: str,
     request: Request,

--- a/backend/src/content/router.py
+++ b/backend/src/content/router.py
@@ -314,7 +314,32 @@ async def get_lesson_audio(
 # ── GET /content/{unit_id}/quiz ───────────────────────────────────────────────
 
 
-@router.get("/content/{unit_id}/quiz", response_model=QuizResponse)
+def _strip_answer_key(data: dict) -> dict:
+    """
+    Remove `correct_option` and `explanation` from every question before the quiz
+    leaves the server.
+
+    Shipping the answer key to the browser meant a student could read the correct
+    answers straight out of the network response. The key is revealed one question
+    at a time by POST /progress/session/{id}/answer, after the student commits to
+    a choice — which is also where grading now happens.
+
+    Copies rather than mutating: `data` may be the dict cached in L2/L1, and
+    stripping it in place would poison the cache for the grader.
+    """
+    return {
+        **data,
+        "questions": [
+            {k: v for k, v in q.items() if k not in ("correct_option", "explanation")}
+            for q in data.get("questions", [])
+        ],
+    }
+
+
+# exclude_none: the answer-key fields are stripped above, so they serialise as
+# null. Omit them entirely rather than shipping `"correct_option": null` — a null
+# there reads like an oversight and invites someone to "fix" it by populating it.
+@router.get("/content/{unit_id}/quiz", response_model=QuizResponse, response_model_exclude_none=True)
 async def get_quiz(
     unit_id: str,
     request: Request,
@@ -354,7 +379,7 @@ async def get_quiz(
             override["subject"] = await _subject_display_name(
                 pool, unit_id, override.get("subject")
             )
-            return QuizResponse(**override)
+            return QuizResponse(**_strip_answer_key(override))
 
     curriculum_id, _subject = await _get_curriculum_and_check_published(
         request, unit_id, "quiz", student, pre_resolved_curriculum_id=pre_resolved
@@ -376,7 +401,7 @@ async def get_quiz(
 
     data["subject"] = await _subject_display_name(pool, unit_id, _subject or data.get("subject"))
     log.info("quiz_served unit_id=%s set=%d student_id=%s", unit_id, set_number, student_id)
-    return QuizResponse(**data)
+    return QuizResponse(**_strip_answer_key(data))
 
 
 # ── GET /content/{unit_id}/tutorial ──────────────────────────────────────────

--- a/backend/src/content/schemas.py
+++ b/backend/src/content/schemas.py
@@ -44,9 +44,15 @@ class QuizQuestion(BaseModel):
     question_text: str
     question_type: str
     options: list[QuizOption]
-    correct_option: str
-    explanation: str
     difficulty: str
+
+    # The answer key is deliberately NOT sent to students. It is stripped in the
+    # quiz endpoint and revealed one question at a time by
+    # POST /progress/session/{id}/answer, which grades server-side. These stay on
+    # the model (optional) because the same schema validates raw content files,
+    # which do carry the key.
+    correct_option: str | None = None
+    explanation: str | None = None
 
 
 class QuizResponse(BaseModel):

--- a/backend/src/content/service.py
+++ b/backend/src/content/service.py
@@ -37,6 +37,11 @@ _ENT_TTL = 300  # 5 minutes
 _CSV_TTL = 300  # 5 minutes
 _CONTENT_TTL = 3600  # 1 hour
 
+# Model tag written by scripts/seed_dev_content.py and scripts/setup_dev.py into
+# every stub file they create. Content carrying this tag is never served to a
+# student — see _reject_placeholder().
+PLACEHOLDER_MODEL = "dev-placeholder"
+
 
 # ── School subscription helper ────────────────────────────────────────────────
 
@@ -208,6 +213,32 @@ async def check_content_published(
 # ── Content file serving ──────────────────────────────────────────────────────
 
 
+def _reject_placeholder(data, curriculum_id: str, unit_id: str, filename: str) -> None:
+    """
+    Refuse to serve dev-seeded placeholder content.
+
+    The dev/demo seeders backfill missing units with stub lessons and quizzes
+    (always-'A' answers, "Sample question N about X?") tagged
+    model="dev-placeholder". They only write where a file is absent, so any unit
+    the pipeline hasn't generated keeps its stub forever. Serving one hands a
+    student fake content — and a fake grade — indistinguishable from the real
+    thing. Treat it as missing so the caller 404s into the normal
+    "not available yet" state.
+    """
+    if isinstance(data, dict) and data.get("model") == PLACEHOLDER_MODEL:
+        log.warning(
+            "placeholder_content_refused",
+            extra={
+                "curriculum_id": curriculum_id,
+                "unit_id": unit_id,
+                "filename": filename,
+            },
+        )
+        raise FileNotFoundError(
+            f"placeholder content refused: curricula/{curriculum_id}/{unit_id}/{filename}"
+        )
+
+
 async def get_content_file(
     curriculum_id: str,
     unit_id: str,
@@ -220,18 +251,27 @@ async def get_content_file(
 
     L2 cache: content:{curriculum_id}:{unit_id}:{filename} TTL=3600.
 
-    Raises FileNotFoundError if the file doesn't exist.
+    Raises FileNotFoundError if the file doesn't exist, or if it is dev-seeded
+    placeholder content (see _reject_placeholder).
     """
     key = content_key(curriculum_id, unit_id, filename)
     cached = await redis.get(key)
     if cached:
         try:
-            return json.loads(cached)
-        except Exception:
-            pass  # corrupt cache entry — fall through
+            data = json.loads(cached)
+        except (ValueError, TypeError):
+            data = None  # corrupt cache entry — fall through to the store
+        if data is not None:
+            # Guard the cache path too: a stub cached by an older build would
+            # otherwise keep being served for the full TTL.
+            _reject_placeholder(data, curriculum_id, unit_id, filename)
+            return data
 
     path = f"curricula/{curriculum_id}/{unit_id}/{filename}"
     data = await storage.read_json(path)  # raises FileNotFoundError if absent
+
+    # Check before caching — never let a placeholder into L2.
+    _reject_placeholder(data, curriculum_id, unit_id, filename)
 
     await redis.set(key, json.dumps(data), ex=_CONTENT_TTL)
     return data
@@ -497,3 +537,70 @@ async def get_fork_source_curriculum(
             curriculum_id,
         )
     return row["source_curriculum_id"] if (row and row["source_curriculum_id"]) else None
+
+
+# ── Quiz answer key (server-side grading) ─────────────────────────────────────
+
+
+async def get_quiz_answer_key(
+    curriculum_id: str,
+    unit_id: str,
+    set_number: int,
+    lang: str,
+    redis,
+    storage: StorageBackend,
+) -> dict[str, dict]:
+    """
+    Return the grading key for one quiz set: {question_id: {index, explanation}}.
+
+    The correct answer lives ONLY on the server. Grading resolves it from the
+    content store here rather than trusting anything the client sends.
+
+    `correct_option` is a letter ("A".."D"); the index is that option's position
+    in the question's own `options` list, matched by `option_id` — not by
+    alphabetical position, so a question whose options are ordered B, A, C still
+    grades correctly.
+
+    Raises FileNotFoundError if the set is absent (placeholder content included —
+    get_content_file refuses it).
+    """
+    filename = f"quiz_set_{set_number}_{lang}.json"
+    try:
+        data = await get_content_file(curriculum_id, unit_id, filename, redis, storage)
+    except FileNotFoundError:
+        # Same English fallback the quiz endpoint uses, so grading matches what
+        # was actually served to the student.
+        data = await get_content_file(
+            curriculum_id, unit_id, f"quiz_set_{set_number}_en.json", redis, storage
+        )
+
+    key: dict[str, dict] = {}
+    for question in data.get("questions", []):
+        qid = question.get("question_id")
+        if not qid:
+            continue
+        options = question.get("options", [])
+        correct_option = question.get("correct_option")
+        index = next(
+            (i for i, o in enumerate(options) if o.get("option_id") == correct_option),
+            None,
+        )
+        if index is None:
+            # Content defect: the correct_option names an option that isn't in the
+            # list. Skip rather than silently grading every answer wrong.
+            log.error(
+                "quiz_answer_key_unresolvable",
+                extra={
+                    "curriculum_id": curriculum_id,
+                    "unit_id": unit_id,
+                    "set_number": set_number,
+                    "question_id": qid,
+                    "correct_option": correct_option,
+                },
+            )
+            continue
+        key[qid] = {
+            "index": index,
+            "explanation": question.get("explanation", ""),
+        }
+    return key

--- a/backend/src/core/cache_keys.py
+++ b/backend/src/core/cache_keys.py
@@ -101,6 +101,28 @@ def quiz_set_key(student_id: str, unit_id: str) -> str:
     return f"quiz_set:{student_id}:{unit_id}"
 
 
+def quiz_score_key(session_id: str) -> str:
+    """
+    quizscore:{session_id} — running count of server-graded correct answers.
+
+    The score has to be authoritative but the answer write is fire-and-forget
+    (perf rule #4), so `progress_answers` may not be persisted yet when the
+    session ends. Tally the graded result in Redis as each answer arrives and
+    read it back at end-of-session instead of trusting a client-supplied score.
+    """
+    return f"quizscore:{session_id}"
+
+
+def quiz_session_set_key(session_id: str) -> str:
+    """
+    quizset:{session_id} — which quiz set (1-3) this session is being graded against.
+
+    Pinned on the first answer so the grading key stays stable for the whole
+    session even if the per-unit rotation pointer advances.
+    """
+    return f"quizset:{session_id}"
+
+
 def override_key(
     school_id: str,
     curriculum_id: str,

--- a/backend/src/progress/router.py
+++ b/backend/src/progress/router.py
@@ -28,7 +28,9 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from src.auth.dependencies import get_current_student
+from src.content.service import get_quiz_answer_key
 from src.core.db import get_db
+from src.core.storage import StorageBackend, get_storage
 from src.progress.schemas import (
     EndSessionRequest,
     EndSessionResponse,
@@ -39,9 +41,13 @@ from src.progress.schemas import (
     StartSessionResponse,
 )
 from src.progress.service import (
+    count_correct_answers,
     create_session,
     end_session,
     get_raw_history,
+    read_tally,
+    resolve_session_quiz_set,
+    tally_answer,
     verify_session_owner,
 )
 from src.utils.logger import get_logger
@@ -96,6 +102,7 @@ async def record_answer(
     session_id: str,
     body: RecordAnswerRequest,
     student: Annotated[dict, Depends(get_current_student)],
+    storage: StorageBackend = Depends(get_storage),
 ) -> RecordAnswerResponse:
     """
     Record a single quiz answer.
@@ -122,7 +129,7 @@ async def record_answer(
     # Verify ownership synchronously (cheap DB hit — just SELECT)
     async with get_db(request) as conn:
         try:
-            await verify_session_owner(conn, session_id, student_id)
+            session = await verify_session_owner(conn, session_id, student_id)
         except LookupError:
             raise HTTPException(
                 status_code=404,
@@ -142,7 +149,53 @@ async def record_answer(
                 },
             )
 
-    # Fire-and-forget Celery task for the actual write
+    # ── Grade server-side ─────────────────────────────────────────────────────
+    # The client sends only which option was picked. Correctness is resolved from
+    # the content store here; nothing the browser claims about it is trusted.
+    redis = request.app.state.redis
+    try:
+        set_number = await resolve_session_quiz_set(
+            redis, session_id=session_id, student_id=student_id, unit_id=session["unit_id"]
+        )
+        answer_key = await get_quiz_answer_key(
+            curriculum_id=session["curriculum_id"],
+            unit_id=session["unit_id"],
+            set_number=set_number,
+            lang=student.get("locale", "en"),
+            redis=redis,
+            storage=storage,
+        )
+    except FileNotFoundError:
+        # The quiz the student is answering is gone from the store. Refuse rather
+        # than recording an ungraded answer.
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": "quiz_not_found",
+                "detail": "This quiz is no longer available.",
+                "correlation_id": cid,
+            },
+        )
+
+    entry = answer_key.get(body.question_id)
+    if entry is None:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "unknown_question",
+                "detail": "That question is not part of this quiz.",
+                "correlation_id": cid,
+            },
+        )
+
+    correct_index = entry["index"]
+    correct = body.student_answer == correct_index
+
+    # Running tally in Redis: the DB write below is fire-and-forget, so the rows
+    # may not exist yet when the session ends. This is what end_session reads.
+    await tally_answer(redis, session_id=session_id, correct=correct)
+
+    # Fire-and-forget Celery task for the actual write — with the SERVER's verdict
     from src.core.celery_app import celery_app
 
     celery_app.send_task(
@@ -151,15 +204,21 @@ async def record_answer(
             "session_id": session_id,
             "question_id": body.question_id,
             "student_answer": body.student_answer,
-            "correct_answer": body.correct_answer,
-            "correct": body.correct,
+            "correct_answer": correct_index,
+            "correct": correct,
             "ms_taken": body.ms_taken,
             "event_id": body.event_id,
+            "quiz_set": set_number,
         },
         queue="io",
     )
 
-    return RecordAnswerResponse(answer_id="", correct=body.correct)
+    return RecordAnswerResponse(
+        answer_id="",
+        correct=correct,
+        correct_index=correct_index,
+        explanation=entry.get("explanation", ""),
+    )
 
 
 @router.post(
@@ -172,9 +231,14 @@ async def end_session_endpoint(
     session_id: str,
     body: EndSessionRequest,
     student: Annotated[dict, Depends(get_current_student)],
+    storage: StorageBackend = Depends(get_storage),
 ) -> EndSessionResponse:
     """
     Close a session and compute the final score + passed flag.
+
+    The score is derived from the answers the SERVER graded during the session
+    (Redis tally, falling back to persisted answers) — never from the request
+    body. A client that posts a score is ignored.
 
     Score is written synchronously (client needs the result immediately).
     Streak update and progress view refresh are dispatched as Celery tasks.
@@ -227,9 +291,44 @@ async def end_session_endpoint(
                 },
             )
 
+        # ── Resolve the score server-side ─────────────────────────────────────
+        redis = request.app.state.redis
+
+        score = await read_tally(redis, session_id)
+        if score is None:
+            # Redis lost the tally (restart / TTL). Fall back to what was graded
+            # and persisted. May undercount if writes are still in flight, but it
+            # is still a server-derived number, never the client's.
+            log.warning("quiz_tally_missing_falling_back_to_db", correlation_id=cid)
+            score = await count_correct_answers(conn, session_id)
+
+        # The quiz's real length is the answer key's — not whatever the client says.
+        total_questions = body.total_questions or 1
+        try:
+            set_number = await resolve_session_quiz_set(
+                redis,
+                session_id=session_id,
+                student_id=student_id,
+                unit_id=session_row["unit_id"],
+            )
+            answer_key = await get_quiz_answer_key(
+                curriculum_id=session_row["curriculum_id"],
+                unit_id=session_row["unit_id"],
+                set_number=set_number,
+                lang=student.get("locale", "en"),
+                redis=redis,
+                storage=storage,
+            )
+            if answer_key:
+                total_questions = len(answer_key)
+        except FileNotFoundError:
+            # Content gone since the attempt started — fall back to the client's
+            # hint for the denominator only. The score itself is still ours.
+            log.warning("quiz_answer_key_missing_at_end", correlation_id=cid)
+
         try:
             result = await end_session(
-                conn, session_id=session_id, score=body.score, total_questions=body.total_questions
+                conn, session_id=session_id, score=score, total_questions=total_questions
             )
         except Exception as exc:
             log.error("end_session_failed", error=str(exc), correlation_id=cid)

--- a/backend/src/progress/schemas.py
+++ b/backend/src/progress/schemas.py
@@ -17,17 +17,32 @@ class StartSessionRequest(BaseModel):
 
 
 class RecordAnswerRequest(BaseModel):
+    """
+    The client submits only WHAT the student picked — never whether it was right.
+
+    `correct_answer` and `correct` used to be accepted here and stored verbatim,
+    which let any student mark their own answers correct. Grading is now done
+    server-side from the content store; anything the client claims about
+    correctness is ignored.
+    """
+
     question_id: str = Field(..., min_length=1, max_length=128)
-    student_answer: int
-    correct_answer: int
-    correct: bool
+    student_answer: int = Field(ge=0)
     ms_taken: int = Field(ge=0)
     event_id: str | None = Field(None, max_length=64)  # offline dedup key
 
 
 class EndSessionRequest(BaseModel):
-    score: int = Field(ge=0)
-    total_questions: int = Field(ge=1)
+    """
+    No score field. The score is computed server-side from the answers actually
+    graded during the session — the client cannot assert one.
+
+    `total_questions` is an optional hint used only if the server cannot resolve
+    the quiz's real length (e.g. the content file has since been removed); the
+    answer key is preferred whenever it is available.
+    """
+
+    total_questions: int | None = Field(None, ge=1)
 
 
 # ── Response schemas ──────────────────────────────────────────────────────────
@@ -42,8 +57,18 @@ class StartSessionResponse(BaseModel):
 
 
 class RecordAnswerResponse(BaseModel):
+    """
+    The server's verdict on the answer, plus the reveal.
+
+    `correct_index` and `explanation` are returned HERE rather than shipped inside
+    the quiz payload, so the answer key never sits in the browser before the
+    student has committed to a choice.
+    """
+
     answer_id: str
     correct: bool
+    correct_index: int
+    explanation: str = ""
 
 
 class EndSessionResponse(BaseModel):

--- a/backend/src/progress/service.py
+++ b/backend/src/progress/service.py
@@ -17,12 +17,111 @@ from datetime import UTC, datetime
 
 import asyncpg
 
+from src.core.cache_keys import (
+    quiz_score_key,
+    quiz_session_set_key,
+    quiz_set_key,
+)
 from src.core.subjects import display_subject, resolve_subject_labels
 from src.utils.logger import get_logger
 
 log = get_logger("progress")
 
 QUIZ_PASS_THRESHOLD = 0.60
+
+# A quiz session is short-lived; the tally only needs to outlive the attempt.
+_TALLY_TTL = 6 * 3600  # 6 hours
+
+
+# ── Server-side grading state ─────────────────────────────────────────────────
+
+
+async def resolve_session_quiz_set(
+    redis,
+    session_id: str,
+    student_id: str,
+    unit_id: str,
+) -> int:
+    """
+    Return the quiz set (1-3) this session is being graded against.
+
+    Pinned per session on first use: the per-unit rotation pointer
+    (`quiz_set:{student}:{unit}`, written by get_next_quiz_set when the quiz was
+    served) advances every time a quiz is fetched, so reading it fresh for every
+    answer could grade later answers against a different set's key. Pin it once,
+    then reuse.
+
+    Falls back to set 1 if the rotation pointer has expired — the student is
+    mid-quiz and we still have to grade them against something; set 1 is what the
+    serving endpoint hands out when the pointer is absent.
+    """
+    pinned = await redis.get(quiz_session_set_key(session_id))
+    if pinned is not None:
+        try:
+            return int(pinned)
+        except (ValueError, TypeError):
+            pass  # corrupt — re-pin below
+
+    served = await redis.get(quiz_set_key(student_id, unit_id))
+    try:
+        set_number = int(served)
+    except (ValueError, TypeError):
+        log.warning(
+            "quiz_set_pointer_missing_defaulting_to_1",
+            extra={"session_id": session_id, "unit_id": unit_id},
+        )
+        set_number = 1
+
+    if not 1 <= set_number <= 3:
+        set_number = 1
+
+    await redis.set(quiz_session_set_key(session_id), str(set_number), ex=_TALLY_TTL)
+    return set_number
+
+
+async def tally_answer(redis, session_id: str, correct: bool) -> None:
+    """
+    Record one graded answer against the session's running tally.
+
+    Both counters are kept so end_session can report a score without waiting on
+    the fire-and-forget DB write (perf rule #4).
+    """
+    key = quiz_score_key(session_id)
+    if correct:
+        await redis.incr(key)
+    else:
+        # Ensure the key exists even for an all-wrong run, so end_session can tell
+        # "graded, scored zero" apart from "no tally at all".
+        await redis.setnx(key, 0)
+    await redis.expire(key, _TALLY_TTL)
+
+
+async def read_tally(redis, session_id: str) -> int | None:
+    """Server-graded correct count for the session, or None if no tally exists."""
+    raw = await redis.get(quiz_score_key(session_id))
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+async def count_correct_answers(conn: asyncpg.Connection, session_id: str) -> int:
+    """
+    Fallback score source: count graded-correct answers already persisted.
+
+    Only used when the Redis tally is gone (restart / TTL). May undercount if the
+    fire-and-forget writes are still in flight, which is exactly why the Redis
+    tally is preferred.
+    """
+    return (
+        await conn.fetchval(
+            "SELECT COUNT(*) FROM progress_answers WHERE session_id = $1 AND correct IS TRUE",
+            session_id,
+        )
+        or 0
+    )
 
 
 def _now_iso() -> str:

--- a/backend/tests/test_analytics_missing_view.py
+++ b/backend/tests/test_analytics_missing_view.py
@@ -1,0 +1,63 @@
+"""
+tests/test_analytics_missing_view.py
+
+`end_lesson_view` must not explode when the view row is absent.
+
+Found while draining the Celery backlog after the worker had been down: 29 stale
+`write_lesson_end_task` messages referenced `lesson_views` rows that never
+existed (the lesson had 404'd, so `startLessonView` never inserted one). The
+UPDATE matched zero rows, `fetchrow` returned None, and `row["view_id"]` raised
+TypeError. The task's blanket `except Exception: raise self.retry(...)` then
+retried a write that can never succeed — a poison message burning worker slots.
+
+A missing view is a permanent condition, not a transient fault: report it and
+move on.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.analytics.service import end_lesson_view
+
+_MISSING_VIEW_ID = "c9000000-0000-0000-0000-0000000000ff"
+
+
+@pytest.mark.asyncio
+async def test_end_lesson_view_on_missing_row_does_not_raise():
+    """A view_id with no matching row returns cleanly instead of raising TypeError."""
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)  # UPDATE matched nothing
+
+    result = await end_lesson_view(
+        conn,
+        view_id=_MISSING_VIEW_ID,
+        duration_s=42,
+        audio_played=False,
+        experiment_viewed=False,
+    )
+
+    # Caller gets a well-formed answer it can log; nothing to retry.
+    assert result["view_id"] == _MISSING_VIEW_ID
+    assert result["updated"] is False
+
+
+@pytest.mark.asyncio
+async def test_end_lesson_view_on_existing_row_still_reports_success():
+    """The happy path is unchanged."""
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={"view_id": "abc", "duration_s": 42})
+
+    result = await end_lesson_view(
+        conn,
+        view_id="abc",
+        duration_s=42,
+        audio_played=True,
+        experiment_viewed=False,
+    )
+
+    assert result["view_id"] == "abc"
+    assert result["duration_s"] == 42
+    assert result["updated"] is True

--- a/backend/tests/test_feedback_460_462.py
+++ b/backend/tests/test_feedback_460_462.py
@@ -55,8 +55,17 @@ async def _start_session(client: AsyncClient, token: str) -> dict:
 
 
 @pytest.mark.asyncio
-async def test_end_session_clamps_score_above_total(client, db_conn):
-    """A score greater than total_questions is clamped to total (no 8/5=160%)."""
+async def test_end_session_ignores_a_client_supplied_score(client, db_conn):
+    """
+    #460's real cause was client-side scoring, and it is now fixed at the root:
+    the endpoint takes no score at all.
+
+    The original symptom (8/5 = 160%) was produced by the browser sending an
+    inflated score, which `end_session` then clamped. Clamping hid the overflow at
+    the top of the range but left it visible in the middle — that is how #504
+    (4/5 for a 3/5 run) survived. The score is now the server's own tally, so an
+    impossible one cannot be submitted in the first place.
+    """
     student_id = str(uuid.uuid4())
     await _insert_student(client, student_id)
     token = make_student_token(student_id=student_id, grade=8)
@@ -66,35 +75,53 @@ async def test_end_session_clamps_score_above_total(client, db_conn):
     with patch("src.auth.tasks.celery_app.send_task", return_value=None):
         r = await client.post(
             f"/api/v1/progress/session/{session['session_id']}/end",
-            json={"score": 8, "total_questions": 5},
+            json={"score": 8, "total_questions": 5},  # both ignored
             headers={"Authorization": f"Bearer {token}"},
         )
     assert r.status_code == 200, r.text
     data = r.json()
-    assert data["score"] == 5  # clamped from 8
-    assert data["total_questions"] == 5
-    assert data["passed"] is True
+    # Nothing was graded in this session, so the server scores it zero — it does
+    # NOT echo the 8 the client asked for, clamped or otherwise.
+    assert data["score"] == 0
+    assert data["passed"] is False
 
 
 @pytest.mark.asyncio
-async def test_end_session_valid_score_unchanged(client, db_conn):
-    """A normal score passes through untouched and computes passed correctly."""
-    student_id = str(uuid.uuid4())
-    await _insert_student(client, student_id)
-    token = make_student_token(student_id=student_id, grade=8)
-    session = await _start_session(client, token)
+async def test_end_session_still_clamps_defensively(db_conn):
+    """
+    The clamp inside `end_session` stays as a last line of defence for any caller
+    (a Celery replay, an offline-sync backfill) that passes a nonsense pair.
 
-    with patch("src.auth.tasks.celery_app.send_task", return_value=None):
-        r = await client.post(
-            f"/api/v1/progress/session/{session['session_id']}/end",
-            json={"score": 2, "total_questions": 8},
-            headers={"Authorization": f"Bearer {token}"},
-        )
-    assert r.status_code == 200, r.text
-    data = r.json()
-    assert data["score"] == 2
-    assert data["total_questions"] == 8
-    assert data["passed"] is False  # 2/8 = 25% < 60%
+    Exercised at the service level because the HTTP layer no longer has any way to
+    supply a score.
+    """
+    from src.progress.service import end_session
+
+    student_id = str(uuid.uuid4())
+    session_id = await db_conn.fetchval(
+        """
+        INSERT INTO students (student_id, external_auth_id, name, email, grade, locale, account_status)
+        VALUES ($1, $2, 'Clamp Test', $3, 8, 'en', 'active')
+        ON CONFLICT (student_id) DO NOTHING
+        """,
+        uuid.UUID(student_id),
+        f"auth0|clamp-{student_id.replace('-', '')[:16]}",
+        f"clamp-{student_id[:6]}@test.invalid",
+    )
+    session_id = await db_conn.fetchval(
+        """
+        INSERT INTO progress_sessions
+            (student_id, unit_id, curriculum_id, grade, subject, attempt_number)
+        VALUES ($1, 'G8-MATH-001', 'default-2026-g8', 8, 'Mathematics', 1)
+        RETURNING session_id
+        """,
+        uuid.UUID(student_id),
+    )
+
+    result = await end_session(db_conn, session_id=str(session_id), score=8, total_questions=5)
+
+    assert result["score"] == 5  # clamped from 8 — never 160%
+    assert result["total_questions"] == 5
 
 
 # ── #462 — subject label resolution ───────────────────────────────────────────

--- a/backend/tests/test_pipeline_permanent_errors.py
+++ b/backend/tests/test_pipeline_permanent_errors.py
@@ -1,0 +1,173 @@
+"""
+tests/test_pipeline_permanent_errors.py
+
+A pipeline failure must say what went wrong, and must not retry what cannot succeed.
+
+Both defects showed up on the same run: a Grade 8 build failed 18 of 20 units,
+logging nothing but `error=anthropic call failed` — three times per content type,
+54 wasted API calls — while the actual cause was an exhausted Anthropic credit
+balance (HTTP 400). The provider SDK's message was destroyed by two layers of
+re-wrapping, and the retry loop treated a permanent billing error as transient.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# The pipeline package is bind-mounted at /pipeline — one level above the backend
+# app root — so the repo root must be on sys.path before it can be imported. This
+# is the same bootstrap test_pipeline.py performs (it does it inside each test;
+# module-level imports here need it sooner).
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from pipeline.providers._wegofwd_adapter import (  # noqa: E402
+    PermanentLLMError,
+    _describe,
+    _is_permanent,
+    _root_cause,
+)
+
+# ── Fakes mirroring the real exception chain ──────────────────────────────────
+
+
+class FakeSDKError(Exception):
+    """Stands in for anthropic.BadRequestError etc."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        if status_code is not None:
+            self.status_code = status_code
+
+
+def _chain(outer: str, inner: Exception) -> Exception:
+    """Build `LLMError("anthropic call failed") from <sdk error>`."""
+    err = Exception(outer)
+    err.__cause__ = inner
+    return err
+
+
+_CREDIT = FakeSDKError(
+    "Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', "
+    "'message': 'Your credit balance is too low to access the Anthropic API.'}}"
+)
+_AUTH = FakeSDKError("Error code: 401 - invalid x-api-key")
+_RATE_LIMIT = FakeSDKError("Error code: 429 - rate_limit_error")
+_TIMEOUT = FakeSDKError("Connection timed out")
+
+
+# ── The real message must survive ─────────────────────────────────────────────
+
+
+def test_describe_surfaces_the_root_cause_not_the_wrapper():
+    wrapped = _chain("anthropic call failed", _CREDIT)
+
+    described = _describe(wrapped)
+
+    # The useless wrapper text alone is not acceptable.
+    assert described != "anthropic call failed"
+    assert "credit balance is too low" in described
+
+
+def test_root_cause_walks_the_whole_chain():
+    innermost = FakeSDKError("the actual problem")
+    middle = _chain("http error", innermost)
+    outer = _chain("anthropic call failed", middle)
+
+    assert _root_cause(outer) is innermost
+
+
+def test_describe_is_stable_on_a_cycle():
+    """A self-referencing __context__ must not hang the walk."""
+    a = Exception("a")
+    b = Exception("b")
+    a.__cause__ = b
+    b.__cause__ = a
+
+    assert _describe(a)  # terminates
+
+
+def test_describe_of_a_bare_error_is_just_its_message():
+    assert _describe(FakeSDKError("plain")) == "plain"
+
+
+# ── Permanent vs transient ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "sdk_error,expected",
+    [
+        (_CREDIT, True),  # 400 — out of credit: retrying burns money for nothing
+        (_AUTH, True),  # 401 — bad key: will never authenticate
+        (_RATE_LIMIT, False),  # 429 — transient by definition; retry is correct
+        (_TIMEOUT, False),  # network blip — retry
+    ],
+    ids=["credit_400", "auth_401", "rate_limit_429", "timeout"],
+)
+def test_permanent_classification(sdk_error, expected):
+    assert _is_permanent(_chain("anthropic call failed", sdk_error)) is expected
+
+
+def test_status_code_attribute_is_preferred_over_the_message():
+    """Real SDK exceptions carry status_code; don't depend on message scraping."""
+    err = FakeSDKError("something opaque", status_code=403)
+    assert _is_permanent(_chain("call failed", err)) is True
+
+
+# ── The retry loop honours it ─────────────────────────────────────────────────
+
+
+def test_permanent_error_is_a_runtime_error():
+    """
+    Callers that predate PermanentLLMError catch RuntimeError. Subclassing keeps
+    them working unchanged — only the retry loop opts into the new behaviour.
+    """
+    assert issubclass(PermanentLLMError, RuntimeError)
+
+
+def test_generate_with_retry_does_not_retry_a_permanent_error():
+    from pipeline.build_unit import _generate_and_validate
+
+    calls = {"n": 0}
+
+    class Provider:
+        def generate(self, prompt):
+            calls["n"] += 1
+            raise PermanentLLMError("anthropic call failed — credit balance is too low")
+
+    with pytest.raises(PermanentLLMError, match="credit balance"):
+        _generate_and_validate(
+            provider=Provider(),
+            prompt="x",
+            validator=lambda d: None,
+            content_type="lesson",
+            max_retries=3,
+        )
+
+    assert calls["n"] == 1  # one call, not three
+
+
+def test_generate_with_retry_still_retries_a_transient_error():
+    from pipeline.build_unit import _generate_and_validate
+
+    calls = {"n": 0}
+
+    class Provider:
+        def generate(self, prompt):
+            calls["n"] += 1
+            raise RuntimeError("anthropic call failed — 429 rate_limit_error")
+
+    with pytest.raises(RuntimeError):
+        _generate_and_validate(
+            provider=Provider(),
+            prompt="x",
+            validator=lambda d: None,
+            content_type="lesson",
+            max_retries=3,
+        )
+
+    assert calls["n"] == 3

--- a/backend/tests/test_placeholder_content.py
+++ b/backend/tests/test_placeholder_content.py
@@ -1,0 +1,126 @@
+"""
+tests/test_placeholder_content.py
+
+Placeholder content must never reach a student.
+
+`scripts/seed_dev_content.py` and `scripts/setup_dev.py` fill gaps in the content
+store with stub lessons/quizzes ("Sample question 1 about X?", options "Option A"
+… "Option D", correct answer always "A"). They are tagged `model:
+"dev-placeholder"`. Because the seeders only write where a file is *absent*, any
+unit the pipeline has not generated keeps its stub indefinitely — and the serving
+path used to hand it to students as if it were real, generated content.
+
+The content service now treats a `dev-placeholder` file as absent, so the student
+sees the ordinary "not available yet" state instead of a fake graded quiz.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.content.service import PLACEHOLDER_MODEL, get_content_file
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+REAL_LESSON = {
+    "unit_id": "G8-SCI-001",
+    "title": "Density and Buoyancy",
+    "sections": [{"heading": "Introduction", "body": "Real generated content."}],
+    "model": "claude-sonnet-4-6",
+    "content_version": 1,
+}
+
+PLACEHOLDER_LESSON = {
+    "unit_id": "G8-SCI-001",
+    "title": "Density and Buoyancy",
+    "sections": [{"heading": "Overview", "body": "This lesson covers Density and Buoyancy."}],
+    "model": PLACEHOLDER_MODEL,
+    "content_version": 1,
+}
+
+PLACEHOLDER_QUIZ = {
+    "unit_id": "G8-SCI-001",
+    "questions": [
+        {
+            "question_text": "Sample question 1 about Density and Buoyancy?",
+            "options": [{"option_id": "A", "text": "Option A"}],
+            "correct_option": "A",
+        }
+    ],
+    "model": PLACEHOLDER_MODEL,
+}
+
+
+def _redis(cached: dict | None = None) -> MagicMock:
+    r = MagicMock()
+    r.get = AsyncMock(return_value=json.dumps(cached) if cached else None)
+    r.set = AsyncMock()
+    return r
+
+
+def _storage(payload: dict) -> MagicMock:
+    s = MagicMock()
+    s.read_json = AsyncMock(return_value=payload)
+    return s
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_placeholder_lesson_is_treated_as_absent():
+    """A dev-placeholder lesson read from the store raises FileNotFoundError (→ 404)."""
+    with pytest.raises(FileNotFoundError):
+        await get_content_file(
+            "default-2026-g8", "G8-SCI-001", "lesson_en.json",
+            _redis(), _storage(PLACEHOLDER_LESSON),
+        )
+
+
+@pytest.mark.asyncio
+async def test_placeholder_quiz_is_treated_as_absent():
+    """The stub quiz (always-'A' answers) must never be served as a graded quiz."""
+    with pytest.raises(FileNotFoundError):
+        await get_content_file(
+            "default-2026-g8", "G8-SCI-001", "quiz_set_1_en.json",
+            _redis(), _storage(PLACEHOLDER_QUIZ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_placeholder_is_not_cached():
+    """Rejected placeholders must not be written into the L2 cache."""
+    redis = _redis()
+    with pytest.raises(FileNotFoundError):
+        await get_content_file(
+            "default-2026-g8", "G8-SCI-001", "lesson_en.json",
+            redis, _storage(PLACEHOLDER_LESSON),
+        )
+    redis.set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_placeholder_already_in_cache_is_still_rejected():
+    """A placeholder cached by an older build must still be refused on read."""
+    storage = _storage(REAL_LESSON)  # store would return real content...
+    with pytest.raises(FileNotFoundError):
+        await get_content_file(
+            "default-2026-g8", "G8-SCI-001", "lesson_en.json",
+            _redis(cached=PLACEHOLDER_LESSON), storage,  # ...but cache holds a stub
+        )
+    storage.read_json.assert_not_called()  # served from cache, rejected there
+
+
+@pytest.mark.asyncio
+async def test_real_content_is_served_normally():
+    """Pipeline-generated content is unaffected and still cached."""
+    redis = _redis()
+    data = await get_content_file(
+        "default-2026-g8", "G8-SCI-001", "lesson_en.json",
+        redis, _storage(REAL_LESSON),
+    )
+    assert data == REAL_LESSON
+    redis.set.assert_called_once()

--- a/backend/tests/test_progress.py
+++ b/backend/tests/test_progress.py
@@ -126,27 +126,35 @@ async def test_start_session_increments_attempt_number(client, db_conn):
 
 @pytest.mark.asyncio
 async def test_record_answer_returns_200(client, db_conn, student_token):
-    """POST answer returns 200 immediately (fire-and-forget)."""
+    """
+    POST answer returns 200 with the SERVER's verdict.
+
+    The server grades against the content store, so the answer key is stubbed
+    (CI has no content on disk). The request sends only the picked option — the
+    old `correct` / `correct_answer` fields are gone. q1's key says index 0, so
+    picking 2 is graded wrong by the server regardless of what the client claims.
+    """
     from jose import jwt as _jwt
     payload = _jwt.decode(student_token, "test-secret-do-not-use-in-production-aaaa", algorithms=["HS256"])
     student_id = payload["student_id"]
     await _insert_student(client, student_id)
 
-    with patch("src.auth.tasks.celery_app.send_task", return_value=None):
+    with patch("src.auth.tasks.celery_app.send_task", return_value=None), \
+         patch("src.progress.router.get_quiz_answer_key", new_callable=AsyncMock,
+               return_value=_ANSWER_KEY_8Q):
         session = await _start_session(client, student_token)
         r = await client.post(
             f"/api/v1/progress/session/{session['session_id']}/answer",
             json={
                 "question_id": "q1",
                 "student_answer": 2,
-                "correct_answer": 1,
-                "correct": False,
                 "ms_taken": 3200,
             },
             headers={"Authorization": f"Bearer {student_token}"},
         )
     assert r.status_code == 200
     assert r.json()["correct"] is False
+    assert r.json()["correct_index"] == 0
 
 
 @pytest.mark.asyncio
@@ -161,7 +169,7 @@ async def test_answer_wrong_session_returns_404(client, db_conn, student_token):
     with patch("src.auth.tasks.celery_app.send_task", return_value=None):
         r = await client.post(
             f"/api/v1/progress/session/{fake_session_id}/answer",
-            json={"question_id": "q1", "student_answer": 1, "correct_answer": 1, "correct": True, "ms_taken": 500},
+            json={"question_id": "q1", "student_answer": 1, "ms_taken": 500},
             headers={"Authorization": f"Bearer {student_token}"},
         )
     assert r.status_code == 404
@@ -183,7 +191,7 @@ async def test_answer_other_student_session_returns_403(client, db_conn):
         session_a = await _start_session(client, token_a)
         r = await client.post(
             f"/api/v1/progress/session/{session_a['session_id']}/answer",
-            json={"question_id": "q1", "student_answer": 1, "correct_answer": 1, "correct": True, "ms_taken": 500},
+            json={"question_id": "q1", "student_answer": 1, "ms_taken": 500},
             headers={"Authorization": f"Bearer {token_b}"},
         )
     assert r.status_code == 403

--- a/backend/tests/test_progress.py
+++ b/backend/tests/test_progress.py
@@ -15,16 +15,43 @@ Coverage:
 from __future__ import annotations
 
 import uuid
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
-import pytest_asyncio
 from httpx import AsyncClient
 
 from tests.helpers.token_factory import make_student_token
 
-
 # ── Helpers ───────────────────────────────────────────────────────────────────
+
+# An 8-question quiz whose correct option is always index 0. Grading is exercised
+# through the real endpoint; only the content-store lookup is stubbed.
+_ANSWER_KEY_8Q = {
+    f"q{i}": {"index": 0, "explanation": f"Because of reason {i}."} for i in range(1, 9)
+}
+
+
+async def _answer_all(
+    client: AsyncClient, token: str, session_id: str, correct_count: int, total: int = 8
+) -> None:
+    """
+    Answer `total` questions, getting the first `correct_count` of them right.
+
+    Picks option 0 (correct per _ANSWER_KEY_8Q) or option 1 (wrong). The server
+    decides which is which — the request never says.
+    """
+    for i in range(total):
+        r = await client.post(
+            f"/api/v1/progress/session/{session_id}/answer",
+            json={
+                "question_id": f"q{i + 1}",
+                "student_answer": 0 if i < correct_count else 1,
+                "ms_taken": 100,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["correct"] is (i < correct_count)
 
 async def _insert_student(client: AsyncClient, student_id: str) -> None:
     """Insert a minimal student row using the app pool (committed; visible to all connections)."""
@@ -164,17 +191,25 @@ async def test_answer_other_student_session_returns_403(client, db_conn):
 
 @pytest.mark.asyncio
 async def test_end_session_computes_passed(client, db_conn, student_token):
-    """Session end computes passed = True when score / total >= 0.6."""
+    """
+    Session end computes passed = True when score / total >= 0.6.
+
+    The score comes from answers the server graded — the request body carries no
+    score at all. Drive 6 correct + 2 wrong through /answer and expect 6/8.
+    """
     from jose import jwt as _jwt
     payload = _jwt.decode(student_token, "test-secret-do-not-use-in-production-aaaa", algorithms=["HS256"])
     student_id = payload["student_id"]
     await _insert_student(client, student_id)
 
-    with patch("src.auth.tasks.celery_app.send_task", return_value=None):
+    with patch("src.auth.tasks.celery_app.send_task", return_value=None), \
+         patch("src.progress.router.get_quiz_answer_key", new_callable=AsyncMock,
+               return_value=_ANSWER_KEY_8Q):
         session = await _start_session(client, student_token)
+        await _answer_all(client, student_token, session["session_id"], correct_count=6)
         r = await client.post(
             f"/api/v1/progress/session/{session['session_id']}/end",
-            json={"score": 6, "total_questions": 8},
+            json={},
             headers={"Authorization": f"Bearer {student_token}"},
         )
     assert r.status_code == 200
@@ -185,6 +220,52 @@ async def test_end_session_computes_passed(client, db_conn, student_token):
 
 
 @pytest.mark.asyncio
+async def test_client_cannot_inflate_its_own_score(client, db_conn, student_token):
+    """
+    A student who answers everything wrong and posts a perfect score still scores 0.
+
+    This is the whole point of server-side grading: `correct` on the answer body
+    and `score` on the end body used to be trusted verbatim.
+    """
+    from jose import jwt as _jwt
+    payload = _jwt.decode(student_token, "test-secret-do-not-use-in-production-aaaa", algorithms=["HS256"])
+    await _insert_student(client, payload["student_id"])
+
+    with patch("src.auth.tasks.celery_app.send_task", return_value=None), \
+         patch("src.progress.router.get_quiz_answer_key", new_callable=AsyncMock,
+               return_value=_ANSWER_KEY_8Q):
+        session = await _start_session(client, student_token)
+
+        # Every answer wrong — and each request lies about it being correct.
+        for i in range(8):
+            r = await client.post(
+                f"/api/v1/progress/session/{session['session_id']}/answer",
+                json={
+                    "question_id": f"q{i + 1}",
+                    "student_answer": 3,      # key says 0 → wrong
+                    "correct_answer": 3,      # ignored
+                    "correct": True,          # ignored
+                    "ms_taken": 10,
+                },
+                headers={"Authorization": f"Bearer {student_token}"},
+            )
+            assert r.status_code == 200
+            assert r.json()["correct"] is False  # server overrules the client
+
+        # ...and the end request claims a perfect score.
+        r = await client.post(
+            f"/api/v1/progress/session/{session['session_id']}/end",
+            json={"score": 8, "total_questions": 8},
+            headers={"Authorization": f"Bearer {student_token}"},
+        )
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["score"] == 0
+    assert data["passed"] is False
+
+
+@pytest.mark.asyncio
 async def test_end_session_not_passed_below_threshold(client, db_conn, student_token):
     """Session end computes passed = False when score / total < 0.6."""
     from jose import jwt as _jwt
@@ -192,11 +273,14 @@ async def test_end_session_not_passed_below_threshold(client, db_conn, student_t
     student_id = payload["student_id"]
     await _insert_student(client, student_id)
 
-    with patch("src.auth.tasks.celery_app.send_task", return_value=None):
+    with patch("src.auth.tasks.celery_app.send_task", return_value=None), \
+         patch("src.progress.router.get_quiz_answer_key", new_callable=AsyncMock,
+               return_value=_ANSWER_KEY_8Q):
         session = await _start_session(client, student_token)
+        await _answer_all(client, student_token, session["session_id"], correct_count=4)
         r = await client.post(
             f"/api/v1/progress/session/{session['session_id']}/end",
-            json={"score": 4, "total_questions": 8},
+            json={},
             headers={"Authorization": f"Bearer {student_token}"},
         )
     assert r.status_code == 200

--- a/backend/tests/test_progress_server_side_grading.py
+++ b/backend/tests/test_progress_server_side_grading.py
@@ -1,0 +1,232 @@
+"""
+tests/test_progress_server_side_grading.py
+
+Quiz grading is the server's job.
+
+Before this, `POST /progress/session/{id}/answer` accepted `correct: bool` and
+`POST /progress/session/{id}/end` accepted `score: int`, and the backend stored
+whatever the browser sent. The quiz payload also shipped `correct_option` for
+every question. Between them, a student could read the answers out of the network
+tab and then post themselves a perfect score.
+
+Now:
+  - the client sends only which option it picked
+  - the server resolves the correct option from the content store and grades it
+  - the score at end-of-session is the server's running tally, not a request field
+  - the served quiz carries no answer key at all
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.content.router import _strip_answer_key
+from src.content.service import get_quiz_answer_key
+from src.progress.service import (
+    read_tally,
+    resolve_session_quiz_set,
+    tally_answer,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+# Correct answer is "B" — and note B is NOT at alphabetical index 1 in the option
+# list: the options are deliberately ordered C, B, A so that a grader keying off
+# alphabetical position instead of the option's real position would get it wrong.
+QUIZ_SET_2 = {
+    "unit_id": "G10-ENG-001",
+    "set_number": 2,
+    "questions": [
+        {
+            "question_id": "q1",
+            "question_text": "What holds the beam up?",
+            "question_type": "multiple_choice",
+            "options": [
+                {"option_id": "C", "text": "Magic"},
+                {"option_id": "B", "text": "The support reaction"},
+                {"option_id": "A", "text": "Nothing"},
+            ],
+            "correct_option": "B",
+            "explanation": "The support reaction balances the load.",
+            "difficulty": "medium",
+        },
+        {
+            "question_id": "q2",
+            "question_text": "Second question?",
+            "question_type": "multiple_choice",
+            "options": [
+                {"option_id": "A", "text": "Right"},
+                {"option_id": "B", "text": "Wrong"},
+            ],
+            "correct_option": "A",
+            "explanation": "A is right.",
+            "difficulty": "easy",
+        },
+    ],
+    "model": "claude-sonnet-4-6",
+}
+
+
+def _redis_store() -> MagicMock:
+    """A MagicMock redis with a real dict behind it, so INCR/GET actually work."""
+    data: dict[str, str] = {}
+
+    async def _get(k):
+        return data.get(k)
+
+    async def _set(k, v, ex=None):
+        data[k] = str(v)
+
+    async def _incr(k):
+        data[k] = str(int(data.get(k, 0)) + 1)
+        return int(data[k])
+
+    async def _setnx(k, v):
+        if k not in data:
+            data[k] = str(v)
+            return True
+        return False
+
+    async def _expire(k, ttl):
+        return True
+
+    r = MagicMock()
+    r.get, r.set, r.incr, r.setnx, r.expire = (
+        AsyncMock(side_effect=_get),
+        AsyncMock(side_effect=_set),
+        AsyncMock(side_effect=_incr),
+        AsyncMock(side_effect=_setnx),
+        AsyncMock(side_effect=_expire),
+    )
+    r._data = data
+    return r
+
+
+def _storage(payload: dict) -> MagicMock:
+    s = MagicMock()
+    s.read_json = AsyncMock(return_value=payload)
+    return s
+
+
+# ── The answer key never leaves the server ────────────────────────────────────
+
+
+def test_served_quiz_carries_no_answer_key():
+    stripped = _strip_answer_key(QUIZ_SET_2)
+
+    for q in stripped["questions"]:
+        assert "correct_option" not in q
+        assert "explanation" not in q
+
+    # Everything the student legitimately needs survives.
+    assert stripped["questions"][0]["question_text"] == "What holds the beam up?"
+    assert len(stripped["questions"][0]["options"]) == 3
+    assert stripped["set_number"] == 2
+
+
+def test_strip_does_not_mutate_the_cached_source():
+    """The dict handed to _strip_answer_key may be the L2-cached object."""
+    original = json.loads(json.dumps(QUIZ_SET_2))
+    _strip_answer_key(original)
+    assert original["questions"][0]["correct_option"] == "B"
+
+
+# ── Grading resolves the key from the content store ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_answer_key_uses_option_position_not_alphabetical_order():
+    """
+    The correct option is "B", which sits at position 1 in an option list ordered
+    C, B, A. A grader that mapped "B" → alphabetical index 1 would get the right
+    answer here by luck; one that mapped "A" → 0 would mark q1's real answer wrong.
+    Pin the behaviour: the index is the option's position in ITS OWN list.
+    """
+    key = await get_quiz_answer_key(
+        "default-2026-g10", "G10-ENG-001", 2, "en", _redis_store(), _storage(QUIZ_SET_2)
+    )
+
+    assert key["q1"]["index"] == 1  # "B" is the 2nd option in the C, B, A list
+    assert key["q2"]["index"] == 0  # "A" is the 1st option in the A, B list
+    assert key["q1"]["explanation"] == "The support reaction balances the load."
+
+
+@pytest.mark.asyncio
+async def test_answer_key_skips_question_whose_correct_option_is_not_an_option():
+    """A content defect must not silently mark every answer wrong."""
+    broken = json.loads(json.dumps(QUIZ_SET_2))
+    broken["questions"][0]["correct_option"] = "Z"  # not present in options
+
+    key = await get_quiz_answer_key(
+        "default-2026-g10", "G10-ENG-001", 2, "en", _redis_store(), _storage(broken)
+    )
+
+    assert "q1" not in key  # unresolvable → excluded, logged
+    assert "q2" in key
+
+
+# ── The score is the server's tally, not the client's claim ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_tally_counts_only_server_graded_correct_answers():
+    redis = _redis_store()
+    session = "11111111-1111-1111-1111-111111111111"
+
+    await tally_answer(redis, session_id=session, correct=True)
+    await tally_answer(redis, session_id=session, correct=False)
+    await tally_answer(redis, session_id=session, correct=True)
+
+    assert await read_tally(redis, session) == 2
+
+
+@pytest.mark.asyncio
+async def test_all_wrong_run_tallies_zero_not_missing():
+    """
+    An all-wrong run must read back as 0, distinguishable from "no tally at all"
+    (None) — otherwise end_session would fall back to the DB and could report a
+    stale or partial number.
+    """
+    redis = _redis_store()
+    session = "22222222-2222-2222-2222-222222222222"
+
+    await tally_answer(redis, session_id=session, correct=False)
+    await tally_answer(redis, session_id=session, correct=False)
+
+    assert await read_tally(redis, session) == 0
+
+
+@pytest.mark.asyncio
+async def test_read_tally_is_none_when_session_never_graded():
+    assert await read_tally(_redis_store(), "33333333-3333-3333-3333-333333333333") is None
+
+
+# ── The graded set is pinned for the life of the session ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_quiz_set_is_pinned_and_survives_rotation_advancing():
+    """
+    `question_id` is q1..qN in EVERY set, with different correct answers per set.
+    So the set must stay fixed for the session: if the per-unit rotation pointer
+    advances mid-quiz (student opens the unit again in another tab), later answers
+    must still be graded against the set the student is actually holding.
+    """
+    redis = _redis_store()
+    session, student, unit = "s-1", "stu-1", "G10-ENG-001"
+
+    await redis.set("quiz_set:stu-1:G10-ENG-001", "2")
+    assert await resolve_session_quiz_set(redis, session, student, unit) == 2
+
+    # Rotation moves on — the pinned session must not follow it.
+    await redis.set("quiz_set:stu-1:G10-ENG-001", "3")
+    assert await resolve_session_quiz_set(redis, session, student, unit) == 2
+
+
+@pytest.mark.asyncio
+async def test_quiz_set_defaults_to_1_when_rotation_pointer_expired():
+    redis = _redis_store()
+    assert await resolve_session_quiz_set(redis, "s-2", "stu-2", "G10-ENG-001") == 1

--- a/docs/feedback_07_11_2026_five_questions.md
+++ b/docs/feedback_07_11_2026_five_questions.md
@@ -1,0 +1,131 @@
+# Five questions from the 07-11 report, answered
+
+Each answer is traced to the exact place in the code that decides it, so the
+behaviour on screen can be matched to how the system actually works.
+
+> **`file:line`** = source location. Two of these — **Q4** and **Q5** — surfaced
+> real reporting quirks worth knowing about.
+
+---
+
+## Q1 — How does the subject / grade get mapped?
+
+**The school admin sets the grade; the grade plus the school picks a curriculum;
+the curriculum's units supply the subjects.**
+
+A three-link chain:
+
+| Link | What happens |
+|---|---|
+| **Grade** | Set by the school on the student screen — the school is the authority. A school student who tries to change their own grade is refused. |
+| **Curriculum** | Resolved in 3 steps: the school's own curriculum for that grade → else the platform package on the student's classroom → else the default STEM package. |
+| **Subjects** | Read off the curriculum's units. Display names like "Physics" come from published content, falling back to the internal code ("G11-PHYS") until then. |
+
+The middle step is the important one: the **classroom package is how streams**
+(Commerce, Science) get selected for a grade — otherwise a student lands on the
+default STEM package for their grade.
+
+- `school/enrolment_service.py:342, 365` — assignment writes the grade; school is the authority
+- `auth/router.py:1050` — student self-change of grade returns 403
+- `content/service.py:313–384` — the 3-step curriculum resolver
+- `curriculum/router.py:528` — subject display name (`COALESCE(csv.subject_name, cu.subject)`)
+
+---
+
+## Q2 — Where does a logged-in student see their assigned subjects?
+
+**Two places, both fed by the same curriculum data: Subjects (`/subjects`) and
+Curriculum Map (`/curriculum`).**
+
+The student sees subject cards; opening one reveals its units, each with a
+**Lesson** and a **Quiz** button — or a **Coming soon** pill for units whose
+content isn't published yet. The Curriculum Map is the same structure with
+progress overlaid on each unit.
+
+- `web/app/(student)/subjects/page.tsx`
+- `StudentNav.tsx:21`
+- `GET /curriculum/tree`
+
+---
+
+## Q3 — How do students get associated with teachers?
+
+**Three mechanisms. The one behind the "My students" toggle is the classroom.**
+
+1. **Classroom — the one behind "My students."** A classroom has one teacher;
+   students are enrolled in it. The "My students" toggle is worked out **in the
+   browser**: students in classrooms *you lead* (`classroom.teacher_id === you`).
+   `school/service.py:386, 661` · `students/page.tsx:85`
+
+2. **Direct grade assignment — the formal record.** The assignment screen writes
+   one student → grade → teacher row (one teacher per grade) and syncs the
+   student's grade. This is the school-owned source of truth for ownership.
+   `enrolment_service.py:342`
+
+3. **Enrolment default.** A roster upload can carry a teacher at enrolment time,
+   which seeds mechanism 2. `enrolment_service.py:225`
+
+> **Why you saw "My students (0) / All school (4)":** you were signed in as a
+> **school admin** who doesn't personally lead a classroom, so zero students are
+> "yours" — while all four are enrolled in the school. Assign yourself as a
+> classroom's teacher (or view **All school**) to see them.
+
+One nuance worth knowing: the reporting backend is **school-wide** — it scopes by
+`school_id` only and never by teacher (`reports/service.py:52`). So "All school"
+is the backend; "My students" is a client-side classroom filter layered on top.
+The two association models are not synchronized.
+
+---
+
+## Q4 — Is the pass rate based on quiz marks, or something else?
+
+**Quiz marks. A pass = quiz score ≥ 60%, recorded once when the quiz is
+submitted. But two screens count the *rate* differently.**
+
+| Screen | Basis |
+|---|---|
+| **Overview — "1st-attempt pass rate"** (`reports/service.py:135–157`) | **First tries only.** Passed first-attempts ÷ completed first-attempts. A retry never counts. |
+| **At-Risk — "pass rate"** (`reports/service.py:1072–1079`) | **All attempts, lifetime.** Passed sessions ÷ all completed sessions. A fail-then-pass counts as a pass. |
+
+> **Worth knowing:** because the two use different denominators, the same
+> student's pass rate will **legitimately differ** between the Overview and the
+> At-Risk screen. That's a labelling gap, not a calculation error — worth
+> clarifying in the UI.
+
+- `progress/service.py:30, 299` — the 60% threshold (`QUIZ_PASS_THRESHOLD`, `passed`)
+
+---
+
+## Q5 — What is the basis of the data under "Risk / Inactive"?
+
+**Thresholds: inactive > 14 days, or pass rate < 50%. "Last active" = the
+student's most recent completed quiz.**
+
+> **Why every student showed "Inactive / —":** a student who has **never
+> completed a quiz** has no session on record, so "last active" is empty — and
+> the query counts an empty last-active as inactive, with pass rate shown as "—".
+> Since lessons and quizzes were failing to open (the curriculum bug), **no quiz
+> was ever taken**, so every student collapsed into that empty state. The screen
+> was reporting **absence of data, not real disengagement.**
+
+> ✅ **Resolved:** the content fix in **PR #506** makes lessons and quizzes open,
+> so sessions get recorded. Once students actually complete quizzes, this screen
+> becomes a real signal instead of an artefact.
+
+- `reports/service.py:1050–1058` — thresholds (14 days, 50%)
+- `reports/service.py:1071` — last active = `MAX(ended_at)`
+- `reports/service.py:1100, 1113` — empty last-active treated as inactive
+- `reports/service.py:1130` — empty pass rate rendered as "—"
+
+---
+
+## The bigger picture
+
+The same root cause behind Q5 — content failing to open — is what emptied the
+**Overview, Engagement, and Student Progress** screens too. Each one fails
+*differently* on missing data (zeros here, "Never active" there, "Inactive / —"
+on the risk screen), which made it look like four separate bugs when it was one
+broken content path. **One fix (PR #506) addresses all of them.**
+
+Q4's two-denominator mismatch and the UI labelling notes are separate, smaller
+follow-ups.

--- a/pipeline/build_unit.py
+++ b/pipeline/build_unit.py
@@ -37,6 +37,7 @@ if _REPO_ROOT not in sys.path:
 
 from pipeline.alex_runner import run_alex
 from pipeline.pdf_worker import generate_pdf
+from pipeline.providers._wegofwd_adapter import PermanentLLMError
 from pipeline.content_format_validator import FormatWarning, check_content
 from pipeline.prompts import (
     build_experiment_prompt,
@@ -111,6 +112,14 @@ def _generate_and_validate(
             validator(data)
             return data, total_in, total_out
 
+        except PermanentLLMError as exc:
+            # No credit / bad key / dead model. Retrying costs money and time and
+            # cannot succeed — fail the unit now, with the provider's real message
+            # rather than "Failed after 3 attempts".
+            log.error(
+                "generate_permanent_failure content_type=%s error=%s", content_type, exc
+            )
+            raise
         except json.JSONDecodeError as exc:
             last_error = f"JSON parse error (attempt {attempt}): {exc}"
             log.warning("generate_retry json_error attempt=%d content_type=%s error=%s", attempt, content_type, exc)

--- a/pipeline/providers/_wegofwd_adapter.py
+++ b/pipeline/providers/_wegofwd_adapter.py
@@ -26,7 +26,63 @@ wegofwd-llm message is key-free by guarantee, so re-raising its text is safe.
 
 from __future__ import annotations
 
+import re
+
 from pipeline.providers.base import LLMProvider
+
+
+class PermanentLLMError(RuntimeError):
+    """
+    An LLM failure that retrying cannot fix.
+
+    Exhausted credits, a bad API key, a disabled model: the call will fail
+    identically every time. The build loop retries ``RuntimeError`` three times,
+    which for these turns one wasted call into three and buries the real message
+    under "Failed after 3 attempts".
+    """
+
+
+# HTTP statuses that will never succeed on retry, however many times we ask.
+# 429 is deliberately NOT here — rate limits are transient and worth retrying.
+_PERMANENT_STATUSES = (400, 401, 403, 404)
+
+
+def _root_cause(exc: BaseException) -> BaseException:
+    """Walk to the deepest cause — where the provider SDK's real message lives."""
+    seen: set[int] = set()
+    cur = exc
+    while True:
+        nxt = cur.__cause__ or cur.__context__
+        if nxt is None or id(nxt) in seen:
+            return cur
+        seen.add(id(nxt))
+        cur = nxt
+
+
+def _describe(exc: BaseException) -> str:
+    """
+    Build a message that says what actually went wrong.
+
+    ``wegofwd_llm`` raises ``LLMError("anthropic call failed")`` — true but
+    useless. The provider SDK's exception (e.g. anthropic's
+    "Your credit balance is too low") is one or two links down the ``__cause__``
+    chain, and was being thrown away. An 18-unit build once failed with nothing
+    but "anthropic call failed" ×54 when the account had simply run out of credit.
+    """
+    root = _root_cause(exc)
+    if root is exc:
+        return str(exc)
+    return f"{exc} — {type(root).__name__}: {root}"
+
+
+def _is_permanent(exc: BaseException) -> bool:
+    root = _root_cause(exc)
+    status = getattr(root, "status_code", None)
+    if status is None:
+        # anthropic/openai SDK errors carry the code in the text as "Error code: NNN".
+        m = re.search(r"Error code:\s*(\d{3})", str(root))
+        status = int(m.group(1)) if m else None
+    return status in _PERMANENT_STATUSES
 
 
 class WegofwdAdapter(LLMProvider):
@@ -68,7 +124,10 @@ class WegofwdAdapter(LLMProvider):
             )
         except LLMError as exc:
             # Preserve the legacy contract: providers raise RuntimeError on failure.
-            raise RuntimeError(str(exc)) from exc
+            # PermanentLLMError is a RuntimeError, so callers that don't know about
+            # it behave exactly as before; the retry loop checks for it and stops.
+            error_class = PermanentLLMError if _is_permanent(exc) else RuntimeError
+            raise error_class(_describe(exc)) from exc
         if not resp.text:
             raise RuntimeError(f"{provider_label(self.provider_id)} returned an empty response")
         return resp.text, resp.input_tokens, resp.output_tokens

--- a/web/components/content/QuizPlayer.tsx
+++ b/web/components/content/QuizPlayer.tsx
@@ -25,7 +25,7 @@ interface State {
 
 type Action =
   | { type: "SELECT"; index: number }
-  | { type: "REVIEWED"; result: AnswerResponse; correct: boolean }
+  | { type: "REVIEWED"; result: AnswerResponse }
   | { type: "NEXT" }
   | { type: "SCORE"; result: SessionEndResponse };
 
@@ -38,7 +38,9 @@ function reducer(state: State, action: Action): State {
         ...state,
         phase: "reviewing",
         answerResult: action.result,
-        correctCount: action.correct ? state.correctCount + 1 : state.correctCount,
+        // Local tally is for display only. The score on the result screen is the
+        // server's — it grades each answer and keeps its own count.
+        correctCount: action.result.correct ? state.correctCount + 1 : state.correctCount,
       };
     case "NEXT":
       return {
@@ -83,22 +85,20 @@ export function QuizPlayer({ quiz, sessionId, onRetry }: QuizPlayerProps) {
 
   async function handleSubmit() {
     if (state.selectedIndex === null) return;
-    const correct = state.selectedIndex === question.correct_index;
+    // The server grades this. We send the choice; it returns the verdict, the
+    // correct option and the explanation — none of which we had beforehand.
     const res = await submitAnswer({
       session_id: sessionId,
-      unit_id: quiz.unit_id,
-      question_index: state.questionIndex,
+      question_id: question.question_id,
       answer_index: state.selectedIndex,
-      correct_index: question.correct_index,
     });
-    dispatch({ type: "REVIEWED", result: res, correct });
+    dispatch({ type: "REVIEWED", result: res });
   }
 
   async function handleNext() {
     if (isLast) {
-      const total = quiz.questions.length;
-      const score = state.correctCount + (state.answerResult?.correct ? 1 : 0);
-      const res = await endSession(sessionId, score, total);
+      // No score is sent: the backend reports what it graded during the session.
+      const res = await endSession(sessionId);
       // Session completion is written synchronously by endSession, so the
       // stats/history reads are fresh — refresh them now instead of waiting for
       // a manual browser reload (#466).
@@ -183,8 +183,10 @@ export function QuizPlayer({ quiz, sessionId, onRetry }: QuizPlayerProps) {
         <div className="space-y-3">
           {question.options.map((option, i) => {
             const isSelected = state.selectedIndex === i;
-            const isCorrect = i === question.correct_index;
             const reviewed = state.phase === "reviewing";
+            // Which option is right is only known once the server has told us —
+            // it isn't in the quiz payload.
+            const isCorrect = reviewed && i === state.answerResult?.correct_index;
 
             const variant = "outline";
             let extra = "";
@@ -220,10 +222,10 @@ export function QuizPlayer({ quiz, sessionId, onRetry }: QuizPlayerProps) {
           })}
         </div>
 
-        {/* Explanation */}
-        {state.phase === "reviewing" && question.explanation && (
+        {/* Explanation — supplied by the server with the verdict */}
+        {state.phase === "reviewing" && state.answerResult?.explanation && (
           <div className="mt-4 rounded-lg border bg-gray-50 p-3 text-sm text-gray-600">
-            {question.explanation}
+            {state.answerResult.explanation}
           </div>
         )}
       </div>

--- a/web/lib/api/content.ts
+++ b/web/lib/api/content.ts
@@ -28,9 +28,9 @@ interface BackendQuizQuestion {
   question_text: string;
   question_type: string;
   options: BackendQuizOption[];
-  correct_option: string; // "A" | "B" | "C" | "D"
-  explanation: string;
   difficulty: string;
+  // No correct_option / explanation — the server strips the answer key before
+  // sending the quiz. Grading happens in POST /progress/session/{id}/answer.
 }
 interface BackendQuizResponse {
   unit_id: string;
@@ -46,8 +46,6 @@ interface BackendQuizResponse {
   subject: string | null;
 }
 
-const OPTION_IDS = ["A", "B", "C", "D"];
-
 export async function getQuiz(unitId: string): Promise<QuizContent> {
   const res = await api.get<BackendQuizResponse>(`/content/${unitId}/quiz`);
   const raw = res.data;
@@ -58,10 +56,9 @@ export async function getQuiz(unitId: string): Promise<QuizContent> {
     subject: raw.subject ?? undefined,
     questions: raw.questions.map((q, index) => ({
       index,
+      question_id: q.question_id,
       question: q.question_text,
       options: q.options.map((o) => o.text),
-      correct_index: OPTION_IDS.indexOf(q.correct_option),
-      explanation: q.explanation,
     })),
   };
 }

--- a/web/lib/api/progress.ts
+++ b/web/lib/api/progress.ts
@@ -18,39 +18,47 @@ export async function startSession(
   return res.data;
 }
 
+/**
+ * Submit the option the student picked. The server grades it.
+ *
+ * We send only the choice — never whether it was right. The verdict, the correct
+ * option and the explanation all come back in the response; the browser is never
+ * given the answer key up front.
+ *
+ * `question_id` must be the id from the quiz payload (the content's own ids are
+ * `q1`…`qN`), because that is what the server looks the answer up by.
+ */
 export async function submitAnswer(payload: {
   session_id: string;
-  unit_id: string;
-  question_index: number;
+  question_id: string;
   answer_index: number;
-  correct_index: number;
+  ms_taken?: number;
 }): Promise<AnswerResponse> {
-  // Backend: POST /progress/session/{session_id}/answer
-  // Body: { question_id, student_answer, correct_answer, correct, ms_taken }
-  const { session_id, unit_id, question_index, answer_index, correct_index } = payload;
-  const correct = answer_index === correct_index;
+  const { session_id, question_id, answer_index, ms_taken = 0 } = payload;
 
-  const res = await api.post<{ answer_id: string; correct: boolean }>(
-    `/progress/session/${session_id}/answer`,
-    {
-      question_id: `${unit_id}-Q${question_index + 1}`,
-      student_answer: answer_index,
-      correct_answer: correct_index,
-      correct,
-      ms_taken: 0,
-    },
-  );
-  // Return shape the QuizPlayer expects
-  return { correct: res.data.correct, explanation: "" };
+  const res = await api.post<{
+    answer_id: string;
+    correct: boolean;
+    correct_index: number;
+    explanation: string;
+  }>(`/progress/session/${session_id}/answer`, {
+    question_id,
+    student_answer: answer_index,
+    ms_taken,
+  });
+
+  return {
+    correct: res.data.correct,
+    correct_index: res.data.correct_index,
+    explanation: res.data.explanation ?? "",
+  };
 }
 
-export async function endSession(
-  sessionId: string,
-  score: number,
-  total: number,
-): Promise<SessionEndResponse> {
-  // Backend: POST /progress/session/{session_id}/end
-  // Body: { score, total_questions }  (not /session/end with body session_id)
+/**
+ * Close the session. The score is whatever the server graded during it — there is
+ * no score to send.
+ */
+export async function endSession(sessionId: string): Promise<SessionEndResponse> {
   const res = await api.post<{
     session_id: string;
     score: number;
@@ -58,10 +66,8 @@ export async function endSession(
     passed: boolean;
     attempt_number: number;
     ended_at: string;
-  }>(`/progress/session/${sessionId}/end`, {
-    score,
-    total_questions: total,
-  });
+  }>(`/progress/session/${sessionId}/end`, {});
+
   // Map total_questions → total for the SessionEndResponse type
   return {
     score: res.data.score,

--- a/web/lib/api/types.gen.ts
+++ b/web/lib/api/types.gen.ts
@@ -948,6 +948,10 @@ export interface paths {
          * End Session Endpoint
          * @description Close a session and compute the final score + passed flag.
          *
+         *     The score is derived from the answers the SERVER graded during the session
+         *     (Redis tally, falling back to persisted answers) — never from the request
+         *     body. A client that posts a score is ignored.
+         *
          *     Score is written synchronously (client needs the result immediately).
          *     Streak update and progress view refresh are dispatched as Celery tasks.
          *     Dashboard cache for this student is invalidated.
@@ -7545,12 +7549,18 @@ export interface components {
         EditStructureRequest: {
             structured_toc: components["schemas"]["StructuredTOC"];
         };
-        /** EndSessionRequest */
+        /**
+         * EndSessionRequest
+         * @description No score field. The score is computed server-side from the answers actually
+         *     graded during the session — the client cannot assert one.
+         *
+         *     `total_questions` is an optional hint used only if the server cannot resolve
+         *     the quiz's real length (e.g. the content file has since been removed); the
+         *     answer key is preferred whenever it is available.
+         */
         EndSessionRequest: {
-            /** Score */
-            score: number;
             /** Total Questions */
-            total_questions: number;
+            total_questions?: number | null;
         };
         /** EndSessionResponse */
         EndSessionResponse: {
@@ -8568,12 +8578,12 @@ export interface components {
             question_type: string;
             /** Options */
             options: components["schemas"]["QuizOption"][];
-            /** Correct Option */
-            correct_option: string;
-            /** Explanation */
-            explanation: string;
             /** Difficulty */
             difficulty: string;
+            /** Correct Option */
+            correct_option?: string | null;
+            /** Explanation */
+            explanation?: string | null;
         };
         /** QuizResponse */
         QuizResponse: {
@@ -8649,27 +8659,45 @@ export interface components {
              */
             submitted_at: string;
         };
-        /** RecordAnswerRequest */
+        /**
+         * RecordAnswerRequest
+         * @description The client submits only WHAT the student picked — never whether it was right.
+         *
+         *     `correct_answer` and `correct` used to be accepted here and stored verbatim,
+         *     which let any student mark their own answers correct. Grading is now done
+         *     server-side from the content store; anything the client claims about
+         *     correctness is ignored.
+         */
         RecordAnswerRequest: {
             /** Question Id */
             question_id: string;
             /** Student Answer */
             student_answer: number;
-            /** Correct Answer */
-            correct_answer: number;
-            /** Correct */
-            correct: boolean;
             /** Ms Taken */
             ms_taken: number;
             /** Event Id */
             event_id?: string | null;
         };
-        /** RecordAnswerResponse */
+        /**
+         * RecordAnswerResponse
+         * @description The server's verdict on the answer, plus the reveal.
+         *
+         *     `correct_index` and `explanation` are returned HERE rather than shipped inside
+         *     the quiz payload, so the answer key never sits in the browser before the
+         *     student has committed to a choice.
+         */
         RecordAnswerResponse: {
             /** Answer Id */
             answer_id: string;
             /** Correct */
             correct: boolean;
+            /** Correct Index */
+            correct_index: number;
+            /**
+             * Explanation
+             * @default
+             */
+            explanation: string;
         };
         /**
          * RefreshRequest

--- a/web/lib/types/api.ts
+++ b/web/lib/types/api.ts
@@ -52,10 +52,12 @@ export interface AudioUrlResponse {
 
 export interface QuizQuestion {
   index: number;
+  /** The content's own question id (`q1`…`qN`) — what the server grades against. */
+  question_id: string;
   question: string;
   options: string[];
-  correct_index: number;
-  explanation: string;
+  // No correct_index / explanation: the answer key is not sent to the browser.
+  // Both arrive in AnswerResponse once the student has committed to a choice.
 }
 
 export interface QuizContent {
@@ -118,6 +120,8 @@ export interface SessionStartResponse {
 
 export interface AnswerResponse {
   correct: boolean;
+  /** The server's answer, revealed only after the student has answered. */
+  correct_index: number;
   explanation: string;
 }
 

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -1852,7 +1852,7 @@
           "progress"
         ],
         "summary": "End Session Endpoint",
-        "description": "Close a session and compute the final score + passed flag.\n\nScore is written synchronously (client needs the result immediately).\nStreak update and progress view refresh are dispatched as Celery tasks.\nDashboard cache for this student is invalidated.",
+        "description": "Close a session and compute the final score + passed flag.\n\nThe score is derived from the answers the SERVER graded during the session\n(Redis tally, falling back to persisted answers) \u2014 never from the request\nbody. A client that posts a score is ignored.\n\nScore is written synchronously (client needs the result immediately).\nStreak update and progress view refresh are dispatched as Celery tasks.\nDashboard cache for this student is invalidated.",
         "operationId": "end_session_endpoint_api_v1_progress_session__session_id__end_post",
         "security": [
           {
@@ -20142,23 +20142,22 @@
       },
       "EndSessionRequest": {
         "properties": {
-          "score": {
-            "type": "integer",
-            "minimum": 0.0,
-            "title": "Score"
-          },
           "total_questions": {
-            "type": "integer",
-            "minimum": 1.0,
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Total Questions"
           }
         },
         "type": "object",
-        "required": [
-          "score",
-          "total_questions"
-        ],
-        "title": "EndSessionRequest"
+        "title": "EndSessionRequest",
+        "description": "No score field. The score is computed server-side from the answers actually\ngraded during the session \u2014 the client cannot assert one.\n\n`total_questions` is an optional hint used only if the server cannot resolve\nthe quiz's real length (e.g. the content file has since been removed); the\nanswer key is preferred whenever it is available."
       },
       "EndSessionResponse": {
         "properties": {
@@ -22758,17 +22757,31 @@
             "type": "array",
             "title": "Options"
           },
-          "correct_option": {
-            "type": "string",
-            "title": "Correct Option"
-          },
-          "explanation": {
-            "type": "string",
-            "title": "Explanation"
-          },
           "difficulty": {
             "type": "string",
             "title": "Difficulty"
+          },
+          "correct_option": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Correct Option"
+          },
+          "explanation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Explanation"
           }
         },
         "type": "object",
@@ -22777,8 +22790,6 @@
           "question_text",
           "question_type",
           "options",
-          "correct_option",
-          "explanation",
           "difficulty"
         ],
         "title": "QuizQuestion"
@@ -23005,15 +23016,8 @@
           },
           "student_answer": {
             "type": "integer",
+            "minimum": 0.0,
             "title": "Student Answer"
-          },
-          "correct_answer": {
-            "type": "integer",
-            "title": "Correct Answer"
-          },
-          "correct": {
-            "type": "boolean",
-            "title": "Correct"
           },
           "ms_taken": {
             "type": "integer",
@@ -23037,11 +23041,10 @@
         "required": [
           "question_id",
           "student_answer",
-          "correct_answer",
-          "correct",
           "ms_taken"
         ],
-        "title": "RecordAnswerRequest"
+        "title": "RecordAnswerRequest",
+        "description": "The client submits only WHAT the student picked \u2014 never whether it was right.\n\n`correct_answer` and `correct` used to be accepted here and stored verbatim,\nwhich let any student mark their own answers correct. Grading is now done\nserver-side from the content store; anything the client claims about\ncorrectness is ignored."
       },
       "RecordAnswerResponse": {
         "properties": {
@@ -23052,14 +23055,25 @@
           "correct": {
             "type": "boolean",
             "title": "Correct"
+          },
+          "correct_index": {
+            "type": "integer",
+            "title": "Correct Index"
+          },
+          "explanation": {
+            "type": "string",
+            "title": "Explanation",
+            "default": ""
           }
         },
         "type": "object",
         "required": [
           "answer_id",
-          "correct"
+          "correct",
+          "correct_index"
         ],
-        "title": "RecordAnswerResponse"
+        "title": "RecordAnswerResponse",
+        "description": "The server's verdict on the answer, plus the reveal.\n\n`correct_index` and `explanation` are returned HERE rather than shipped inside\nthe quiz payload, so the answer key never sits in the browser before the\nstudent has committed to a choice."
       },
       "RefreshRequest": {
         "properties": {

--- a/web/tests/e2e/data/quiz-page.ts
+++ b/web/tests/e2e/data/quiz-page.ts
@@ -45,9 +45,6 @@ export const MOCK_BACKEND_QUIZ_RESPONSE = {
         { option_id: "C", text: "Tissue" },
         { option_id: "D", text: "Organ" },
       ],
-      correct_option: "B",
-      explanation:
-        "The cell is the basic structural and functional unit of all living organisms.",
       difficulty: "easy",
     },
     {
@@ -60,8 +57,6 @@ export const MOCK_BACKEND_QUIZ_RESPONSE = {
         { option_id: "C", text: "Nucleus" },
         { option_id: "D", text: "Vacuole" },
       ],
-      correct_option: "C",
-      explanation: "The nucleus houses the cell's genetic material (DNA).",
       difficulty: "easy",
     },
     {
@@ -74,9 +69,6 @@ export const MOCK_BACKEND_QUIZ_RESPONSE = {
         { option_id: "C", text: "ATP (energy)" },
         { option_id: "D", text: "Cell membrane" },
       ],
-      correct_option: "C",
-      explanation:
-        "Mitochondria are the powerhouse of the cell, producing ATP through cellular respiration.",
       difficulty: "medium",
     },
   ],
@@ -97,29 +89,38 @@ export const MOCK_QUIZ: QuizContent = {
   questions: [
     {
       index: 0,
+      question_id: "G8-SCI-001-Q1",
       question: "What is the basic unit of all living organisms?",
       options: ["Atom", "Cell", "Tissue", "Organ"],
-      correct_index: 1,
-      explanation:
-        "The cell is the basic structural and functional unit of all living organisms.",
     },
     {
       index: 1,
+      question_id: "G8-SCI-001-Q2",
       question: "Which organelle contains the cell's DNA?",
       options: ["Mitochondria", "Ribosome", "Nucleus", "Vacuole"],
-      correct_index: 2,
-      explanation: "The nucleus houses the cell's genetic material (DNA).",
     },
     {
       index: 2,
+      question_id: "G8-SCI-001-Q3",
       question: "What do mitochondria produce?",
       options: ["Protein", "DNA", "ATP (energy)", "Cell membrane"],
-      correct_index: 2,
-      explanation:
-        "Mitochondria are the powerhouse of the cell, producing ATP through cellular respiration.",
     },
   ],
 };
+
+/**
+ * Which option each question's answer actually is.
+ *
+ * This lives OUTSIDE QuizContent on purpose: the real quiz payload no longer
+ * carries the answer key, so the fixture must not either. Tests use this to know
+ * which button to click; the component only learns the answer from the mocked
+ * AnswerResponse, exactly as it does from the server in production.
+ */
+export const MOCK_CORRECT_INDEXES = [1, 2, 2] as const;
+
+/** The text of the correct option for question `i`. */
+export const correctOptionText = (i: number): string =>
+  MOCK_QUIZ.questions[i].options[MOCK_CORRECT_INDEXES[i]];
 
 // ---------------------------------------------------------------------------
 // Mock session start (STU-24)
@@ -133,12 +134,14 @@ export const MOCK_SESSION_ID = "sess-test-001";
 
 export const MOCK_ANSWER_CORRECT: AnswerResponse = {
   correct: true,
+  correct_index: 1,
   explanation:
     "The cell is the basic structural and functional unit of all living organisms.",
 };
 
 export const MOCK_ANSWER_WRONG: AnswerResponse = {
   correct: false,
+  correct_index: 1,
   explanation:
     "The cell is the basic structural and functional unit of all living organisms.",
 };

--- a/web/tests/e2e/data/quiz-page.ts
+++ b/web/tests/e2e/data/quiz-page.ts
@@ -122,6 +122,19 @@ export const MOCK_CORRECT_INDEXES = [1, 2, 2] as const;
 export const correctOptionText = (i: number): string =>
   MOCK_QUIZ.questions[i].options[MOCK_CORRECT_INDEXES[i]];
 
+/**
+ * Explanations, keyed by question index.
+ *
+ * Also outside QuizContent: the server sends the explanation back with the
+ * verdict, not up front with the quiz — revealing it early would reveal the
+ * answer.
+ */
+export const QUIZ_EXPLANATIONS = [
+  "The cell is the basic structural and functional unit of all living organisms.",
+  "The nucleus houses the cell's genetic material (DNA).",
+  "Mitochondria are the powerhouse of the cell, producing ATP through cellular respiration.",
+] as const;
+
 // ---------------------------------------------------------------------------
 // Mock session start (STU-24)
 // ---------------------------------------------------------------------------

--- a/web/tests/e2e/student_flow.spec.ts
+++ b/web/tests/e2e/student_flow.spec.ts
@@ -32,6 +32,9 @@ import {
   MOCK_BACKEND_QUIZ_RESPONSE,
   MOCK_QUIZ_DISPLAY_TITLE,
   MOCK_SESSION_ID,
+  MOCK_CORRECT_INDEXES,
+  QUIZ_EXPLANATIONS,
+  correctOptionText,
   QUIZ_STRINGS,
 } from "./data/quiz-page";
 // MOCK_PROGRESS_HISTORY not imported — stubProgressApis uses inline backend-format response
@@ -107,9 +110,34 @@ async function stubQuizApis(page: Page) {
     (route) => route.fulfill({ status: 200, json: { session_id: MOCK_SESSION_ID } }),
   );
   // POST /progress/session/{id}/answer
-  await page.route("**/api/v1/progress/session/*/answer", (route) =>
-    route.fulfill({ status: 200, json: { correct: true, explanation: "" } }),
-  );
+  //
+  // Grading is server-side now: the client posts only the option it picked, and
+  // the response carries the verdict plus the reveal (correct_index +
+  // explanation), which the quiz payload no longer contains. The stub grades the
+  // same way the real endpoint does — by looking the question up — rather than
+  // blindly answering `correct: true`, so the spec would catch the player sending
+  // the wrong question_id.
+  await page.route("**/api/v1/progress/session/*/answer", (route) => {
+    const body = route.request().postDataJSON() as {
+      question_id: string;
+      student_answer: number;
+    };
+    const i = MOCK_QUIZ.questions.findIndex((q) => q.question_id === body.question_id);
+    if (i === -1) {
+      route.fulfill({ status: 400, json: { detail: { error: "unknown_question" } } });
+      return;
+    }
+    const correctIndex = MOCK_CORRECT_INDEXES[i];
+    route.fulfill({
+      status: 200,
+      json: {
+        answer_id: "",
+        correct: body.student_answer === correctIndex,
+        correct_index: correctIndex,
+        explanation: QUIZ_EXPLANATIONS[i],
+      },
+    });
+  });
   // POST /progress/session/{id}/end — backend returns total_questions, not total
   await page.route("**/api/v1/progress/session/*/end", (route) =>
     route.fulfill({
@@ -243,14 +271,15 @@ test("student learning loop: lesson → quiz → result → progress", async ({ 
     // Question text visible
     await expect(page.getByText(q.question)).toBeVisible();
 
-    // Select the correct option
-    await page.getByRole("button", { name: q.options[q.correct_index] }).click();
+    // Select the correct option. The quiz payload no longer carries the answer
+    // key, so the fixture supplies it — the page itself cannot know it yet.
+    await page.getByRole("button", { name: correctOptionText(i) }).click();
 
     // Submit
     await page.getByRole("button", { name: QUIZ_STRINGS.submitBtn }).click();
 
-    // Explanation appears
-    await expect(page.getByText(q.explanation)).toBeVisible();
+    // Explanation appears — it arrives with the server's verdict, not with the quiz
+    await expect(page.getByText(QUIZ_EXPLANATIONS[i])).toBeVisible();
 
     // Advance to next question or results
     if (isLast) {

--- a/web/tests/unit/quiz-page.test.tsx
+++ b/web/tests/unit/quiz-page.test.tsx
@@ -11,6 +11,8 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { QuizPlayer } from "@/components/content/QuizPlayer";
 import {
   MOCK_QUIZ,
+  MOCK_CORRECT_INDEXES,
+  correctOptionText,
   MOCK_SESSION_ID,
   MOCK_ANSWER_CORRECT,
   MOCK_ANSWER_WRONG,
@@ -168,8 +170,7 @@ describe("STU-21 — Correct answer shown after submit", () => {
     );
 
     // Select the correct option (index 1 → "Cell")
-    const correctOption =
-      MOCK_QUIZ.questions[0].options[MOCK_QUIZ.questions[0].correct_index];
+    const correctOption = correctOptionText(0);
     fireEvent.click(screen.getByRole("button", { name: new RegExp(correctOption) }));
     fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
 
@@ -190,8 +191,7 @@ describe("STU-21 — Correct answer shown after submit", () => {
         curriculumId="default-2026-g8"
       />,
     );
-    const correctOption =
-      MOCK_QUIZ.questions[0].options[MOCK_QUIZ.questions[0].correct_index];
+    const correctOption = correctOptionText(0);
     fireEvent.click(screen.getByRole("button", { name: new RegExp(correctOption) }));
     fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
 
@@ -212,8 +212,7 @@ describe("STU-21 — Correct answer shown after submit", () => {
         curriculumId="default-2026-g8"
       />,
     );
-    const correctOption =
-      MOCK_QUIZ.questions[0].options[MOCK_QUIZ.questions[0].correct_index];
+    const correctOption = correctOptionText(0);
     fireEvent.click(screen.getByRole("button", { name: new RegExp(correctOption) }));
     fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
 
@@ -233,8 +232,7 @@ describe("STU-21 — Correct answer shown after submit", () => {
         curriculumId="default-2026-g8"
       />,
     );
-    const correctOption =
-      MOCK_QUIZ.questions[0].options[MOCK_QUIZ.questions[0].correct_index];
+    const correctOption = correctOptionText(0);
     fireEvent.click(screen.getByRole("button", { name: new RegExp(correctOption) }));
     fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
 
@@ -289,8 +287,7 @@ describe("STU-22 — Wrong answer shown after submit", () => {
     fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
 
     await waitFor(() => {
-      const correctOption =
-        MOCK_QUIZ.questions[0].options[MOCK_QUIZ.questions[0].correct_index];
+      const correctOption = correctOptionText(0);
       const buttons = container.querySelectorAll("button");
       const correctBtn = Array.from(buttons).find((b) =>
         b.textContent?.includes(correctOption),
@@ -340,8 +337,7 @@ describe("STU-23 — Score screen after quiz completion", () => {
 
   async function completeQuiz() {
     for (let q = 0; q < MOCK_QUIZ.questions.length; q++) {
-      const question = MOCK_QUIZ.questions[q];
-      const correctOption = question.options[question.correct_index];
+      const correctOption = correctOptionText(q);
 
       await waitFor(() => {
         expect(
@@ -465,8 +461,7 @@ describe("STU-24 — Session ID is passed to progress API", () => {
       />,
     );
 
-    const correctOption =
-      MOCK_QUIZ.questions[0].options[MOCK_QUIZ.questions[0].correct_index];
+    const correctOption = correctOptionText(0);
     fireEvent.click(screen.getByRole("button", { name: new RegExp(correctOption) }));
     fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
 
@@ -489,7 +484,7 @@ describe("STU-24 — Session ID is passed to progress API", () => {
     expect(screen.queryByText(/error/i)).toBeNull();
   });
 
-  it("submitAnswer is called with correct unit_id and question_index", async () => {
+  it("submitAnswer is called with the content's own question_id", async () => {
     render(
       <QuizPlayer
         quiz={MOCK_QUIZ}
@@ -498,16 +493,18 @@ describe("STU-24 — Session ID is passed to progress API", () => {
       />,
     );
 
-    const correctOption =
-      MOCK_QUIZ.questions[0].options[MOCK_QUIZ.questions[0].correct_index];
+    const correctOption = correctOptionText(0);
     fireEvent.click(screen.getByRole("button", { name: new RegExp(correctOption) }));
     fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
 
     await waitFor(() => {
+      // The server grades by question_id; it must be the id from the payload,
+      // not a synthesised `${unit_id}-Q${n}` that no content file uses.
       expect(mockSubmitAnswer).toHaveBeenCalledWith(
         expect.objectContaining({
-          unit_id: MOCK_QUIZ.unit_id,
-          question_index: 0,
+          session_id: MOCK_SESSION_ID,
+          question_id: MOCK_QUIZ.questions[0].question_id,
+          answer_index: MOCK_CORRECT_INDEXES[0],
         }),
       );
     });

--- a/web/tests/unit/quiz-player-scoring.test.tsx
+++ b/web/tests/unit/quiz-player-scoring.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for QuizPlayer scoring (#504).
+ *
+ * Two regressions live here:
+ *
+ * 1. The final question was counted twice when answered correctly: `correctCount`
+ *    had already been incremented by the REVIEWED reducer before `handleNext`
+ *    added `answerResult.correct` again. A student who got 3/5 right (last one
+ *    correct) saw 4/5. At full marks it sent score=6 for a 5-question quiz, which
+ *    the clamps quietly rewrote to 5 — that was the real cause of #460.
+ *
+ * 2. Scoring was client-side entirely. The quiz payload shipped the answer key and
+ *    the browser told the backend both `correct` per answer and the final `score`.
+ *    Grading is now the server's job: the player sends only the picked option, and
+ *    the result screen renders the score the server reports.
+ *
+ * Run with:
+ *   npm test -- quiz-player-scoring
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QuizPlayer } from "@/components/content/QuizPlayer";
+import type { QuizContent } from "@/lib/types/api";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockSubmitAnswer = vi.fn();
+const mockEndSession = vi.fn();
+
+vi.mock("@/lib/api/progress", () => ({
+  submitAnswer: (...args: unknown[]) => mockSubmitAnswer(...args),
+  endSession: (...args: unknown[]) => mockEndSession(...args),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, vals?: Record<string, unknown>) =>
+    vals ? `${key}:${JSON.stringify(vals)}` : key,
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return { ...actual, useQueryClient: () => ({ invalidateQueries: vi.fn() }) };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * 5 questions. Note there is NO correct_index here — the browser is not given the
+ * answer key. The server decides; option 0 is "Right" only by the mock's grading.
+ */
+const QUIZ: QuizContent = {
+  unit_id: "G8-SCI-001",
+  title: "Quiz — Set 1",
+  pass_threshold: 3,
+  subject: "Science",
+  questions: Array.from({ length: 5 }, (_, i) => ({
+    index: i,
+    question_id: `q${i + 1}`,
+    question: `Question ${i + 1}?`,
+    options: ["Right", "Wrong A", "Wrong B", "Wrong C"],
+  })),
+};
+
+const CORRECT = 0;
+const WRONG = 1;
+
+/** Server-side grading, simulated: option 0 is the correct one. */
+const SERVER_CORRECT_INDEX = 0;
+
+async function playQuiz(answers: number[]) {
+  for (let i = 0; i < answers.length; i++) {
+    const isLast = i === answers.length - 1;
+    const nextLabel = isLast ? /see results/i : /next question/i;
+
+    fireEvent.click(await screen.findByText(QUIZ.questions[i].options[answers[i]]));
+    fireEvent.click(screen.getByRole("button", { name: /submit answer/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: nextLabel })).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: nextLabel }));
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+describe("QuizPlayer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The server grades and returns the verdict + the reveal.
+    mockSubmitAnswer.mockImplementation(async ({ answer_index }) => ({
+      correct: answer_index === SERVER_CORRECT_INDEX,
+      correct_index: SERVER_CORRECT_INDEX,
+      explanation: "Because that is the right one.",
+    }));
+    mockEndSession.mockResolvedValue({
+      score: 3,
+      total: 5,
+      passed: true,
+      attempt_number: 1,
+    });
+  });
+
+  describe("server-side grading contract", () => {
+    it("submits only the picked option — never a correctness claim", async () => {
+      render(<QuizPlayer quiz={QUIZ} sessionId="s1" curriculumId="default-2026-g8" />);
+      await playQuiz([CORRECT, WRONG, WRONG, CORRECT, CORRECT]);
+
+      const firstCall = mockSubmitAnswer.mock.calls[0][0];
+      expect(firstCall).toEqual({
+        session_id: "s1",
+        question_id: "q1", // the content's own id, not a synthesised one
+        answer_index: 0,
+      });
+      // The client must not be asserting correctness or shipping the key back.
+      expect(firstCall).not.toHaveProperty("correct");
+      expect(firstCall).not.toHaveProperty("correct_index");
+    });
+
+    it("ends the session without sending a score", async () => {
+      render(<QuizPlayer quiz={QUIZ} sessionId="s1" curriculumId="default-2026-g8" />);
+      await playQuiz([CORRECT, WRONG, WRONG, CORRECT, CORRECT]);
+
+      await waitFor(() => expect(mockEndSession).toHaveBeenCalledTimes(1));
+      expect(mockEndSession).toHaveBeenCalledWith("s1");
+    });
+
+    it("renders the score the SERVER reports, not a locally counted one", async () => {
+      // Server says 2/5 even though the player locally saw 3 correct. The server wins.
+      mockEndSession.mockResolvedValue({
+        score: 2,
+        total: 5,
+        passed: false,
+        attempt_number: 1,
+      });
+
+      render(<QuizPlayer quiz={QUIZ} sessionId="s1" curriculumId="default-2026-g8" />);
+      await playQuiz([CORRECT, WRONG, WRONG, CORRECT, CORRECT]);
+
+      expect(await screen.findByText(/"score":2/)).toBeTruthy();
+    });
+  });
+
+  describe("reveal comes from the server response", () => {
+    it("shows the explanation returned with the verdict", async () => {
+      render(<QuizPlayer quiz={QUIZ} sessionId="s1" curriculumId="default-2026-g8" />);
+
+      fireEvent.click(await screen.findByText("Wrong A"));
+      fireEvent.click(screen.getByRole("button", { name: /submit answer/i }));
+
+      expect(await screen.findByText("Because that is the right one.")).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
Fixes the issues raised in Venki's 2026-07-11 test report, plus four defects found while root-causing them.

Most of the report turned out to be **three root causes, not twelve bugs**.

## What was actually wrong

**1. Students were being graded on fabricated content.** The quiz in the report — *"Sample question 1 about Mechanical Systems?"*, options *"Option A".."Option D"*, explanation *"Option A is correct because it best describes Mechanical Systems"* — is output from `scripts/seed_dev_content.py`. The seeders backfill any ungenerated unit with stubs tagged `model: "dev-placeholder"`, only where a file is absent, so they persist indefinitely and were served as though real. Grade 8 was **100% placeholder**: 20 of 20 units. The one grade that "worked" was the one that was entirely fake.

**2. The demo pointed at an empty curriculum namespace.** The seeder created `demo-2026-g{8,9,10}` and wired the classrooms to it; the pipeline generates into `default-2026-g*`. The Subjects tree rendered (read from `curriculum_units`, which the seeder writes) while every lesson and quiz 404'd — the reported *"This isn't available yet."*

This cascades into most of the school-admin complaints. The lesson page returns early before `startLessonView` when content fails to load, so no view event is ever emitted — which is why `LESSONS VIEWED=0`, `ACTIVE=0%`, `Last active: Never` and at-risk-is-everyone. Five "broken reports" were one broken content path.

Underneath it, **151 units across 11 curricula were generated, paid for, and invisible to the app** — `build_grade.py` writes files first, then upserts the DB inside a broad `except` that logs and continues (pitfalls #28/#29/#30), so generation "succeeds" while `curricula` / `curriculum_units` / `content_subject_versions` stay empty.

**3. The browser was the source of truth for quiz grades.** The payload shipped `correct_option` for every question; `POST /answer` accepted `correct: bool`; `POST /end` accepted `score: int`. The backend compared nothing. A student could read the answers from the network tab and post themselves a perfect score.

The reported **4/5 for a 3-of-5 run** was a client-side double-count of the final question. At full marks it sent `score: 6` for a 5-question quiz — which the clamps added for the earlier "8/5 = 160%" report quietly rewrote to 5. That clamp is exactly why the overflow was invisible at the top of the range and visible in the middle: the previous fix treated the symptom and hid the cause.

## Changes

| Commit | |
|---|---|
| `82bf15e` | Placeholder content is refused on both the store and cache paths — an ungenerated unit 404s honestly instead of serving fiction |
| `906d58e` | Demo consumes the real platform curricula; `backfill_content_registry.py` registers the 151 stranded units (idempotent, dry-run by default) |
| `e1f7b00` | `end_lesson_view` no longer raises `TypeError` on a missing row and gets retried forever as a poison message |
| `8a4d3df` | **BREAKING** — quizzes are graded server-side; the answer key never reaches the browser |
| `92147f6` | Pipeline reports the real LLM error and stops retrying permanent ones |
| `5009147` | Alembic announces its target database; CLAUDE.md pitfalls + migration 0061 |

### Server-side grading — two constraints shaped it

**Which set?** `question_id` is `q1…qN` in *all three* quiz sets with *different* correct options, so the id alone can't identify the answer. The server already picks the set, but the per-unit rotation pointer advances on every quiz fetch — reading it per answer would grade later answers against the wrong key if the student opened the unit in a second tab. The set is pinned per session and persisted to `progress_sessions.quiz_set` (migration 0061).

**Which score?** Answer writes are fire-and-forget Celery, so `end_session` *cannot* count `progress_answers` — the rows may not exist yet. That race is precisely why the original code trusted the client. The graded result is tallied in Redis (`INCR`, non-blocking, honouring the no-DB-write-on-the-request-path rule) and read back at end of session, falling back to persisted answers only if Redis lost it.

## Breaking change

`RecordAnswerRequest` drops `correct` and `correct_answer`; `EndSessionRequest` drops `score`; the quiz payload drops `correct_option` and `explanation` (revealed per-question in the answer response instead). The Kivy mobile client still grades locally from a `correct_index` it will no longer receive — it's parked behind the Expo rewrite (Epic 3) and has the same hole; it needs the same treatment.

## Test plan

- Backend **1175 passed, 0 failed** · web **839 passed, 0 failed** · prettier, eslint, typecheck clean
- **Cheat attempt, live API:** a client answering every question wrong, claiming `correct: true` on each, and posting `99/99` is recorded as **0/8, failed**
- **Honest run, live API:** 6 of 8 correct scores **6/8, passed** — and the two runs drew *different* quiz sets, each graded against its own pinned key
- **Grade 10 student → `GET /content/G10-ENG-001/lesson` → 200**, real Sonnet content ("Statics and Structural Analysis") — the exact unit that 404'd in the report
- **Grade 8 → 404** until its pipeline run completes, rather than serving stubs
- Backfill verified idempotent (second run registers 0)

## Notes for the reviewer

- **Migration 0061** adds a nullable `quiz_set` column. Apply with `docker compose exec -e TEST_DB_URL= api alembic upgrade head` — without that flag it migrates `studybuddy_test` and reports success (new pitfall #34; `env.py` now prints its target).
- The Grade 8 pipeline run is **in progress** and not part of this PR (content isn't tracked). Until it lands, G8 units 4–20 will 404 by design.
- Not addressed here, all confirmed with root causes: the billing-portal endpoint doesn't exist (`GET /subscription/billing-portal` — 404 hidden by an empty `catch {}`); the `/visuals` 500 (Next `rewrites()` baked at build time without `INTERNAL_API_URL`); tutorial/experiment pages emit no analytics; `curriculum_id` hardcoded to `"default"` on the lesson/quiz pages; "active" counted from `lesson_views` only, so a quiz-only student reads as inactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)