### PR TITLE
security: remove hardcoded default super-admin password

### DIFF
--- a/backend/scripts/seed_super_admin.py
+++ b/backend/scripts/seed_super_admin.py
@@ -4,7 +4,8 @@ backend/scripts/seed_super_admin.py
 
 Creates (or updates) the super admin account in the database.
 
-Reads credentials from env vars; falls back to the defaults in .env.
+Reads credentials from env vars. SUPER_ADMIN_PASSWORD is REQUIRED — there is no
+hardcoded default, so a known password can never be shipped to a deploy.
 
 Usage:
     # From backend/ directory:
@@ -31,7 +32,24 @@ load_dotenv(_here / ".env")
 
 DATABASE_URL = os.environ["DATABASE_URL"]
 SUPER_ADMIN_EMAIL = os.environ.get("SUPER_ADMIN_EMAIL", "wegofwd2020@gmail.com")
-SUPER_ADMIN_PASSWORD = os.environ.get("SUPER_ADMIN_PASSWORD", "Admin1234!")
+
+# SECURITY: no hardcoded default. A default here previously shipped a known
+# super-admin password to the internet-facing demo (seed.sh runs this script
+# without setting the env var). The password MUST come from the environment,
+# and we reject obviously-weak or previously-leaked values.
+_WEAK_PASSWORDS = frozenset({"Admin1234!", "admin", "password", "changeme", "demo"})
+SUPER_ADMIN_PASSWORD = os.environ.get("SUPER_ADMIN_PASSWORD", "")
+if not SUPER_ADMIN_PASSWORD:
+    sys.exit(
+        "[seed_super_admin] SUPER_ADMIN_PASSWORD is required (no default). "
+        "Set a strong value, e.g.:\n"
+        "  SUPER_ADMIN_PASSWORD='<strong-secret>' python scripts/seed_super_admin.py"
+    )
+if len(SUPER_ADMIN_PASSWORD) < 12 or SUPER_ADMIN_PASSWORD in _WEAK_PASSWORDS:
+    sys.exit(
+        "[seed_super_admin] SUPER_ADMIN_PASSWORD is too weak — use at least 12 "
+        "characters and not a known default."
+    )
 
 
 def _hash(password: str) -> str:

--- a/docs/DEMO_LAUNCH_PLAN.md
+++ b/docs/DEMO_LAUNCH_PLAN.md
@@ -609,7 +609,7 @@ docker compose --env-file .env.demo exec api bash /app/scripts/demo/seed.sh
 
 What it does:
 1. `alembic upgrade head` (idempotent; skips if at head)
-2. `python scripts/seed_super_admin.py` — creates `wegofwd2020@gmail.com` / Admin1234! (writes credentials to a one-shot file with `chmod 600`)
+2. `python scripts/seed_super_admin.py` — creates `wegofwd2020@gmail.com`; the password comes from `SUPER_ADMIN_PASSWORD` (required — no default). `seed.sh` generates a strong random one if unset and writes it to a `chmod 600` one-shot file.
 3. `python scripts/seed_demo_milfordwaterford.py` — MilfordWaterford school + 4 teachers + 15 students (matches DEMO_WALKTHROUGH.md §0 exactly)
 4. `python scripts/seed_demo_test_account.py` — public "Try it" student (`demo-test@studybuddy.dev`)
 5. `python scripts/seed_phase_a_dev.py` — Dev School + Phase A local-auth admin

--- a/scripts/demo/seed.sh
+++ b/scripts/demo/seed.sh
@@ -48,7 +48,20 @@ info "pre-flight — running alembic upgrade head (idempotent)"
 alembic upgrade head
 
 # ── Step 1: super admin ────────────────────────────────────────────────────
-info "step 1/5 — super admin (wegofwd2020@gmail.com)"
+# seed_super_admin.py now REQUIRES SUPER_ADMIN_PASSWORD (no hardcoded default,
+# so a known password can never ship). If the operator didn't supply one,
+# generate a strong random password and write it once to a chmod-600 file.
+if [ -z "${SUPER_ADMIN_PASSWORD:-}" ]; then
+  SUPER_ADMIN_PASSWORD="$(openssl rand -base64 24 | tr -d '/+=' | cut -c1-24)Aa1!"
+  export SUPER_ADMIN_PASSWORD
+  cred_file="${SUPER_ADMIN_CRED_FILE:-./super_admin_credentials.txt}"
+  ( umask 177; printf 'super_admin email:    %s\nsuper_admin password: %s\n' \
+      "${SUPER_ADMIN_EMAIL:-wegofwd2020@gmail.com}" "$SUPER_ADMIN_PASSWORD" > "$cred_file" )
+  chmod 600 "$cred_file"
+  warn "  no SUPER_ADMIN_PASSWORD set — generated a random one → $cred_file (chmod 600)."
+  warn "  record it somewhere safe, then delete that file."
+fi
+info "step 1/5 — super admin (${SUPER_ADMIN_EMAIL:-wegofwd2020@gmail.com})"
 if python scripts/seed_super_admin.py 2>&1 | tee /tmp/seed_super_admin.log; then
   info "  done"
 else


### PR DESCRIPTION
## Problem
`backend/scripts/seed_super_admin.py` defaulted `SUPER_ADMIN_PASSWORD` to `Admin1234!` when the env var was unset. `scripts/demo/seed.sh` (the demo seed orchestrator) runs the script **without** setting that variable, so any demo seeded via `seed.sh` provisions the super-admin `wegofwd2020@gmail.com` with a **publicly-documented, weak password** on an **internet-facing admin login** (`POST /api/v1/admin/auth/login`, confirmed mounted by `scripts/demo/smoke.sh`, on `demo.usestudybuddy.com`).

This is a real credential exposure, not local-only.

## Fix
- **`seed_super_admin.py`** — `SUPER_ADMIN_PASSWORD` is now **required** (no default). Rejects empty, `<12` chars, or known-weak/leaked values (including the old `Admin1234!`). Fails closed with a clear message.
- **`seed.sh`** — if the operator didn't set `SUPER_ADMIN_PASSWORD`, generate a **strong random** one and write it to a `chmod 600` one-shot file, so the demo workflow still works with zero hardcoded secret.
- **`DEMO_LAUNCH_PLAN.md`** — stop printing the old default.

## Verification
- `python3 -m py_compile` passes.
- Guard logic (isolated): unset → exit 1 (required); `Admin1234!` → exit 1 (weak); `short1!` → exit 1 (weak); strong passphrase → accepted.
- `bash -n seed.sh` passes; generated password sample is 28 chars, meets the ≥12 policy.
- No test referenced the old default (grep clean), so the suite is unaffected.

## NOT in this PR (follow-ups)
1. **Operational rotation of the live demo** — if a demo was already seeded with the default, rotate now: `SUPER_ADMIN_PASSWORD='<strong>' python scripts/seed_super_admin.py` (UPSERT resets the hash). This code change does not touch the live DB.
2. Sibling dev-only defaults (`DevAdmin1234!` in `setup_dev.py`, `seed_phase_a_dev.py`, `vm-localhost-bootstrap.sh`) — localhost/dev, lower severity; worth the same treatment separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)