### PR TITLE
chore(deps): fix aiosmtplib CVE-2026-53533; document unfixable ecdsa advisory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,19 @@ jobs:
         #   stack supports starlette 1.x.
         # python-multipart CVE-2026-53538/53539/53540 are FIXED by the 0.0.31 bump in
         #   requirements.txt (no ignore needed).
-        run: pip-audit -r requirements.txt --ignore-vuln PYSEC-2024-55 --ignore-vuln GHSA-5239-wwwm-4pmq --ignore-vuln PYSEC-2026-161 --ignore-vuln CVE-2026-48817 --ignore-vuln CVE-2026-48818 --ignore-vuln CVE-2026-54282 --ignore-vuln CVE-2026-54283
+        # aiosmtplib CVE-2026-53533 (SMTP command injection via CR/LF in addresses) is
+        #   FIXED by the 5.1.1 bump in requirements.txt (no ignore needed). It was
+        #   directly reachable: we pass user-supplied addresses (registration, demo
+        #   requests, password reset) into aiosmtplib.send().
+        # PYSEC-2026-1325: ecdsa — no fix version exists; upstream declines to harden
+        #   against timing side-channels, stating the library is not intended for
+        #   high-security use. It is a transitive dependency of python-jose and is never
+        #   exercised here: we sign with HS256 (HMAC) and verify Auth0 tokens with RS256
+        #   (RSA, handled by `cryptography`). No ES256/ES384/ES512 anywhere in the
+        #   codebase, so no ECDSA operation is ever performed. Revisit if an EC algorithm
+        #   is ever introduced, or if python-jose is replaced (it is the only thing
+        #   pulling ecdsa in).
+        run: pip-audit -r requirements.txt --ignore-vuln PYSEC-2024-55 --ignore-vuln GHSA-5239-wwwm-4pmq --ignore-vuln PYSEC-2026-161 --ignore-vuln CVE-2026-48817 --ignore-vuln CVE-2026-48818 --ignore-vuln CVE-2026-54282 --ignore-vuln CVE-2026-54283 --ignore-vuln PYSEC-2026-1325
 
   # ── 2. Backend tests + coverage ──────────────────────────────────────────────
   backend-test:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,7 +20,7 @@ slowapi==0.1.9
 alembic==1.18.4
 psycopg2-binary==2.9.9
 python-multipart==0.0.31
-aiosmtplib==3.0.1
+aiosmtplib==5.1.1
 
 stripe>=7.0.0
 


### PR DESCRIPTION
`pip-audit` (the "Backend — Lint & Security" gate) has been red on `main` since at least 2026-07-10 on two advisories against an unchanged dependency set. This unblocks it. Split out of #506 so a dependency/security change isn't buried in a behavioural PR.

## aiosmtplib 3.0.1 → 5.1.1 — real fix

**CVE-2026-53533** (CWE-93, CRLF injection): `SMTP.mail()/rcpt()/vrfy()/expn()` sent caller-supplied addresses to the server without rejecting embedded CR/LF, enabling SMTP command injection.

**Directly reachable in our code** — we pass user-supplied addresses (registration, demo requests, password reset) straight into `aiosmtplib.send()` (`backend/src/email/service.py`). 5.1.1 rejects C0 control characters (CR/LF/NUL) in command arguments *before anything is written to the connection* (`protocol.py`: `"Command arg contains a prohibited control character"`), confirmed in the shipped 5.1.1 source and the [upstream advisory GHSA-v3q9-hj7j-63hq](https://github.com/cole/aiosmtplib/security/advisories/GHSA-v3q9-hj7j-63hq).

Compatibility: the only breaking changes across 4.x/5.x are Python-version drops (5.x needs ≥3.10; we run 3.11). The top-level `send()` signature (`hostname`/`port`/`username`/`password`/`start_tls`/`tls_context`) and `SMTPException` are unchanged — verified against a clean 5.1.1 install.

## ecdsa PYSEC-2026-1325 — ignored, with justification

**No fix version exists.** Upstream declines to harden against the timing side-channel, stating the library is not intended for high-security use. It is a transitive dependency of `python-jose` and is **never exercised here**: we sign with **HS256** (HMAC) and verify Auth0 tokens with **RS256** (RSA, handled by `cryptography`). There is no `ES256`/`ES384`/`ES512` anywhere in the codebase, so no ECDSA operation is ever performed.

Added to the `pip-audit --ignore-vuln` list with that reasoning inline, matching the existing convention in `test.yml`. The comment flags when to revisit: if an EC algorithm is introduced, or `python-jose` (the only thing pulling `ecdsa` in) is replaced.

## Test plan

- `pip-audit -r requirements.txt` with the updated ignore list → **"No known vulnerabilities found, 7 ignored"**
- `tests/test_retention_emails.py` + `tests/test_auth.py` (the email send path) → **25 passed** against 5.1.1
- `src.email.service` imports cleanly; `send()` kwargs and `SMTPException` verified present in 5.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)