### PR TITLE
chore(scripts): make admin/demo seed passwords env-overridable

### DIFF
--- a/backend/scripts/seed_demo_test_account.py
+++ b/backend/scripts/seed_demo_test_account.py
@@ -42,7 +42,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 DEMO_EMAIL = "demo-test@studybuddy.dev"
-DEMO_PASSWORD = "DemoTest-2026!"
+DEMO_PASSWORD = os.environ.get("DEMO_STUDENT_PASSWORD", "DemoTest-2026!")
 DEMO_GRADE = 8
 DEMO_LOCALE = "en"
 

--- a/backend/scripts/seed_phase_a_dev.py
+++ b/backend/scripts/seed_phase_a_dev.py
@@ -44,7 +44,7 @@ SCHOOL_A_ADMIN = {
     "teacher_id": "d0000000-0000-0000-0000-000000000010",
     "name": "Dev Admin",
     "email": "admin@devschool.dev",
-    "password": "DevAdmin1234!",
+    "password": os.environ.get("PHASE_A_SCHOOL_A_ADMIN_PASSWORD", "DevAdmin1234!"),
     "role": "school_admin",
 }
 
@@ -79,7 +79,7 @@ SCHOOL_B_ADMIN = {
     "teacher_id": "d0000000-0000-0000-0000-000000000030",
     "name": "Dev Admin B",
     "email": "admin@devschoolb.dev",
-    "password": "DevAdminB1234!",
+    "password": os.environ.get("PHASE_A_SCHOOL_B_ADMIN_PASSWORD", "DevAdminB1234!"),
     "role": "school_admin",
 }
 

--- a/backend/scripts/setup_dev.py
+++ b/backend/scripts/setup_dev.py
@@ -59,7 +59,7 @@ DEV_SCHOOL_ADMIN_SUB   = "dev|school-admin-001"
 CURRICULUM_ID          = "default-2026-g8"
 
 DEV_ADMIN_EMAIL        = "dev.admin@studybuddy.dev"
-DEV_ADMIN_PASSWORD     = "DevAdmin1234!"
+DEV_ADMIN_PASSWORD     = os.environ.get("DEV_ADMIN_PASSWORD", "DevAdmin1234!")
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -530,7 +530,7 @@ def print_summary() -> None:
     print("  School Admin    http://localhost:3000/school/dashboard   /dev-login → School Admin")
     print("  Admin           http://localhost:3000/admin/login        dev.admin@studybuddy.dev")
     print()
-    print("  Admin password: DevAdmin1234!")
+    print(f"  Admin password: {DEV_ADMIN_PASSWORD}")
     print()
     print("  Dev login page: http://localhost:3000/dev-login")
     print()


### PR DESCRIPTION
## Why

Privileged seed passwords were hardcoded literals in `backend/scripts/`, so:
1. a real/demo deployment could only get a strong admin password by editing code, and
2. weak defaults (`DevAdmin1234!`, etc.) were committed to git.

This follows the pattern already used in `seed_super_admin.py` — `os.environ.get("VAR", "<dev default>")` — so operators override via env, local dev is unchanged.

## What

| File | Change |
|---|---|
| `seed_demo_test_account.py` | `DEMO_PASSWORD` ← `DEMO_STUDENT_PASSWORD` env |
| `setup_dev.py` | `DEV_ADMIN_PASSWORD` ← env; summary `print` now references the constant instead of a duplicated literal |
| `seed_phase_a_dev.py` | both `school_admin` passwords ← env |

## Scope note

Only **admin/privileged + the primary demo-flow** passwords are made env-overridable. Non-privileged dev/demo fixtures (teacher/student rows, the milfordwaterford demo roster) are left as literals — they seed throwaway demo accounts, and per-account env vars would add noise without security value. `seed_super_admin.py` already used this pattern and is untouched.

## Safety

- Defaults unchanged → existing local dev / seed flows behave identically.
- `python -m py_compile` passes on all three files.
- To use in demo/prod: set `DEMO_STUDENT_PASSWORD`, `DEV_ADMIN_PASSWORD`, `PHASE_A_SCHOOL_A_ADMIN_PASSWORD`, `PHASE_A_SCHOOL_B_ADMIN_PASSWORD` in the environment.

Context: hardening after weak seed passwords were found committed to the private docs repo. The permanent fix is env-driven secrets; rotating the live demo admin password is a separate operator step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)