### PR TITLE
fix(demo): serve /visuals from nginx instead of the Next rewrite

### DIFF
--- a/scripts/demo/nginx.conf
+++ b/scripts/demo/nginx.conf
@@ -14,6 +14,7 @@
 #         /api/*           → fastapi container
 #         /healthz, /readyz, /metrics → fastapi container
 #         /content/*       → bind-mount /srv/content/   (lesson JSON + audio)
+#         /visuals/*       → bind-mount /srv/content/visuals/ (visual library)
 #         /sample-visuals/*→ bind-mount /srv/sample-visuals/ (44 tutorial MP4s)
 #         /                → next.js container
 #
@@ -122,6 +123,36 @@ http {
       alias /srv/content/;
       add_header Cache-Control "public, max-age=3600";
       access_log off;   # high-volume, low signal
+    }
+
+    # ── /visuals/* → visual-library assets from /data/content/visuals ───────
+    # Lesson/tutorial content references visuals as /visuals/<path> (the
+    # default VISUAL_STORAGE_PUBLIC_BASE_URL, backend/src/visuals/storage.py).
+    # Without this block the request falls through to `location /` → Next.js,
+    # which rewrites /visuals/* to whatever origin was baked into
+    # routes-manifest.json at BUILD time (web/next.config.ts). The demo image
+    # is built in CI without INTERNAL_API_URL, so that origin is
+    # http://localhost:8000 — nothing listens there inside the web container
+    # and every /visuals/* request 500s. Serving the bytes here removes the
+    # dependency on a build-time value entirely (issue #522).
+    #
+    # Path coupling: this alias assumes the backend's local visual root, i.e.
+    # VISUAL_STORAGE_LOCAL_PATH unset and CONTENT_STORE_PATH=/data/content
+    # (docker-compose.yml:46) — the same /data/content the `/content/` block
+    # above already serves. If VISUAL_STORAGE_BACKEND is ever flipped to s3 on
+    # this box, visuals come from the CDN and this block goes inert.
+    location /visuals/ {
+      alias /srv/content/visuals/;
+      add_header Cache-Control "public, max-age=3600";
+      access_log off;   # high-volume, low signal — same rationale as /content/
+    }
+
+    # The bare path (no trailing slash) is not matched by `location /visuals/`
+    # above, so without this it would still fall through to Next.js and 500 —
+    # and it is the exact URL in the 07-11 QA report. There is no asset at the
+    # bare prefix; 404 is the honest answer.
+    location = /visuals {
+      return 404;
     }
 
     # ── /sample-visuals/* → static MP4s + SVGs from /data/sample-visuals ────


### PR DESCRIPTION
Closes #522. From the 2026-07-11 QA report (Venki); still reproducing on demo as of 2026-07-29.

## What

Adds two nginx locations to `scripts/demo/nginx.conf` so `/visuals/*` is served as static files from the existing content bind-mount, instead of falling through to Next.js.

```nginx
location /visuals/ {
  alias /srv/content/visuals/;
  add_header Cache-Control "public, max-age=3600";
  access_log off;
}

location = /visuals { return 404; }
```

Config-only. No application code touched.

## Why

`https://demo.usestudybuddy.com/visuals` returned **500**. Two gaps combined:

1. **No `/visuals/` location.** The compose nginx routes `/api/v1/`, `/healthz|readyz|metrics`, `/content/`, and `/sample-visuals/` to their upstreams and everything else to Next.js. `/visuals/` was the missing sibling of `/content/`.

2. **Next then proxied it to an address that does not exist inside its own container.** `web/next.config.ts:74-88` rewrites `/visuals/:path*` to `${backendOrigin}`, and `backendOrigin` falls back to `http://localhost:8000` when `INTERNAL_API_URL` is unset. Rewrites are resolved at **build** time into `routes-manifest.json`; the demo image is built in CI (`deploy-demo.yml:85-96`) passing only `NEXT_PUBLIC_DEMO_MODE` as a build-arg. So `localhost:8000` is baked in. `docker-compose.demo.yml:205` does set `INTERNAL_API_URL` — but that is runtime env and cannot reach back into a compiled manifest. Nothing listens on that port inside the web container → ECONNREFUSED → 500.

`/api/v1/*` shares the same broken `backendOrigin` and never shows it, because nginx intercepts that prefix before Next.js ever sees it. `/visuals/` had no such shadow.

## Why `alias` and not `proxy_pass` to the API

The issue originally proposed proxying to `$api_upstream`. Serving the bytes directly is better here:

- nginx **already** bind-mounts `/data/content` → `/srv/content` (`docker-compose.demo.yml:237`), and the backend's visual root is `${CONTENT_STORE_PATH}/visuals` = `/data/content/visuals` (`docker-compose.yml:46`, `app_factory.py:392`). `/visuals/` is a second name for a directory already served under `/content/`.
- Matches the file's established pattern — `/content/` and `/sample-visuals/` are both static aliases, with "faster than proxying via FastAPI" as the stated rationale.
- Removes the dependency on a build-time value entirely, and survives an `api` container roll.

Coupling is documented in the config comment: the alias assumes `VISUAL_STORAGE_LOCAL_PATH` unset and `CONTENT_STORE_PATH=/data/content`. If `VISUAL_STORAGE_BACKEND` is flipped to `s3` on this box, visuals come from the CDN and the block goes inert.

## Why the second (exact-match) location

nginx prefix locations match literally, trailing slash included — `location /visuals/` does **not** match bare `/visuals`, which is the exact URL in the QA report. Without the exact-match it would still fall through to Next.js and 500 while every `/visuals/<something>` path passed. There is no asset at the bare prefix, so 404 is the honest answer.

## Test plan

`nginx -t` passes, but syntax-only was not enough here — verified against a real nginx container with a content mount:

```bash
docker run -d --name sb-nginx-probe -p 18443:8443 \
  -v "$(pwd)/scripts/demo/nginx.conf:/etc/nginx/nginx.conf:ro" \
  -v "$SCRATCH/fakecontent:/srv/content:ro" nginx:alpine
```

| Path | Before | After |
|---|---|---|
| `/visuals` | 500 | **404** |
| `/visuals/` | 308 → 500 | 403 (matches `/content/`) |
| `/visuals/G11-PHYS-001/diagram.svg` | 500 | **200**, `image/svg+xml`, `max-age=3600` |
| `/visuals/missing.svg` | 500 | 404 |
| `/content/probe.json` | 200 | 200 (no regression) |

Traversal: `/visuals/../probe.json` is normalised by nginx *before* location matching, resolves to `/probe.json`, and matches `location /`. The alias cannot be walked out of.

**Post-merge check:** `curl -o /dev/null -w '%{http_code}' https://demo.usestudybuddy.com/visuals` → expect 404, not 500.

## Risk

Low. Config-only, additive — two new locations, no existing block modified. Worst case is that `/data/content/visuals` is empty on the VPS and `/visuals/*` 404s honestly instead of 500ing.

`deploy-demo.yml` runs on push to `main` and already force-recreates the nginx service specifically to pick up `nginx.conf` edits (lines 142-163, the bind-mount inode problem), so no manual step is needed on the box.

## Scope — correctness, not necessarily visibility

Checked the live demo content: `G10-ENG-001` and `G10-SCI-001` lesson + tutorial payloads contain **zero** `/visuals/` references. No student-facing image is currently blocked by this bug — the 500 was reachable by requesting the URL directly. Whether `/data/content/visuals` on the VPS holds any assets is unverified (needs SSH).

## Not addressed

The underlying footgun survives: `next.config.ts:10-12` still falls back to `http://localhost:8000` when `INTERNAL_API_URL` is unset, and `deploy-demo.yml:93` still omits it from `build-args`. Any *future* rewrite not shadowed by an nginx location hits the same 500. The durable fix is to pass `INTERNAL_API_URL` as a build-arg (with a matching `ARG`/`ENV` in `web/Dockerfile` before `npm run build`) and fail the production build when it is unset, rather than defaulting to a value that is silently wrong in every deployed environment. Left out of this PR to keep it config-only; see the discussion on #522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
