### PR TITLE
fix(metrics): define sb_celery_queue_depth once, not per poll (#518)

### DIFF
--- a/backend/src/auth/tasks.py
+++ b/backend/src/auth/tasks.py
@@ -362,13 +362,9 @@ def poll_infra_metrics() -> None:
     from config import settings as cfg
 
     try:
-        from prometheus_client import Gauge
-
-        celery_queue_depth = Gauge(
-            "sb_celery_queue_depth",
-            "Number of tasks waiting in each Celery queue",
-            ["queue"],
-        )
+        # Metric is defined once at module import in core.observability; defining
+        # it here re-registered it on every poll -> "Duplicated timeseries" (#518).
+        from src.core.observability import celery_queue_depth
 
         # ── Queue depth via Redis LLEN ─────────────────────────────────────────
         r = redis_sync.from_url(cfg.REDIS_URL)

--- a/backend/src/core/observability.py
+++ b/backend/src/core/observability.py
@@ -63,6 +63,12 @@ redis_connected = Gauge(
     "1 if Redis is reachable, 0 otherwise",
 )
 
+celery_queue_depth = Gauge(
+    "sb_celery_queue_depth",
+    "Number of tasks waiting in each Celery queue",
+    ["queue"],
+)
+
 auth_exchanges_total = Counter(
     "sb_auth_exchanges_total",
     "Successful auth token exchanges",


### PR DESCRIPTION
Closes #518.

## Problem
`poll_infra_metrics` (Celery Beat, every 30s) constructed the Gauge **inside the task body**:
```python
celery_queue_depth = Gauge("sb_celery_queue_depth", ...)   # re-registered every run
```
`prometheus_client` registers a metric at construction, so the 2nd poll onward raised `ValueError: Duplicated timeseries in CollectorRegistry`. The task caught it (`metrics_poll_failed`) and returned `None` — so `sb_celery_queue_depth` was collected **once per worker lifetime**, then silently stopped. Observed on the demo worker.

## Fix
Move the Gauge to `core/observability.py`, where every other metric already lives at module level (`db_pool_connections`, `redis_connected`, …). The task imports it and calls `.labels().set()`. Module import is once-per-process → no re-registration.

## Verification
- `py_compile` passes both files.
- Behavior is standard `prometheus_client`: constructing a same-named metric twice raises; defining once + `.set()` repeatedly does not. The fix converts the code from the former to the latter.
- Lazy import inside the task → no circular-import risk (observability doesn't import auth.tasks).

## Diff
2 files, +9/-7 — mechanical move, no behavior change beyond fixing the registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)