### PR TITLE
fix(progress): resolve the quiz curriculum server-side, not from the client

### DIFF
--- a/backend/src/analytics/router.py
+++ b/backend/src/analytics/router.py
@@ -40,6 +40,7 @@ from src.analytics.service import (
     verify_view_owner,
 )
 from src.auth.dependencies import get_current_student, get_current_teacher
+from src.content.service import resolve_curriculum_id
 from src.core.db import get_db
 from src.core.subjects import display_subject, resolve_subject_labels
 from src.utils.logger import get_logger
@@ -63,13 +64,24 @@ async def lesson_start(
     student_id = student["student_id"]
     cid = getattr(request.state, "correlation_id", "")
 
+    # Resolved server-side, like the quiz session (#524). The web client sent a
+    # hardcoded "default" here too, which is what every lesson_views row was
+    # attributed to.
+    curriculum_id = await resolve_curriculum_id(
+        student_id,
+        student.get("grade", 8),
+        request.app.state.pool,
+        request.app.state.redis,
+        school_id=student.get("school_id"),
+    )
+
     async with get_db(request) as conn:
         try:
             result = await start_lesson_view(
                 conn,
                 student_id=student_id,
                 unit_id=body.unit_id,
-                curriculum_id=body.curriculum_id,
+                curriculum_id=curriculum_id,
             )
         except Exception as exc:
             log.error("lesson_start_failed", error=str(exc), correlation_id=cid)

--- a/backend/src/analytics/schemas.py
+++ b/backend/src/analytics/schemas.py
@@ -10,8 +10,10 @@ from pydantic import BaseModel
 
 
 class LessonStartRequest(BaseModel):
+    """`curriculum_id` is accepted for older clients and ignored — see #524."""
+
     unit_id: str
-    curriculum_id: str
+    curriculum_id: str | None = None
 
 
 class LessonStartResponse(BaseModel):

--- a/backend/src/progress/router.py
+++ b/backend/src/progress/router.py
@@ -28,7 +28,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from src.auth.dependencies import get_current_student
-from src.content.service import get_quiz_answer_key
+from src.content.service import get_quiz_answer_key, resolve_curriculum_id
 from src.core.db import get_db
 from src.core.storage import StorageBackend, get_storage
 from src.progress.schemas import (
@@ -70,13 +70,25 @@ async def start_session(
     student_id = student["student_id"]
     cid = getattr(request.state, "correlation_id", "")
 
+    # The curriculum is resolved here, not taken from the request. Whatever the
+    # client sends in `curriculum_id` is ignored — grading looks the answer key up
+    # under whatever this session stores, so a client-supplied value that doesn't
+    # resolve in the content store makes every answer 404 (#524).
+    curriculum_id = await resolve_curriculum_id(
+        student_id,
+        student.get("grade", 8),
+        request.app.state.pool,
+        request.app.state.redis,
+        school_id=student.get("school_id"),
+    )
+
     async with get_db(request) as conn:
         try:
             result = await create_session(
                 conn,
                 student_id=student_id,
                 unit_id=body.unit_id,
-                curriculum_id=body.curriculum_id,
+                curriculum_id=curriculum_id,
             )
         except Exception as exc:
             log.error("start_session_failed", error=str(exc), correlation_id=cid)

--- a/backend/src/progress/schemas.py
+++ b/backend/src/progress/schemas.py
@@ -12,8 +12,19 @@ from pydantic import BaseModel, Field
 
 
 class StartSessionRequest(BaseModel):
+    """
+    Open a quiz session.
+
+    `curriculum_id` is accepted for backwards compatibility with older clients
+    and then IGNORED — the server resolves the student's curriculum itself. The
+    web client used to send a hardcoded "default", which the session stored and
+    grading later looked the answer key up under; nothing resolves under that id,
+    so every answer 404'd (#524). Same rule as locale: authoritative server-side,
+    never taken from the request.
+    """
+
     unit_id: str = Field(..., min_length=1, max_length=64)
-    curriculum_id: str = Field(..., min_length=1, max_length=64)
+    curriculum_id: str | None = Field(default=None, max_length=64, deprecated=True)
 
 
 class RecordAnswerRequest(BaseModel):

--- a/backend/tests/test_progress.py
+++ b/backend/tests/test_progress.py
@@ -274,6 +274,92 @@ async def test_client_cannot_inflate_its_own_score(client, db_conn, student_toke
 
 
 @pytest.mark.asyncio
+async def test_session_curriculum_is_resolved_server_side(client, db_conn):
+    """
+    The curriculum the session is graded against comes from the server, not the body.
+
+    The web client used to send a hardcoded "default" here (#524). The session
+    stored it verbatim and grading looked the answer key up under that id, which
+    resolves to nothing in the content store — so every Submit 404'd and the quiz
+    button went dead. Same rule as locale: authoritative from the JWT/server.
+    """
+    from jose import jwt as _jwt
+    token = make_student_token(student_id="f2000000-0000-0000-0000-000000000097", grade=8)
+    payload = _jwt.decode(token, "test-secret-do-not-use-in-production-aaaa", algorithms=["HS256"])
+    await _insert_student(client, payload["student_id"])
+
+    with patch("src.auth.tasks.celery_app.send_task", return_value=None):
+        r = await client.post(
+            "/api/v1/progress/session",
+            json={"unit_id": "G8-MATH-001", "curriculum_id": "default"},  # client's claim
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert r.status_code == 201, r.text
+    # Grade 8, no school → the STEM default package, NOT the "default" sent above.
+    assert r.json()["curriculum_id"] == "default-2026-g8"
+
+
+@pytest.mark.asyncio
+async def test_grading_uses_the_resolved_curriculum_not_the_clients(client, db_conn):
+    """
+    The answer-key lookup is keyed by the resolved curriculum, whatever the client sent.
+
+    Asserting on the kwarg rather than the response is deliberate: the previous
+    tests all stubbed get_quiz_answer_key and never checked what it was called
+    with, which is exactly how #524 shipped green.
+    """
+    from jose import jwt as _jwt
+    token = make_student_token(student_id="f3000000-0000-0000-0000-000000000096", grade=8)
+    payload = _jwt.decode(token, "test-secret-do-not-use-in-production-aaaa", algorithms=["HS256"])
+    await _insert_student(client, payload["student_id"])
+
+    captured: dict = {}
+
+    async def _capture(**kwargs):
+        captured.update(kwargs)
+        return _ANSWER_KEY_8Q
+
+    with patch("src.auth.tasks.celery_app.send_task", return_value=None), \
+         patch("src.progress.router.get_quiz_answer_key", new=_capture):
+        r = await client.post(
+            "/api/v1/progress/session",
+            json={"unit_id": "G8-MATH-001", "curriculum_id": "default"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 201, r.text
+        session_id = r.json()["session_id"]
+
+        r = await client.post(
+            f"/api/v1/progress/session/{session_id}/answer",
+            json={"question_id": "q1", "student_answer": 0, "ms_taken": 100},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert r.status_code == 200, r.text
+    assert captured["curriculum_id"] == "default-2026-g8"
+
+
+@pytest.mark.asyncio
+async def test_start_session_without_curriculum_id_is_accepted(client, db_conn):
+    """The field is optional — the client has no business supplying it at all."""
+    from jose import jwt as _jwt
+    token = make_student_token(student_id="f4000000-0000-0000-0000-000000000095", grade=8)
+    payload = _jwt.decode(token, "test-secret-do-not-use-in-production-aaaa", algorithms=["HS256"])
+    await _insert_student(client, payload["student_id"])
+
+    with patch("src.auth.tasks.celery_app.send_task", return_value=None):
+        r = await client.post(
+            "/api/v1/progress/session",
+            json={"unit_id": "G8-MATH-001"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert r.status_code == 201, r.text
+    assert r.json()["curriculum_id"] == "default-2026-g8"
+
+
+@pytest.mark.asyncio
 async def test_end_session_not_passed_below_threshold(client, db_conn, student_token):
     """Session end computes passed = False when score / total < 0.6."""
     from jose import jwt as _jwt

--- a/web/app/(student)/lesson/[unit_id]/page.tsx
+++ b/web/app/(student)/lesson/[unit_id]/page.tsx
@@ -32,9 +32,8 @@ export default function LessonPage({ params }: PageProps) {
   // sessions that cluttered Progress History with bogus/duplicate attempts (#465).
   useEffect(() => {
     if (!lesson) return;
-    const curriculumId = "default"; // resolved from JWT in production
     endedRef.current = false;
-    startLessonView(unit_id, curriculumId)
+    startLessonView(unit_id)
       .then((r) => {
         viewIdRef.current = r.view_id;
       })

--- a/web/app/(student)/quiz/[unit_id]/page.tsx
+++ b/web/app/(student)/quiz/[unit_id]/page.tsx
@@ -24,7 +24,7 @@ export default function QuizPage({ params }: PageProps) {
   // session id remounts it (also keyed below) so its state starts clean.
   const startNew = useCallback(() => {
     setSessionId(null);
-    startSession(unit_id, "default")
+    startSession(unit_id)
       .then((r) => setSessionId(r.session_id))
       .catch(() => {});
   }, [unit_id]);
@@ -65,7 +65,6 @@ export default function QuizPage({ params }: PageProps) {
             key={sessionId}
             quiz={quiz}
             sessionId={sessionId}
-            curriculumId="default"
             onRetry={startNew}
           />
         )}

--- a/web/components/content/QuizPlayer.tsx
+++ b/web/components/content/QuizPlayer.tsx
@@ -21,10 +21,16 @@ interface State {
   answerResult: AnswerResponse | null;
   correctCount: number;
   result: SessionEndResponse | null;
+  /** Set when a submit/finish request fails, so the student is told something
+   *  happened instead of facing a button that does nothing (#524). */
+  failed: boolean;
+  busy: boolean;
 }
 
 type Action =
   | { type: "SELECT"; index: number }
+  | { type: "SUBMITTING" }
+  | { type: "FAILED" }
   | { type: "REVIEWED"; result: AnswerResponse }
   | { type: "NEXT" }
   | { type: "SCORE"; result: SessionEndResponse };
@@ -32,11 +38,17 @@ type Action =
 function reducer(state: State, action: Action): State {
   switch (action.type) {
     case "SELECT":
-      return { ...state, selectedIndex: action.index };
+      return { ...state, selectedIndex: action.index, failed: false };
+    case "SUBMITTING":
+      return { ...state, busy: true, failed: false };
+    case "FAILED":
+      return { ...state, busy: false, failed: true };
     case "REVIEWED":
       return {
         ...state,
         phase: "reviewing",
+        busy: false,
+        failed: false,
         answerResult: action.result,
         // Local tally is for display only. The score on the result screen is the
         // server's — it grades each answer and keeps its own count.
@@ -49,9 +61,17 @@ function reducer(state: State, action: Action): State {
         questionIndex: state.questionIndex + 1,
         selectedIndex: null,
         answerResult: null,
+        busy: false,
+        failed: false,
       };
     case "SCORE":
-      return { ...state, phase: "scoring", result: action.result };
+      return {
+        ...state,
+        phase: "scoring",
+        busy: false,
+        failed: false,
+        result: action.result,
+      };
     default:
       return state;
   }
@@ -62,7 +82,6 @@ function reducer(state: State, action: Action): State {
 interface QuizPlayerProps {
   quiz: QuizContent;
   sessionId: string;
-  curriculumId: string;
   /** Restart the quiz with a fresh session. The score screen "Try Again" button
    *  calls this instead of navigating to the same URL (which did nothing — #459). */
   onRetry?: () => void;
@@ -78,33 +97,48 @@ export function QuizPlayer({ quiz, sessionId, onRetry }: QuizPlayerProps) {
     answerResult: null,
     correctCount: 0,
     result: null,
+    failed: false,
+    busy: false,
   });
 
   const question = quiz.questions[state.questionIndex];
   const isLast = state.questionIndex === quiz.questions.length - 1;
 
   async function handleSubmit() {
-    if (state.selectedIndex === null) return;
-    // The server grades this. We send the choice; it returns the verdict, the
-    // correct option and the explanation — none of which we had beforehand.
-    const res = await submitAnswer({
-      session_id: sessionId,
-      question_id: question.question_id,
-      answer_index: state.selectedIndex,
-    });
-    dispatch({ type: "REVIEWED", result: res });
+    if (state.selectedIndex === null || state.busy) return;
+    dispatch({ type: "SUBMITTING" });
+    try {
+      // The server grades this. We send the choice; it returns the verdict, the
+      // correct option and the explanation — none of which we had beforehand.
+      const res = await submitAnswer({
+        session_id: sessionId,
+        question_id: question.question_id,
+        answer_index: state.selectedIndex,
+      });
+      dispatch({ type: "REVIEWED", result: res });
+    } catch {
+      // Never leave the button silently dead — that is how #524 reached a QA
+      // pass unnoticed. The message stays non-technical (Content Rule #5).
+      dispatch({ type: "FAILED" });
+    }
   }
 
   async function handleNext() {
+    if (state.busy) return;
     if (isLast) {
-      // No score is sent: the backend reports what it graded during the session.
-      const res = await endSession(sessionId);
-      // Session completion is written synchronously by endSession, so the
-      // stats/history reads are fresh — refresh them now instead of waiting for
-      // a manual browser reload (#466).
-      queryClient.invalidateQueries({ queryKey: ["stats"] });
-      queryClient.invalidateQueries({ queryKey: ["progress"] });
-      dispatch({ type: "SCORE", result: res });
+      dispatch({ type: "SUBMITTING" });
+      try {
+        // No score is sent: the backend reports what it graded during the session.
+        const res = await endSession(sessionId);
+        // Session completion is written synchronously by endSession, so the
+        // stats/history reads are fresh — refresh them now instead of waiting for
+        // a manual browser reload (#466).
+        queryClient.invalidateQueries({ queryKey: ["stats"] });
+        queryClient.invalidateQueries({ queryKey: ["progress"] });
+        dispatch({ type: "SCORE", result: res });
+      } catch {
+        dispatch({ type: "FAILED" });
+      }
     } else {
       dispatch({ type: "NEXT" });
     }
@@ -230,14 +264,27 @@ export function QuizPlayer({ quiz, sessionId, onRetry }: QuizPlayerProps) {
         )}
       </div>
 
+      {/* Something went wrong on the way to the server. Plain language, no
+          status codes or ids — this is a student-facing message. */}
+      {state.failed && (
+        <p role="alert" className="text-sm text-red-600">
+          We couldn&apos;t save that answer. Check your connection and try again.
+        </p>
+      )}
+
       {/* Action button */}
       <div className="flex justify-end">
         {state.phase === "answering" ? (
-          <Button onClick={handleSubmit} disabled={state.selectedIndex === null}>
-            Submit answer
+          <Button
+            onClick={handleSubmit}
+            disabled={state.selectedIndex === null || state.busy}
+          >
+            {state.busy ? "Checking…" : state.failed ? "Try again" : "Submit answer"}
           </Button>
         ) : (
-          <Button onClick={handleNext}>{isLast ? "See results" : "Next question"}</Button>
+          <Button onClick={handleNext} disabled={state.busy}>
+            {isLast ? "See results" : "Next question"}
+          </Button>
         )}
       </div>
     </div>

--- a/web/lib/api/analytics.ts
+++ b/web/lib/api/analytics.ts
@@ -1,13 +1,10 @@
 import api from "./client";
 import type { LessonViewStartResponse, StudentStats } from "@/lib/types/api";
 
-export async function startLessonView(
-  unitId: string,
-  curriculumId: string,
-): Promise<LessonViewStartResponse> {
+/** The server attributes the view to the student's resolved curriculum (#524). */
+export async function startLessonView(unitId: string): Promise<LessonViewStartResponse> {
   const res = await api.post<LessonViewStartResponse>("/analytics/lesson/start", {
     unit_id: unitId,
-    curriculum_id: curriculumId,
   });
   return res.data;
 }

--- a/web/lib/api/progress.ts
+++ b/web/lib/api/progress.ts
@@ -6,14 +6,18 @@ import type {
   ProgressHistory,
 } from "@/lib/types/api";
 
-export async function startSession(
-  unitId: string,
-  curriculumId: string,
-): Promise<SessionStartResponse> {
+/**
+ * Open a quiz attempt.
+ *
+ * No curriculum id is sent: the server resolves the student's curriculum from
+ * their identity. This page used to send a hardcoded "default", which the
+ * session stored and grading then looked the answer key up under — nothing
+ * resolves there, so every answer 404'd and Submit became a dead button (#524).
+ */
+export async function startSession(unitId: string): Promise<SessionStartResponse> {
   // Backend: POST /progress/session  (not /session/start)
   const res = await api.post<SessionStartResponse>("/progress/session", {
     unit_id: unitId,
-    curriculum_id: curriculumId,
   });
   return res.data;
 }

--- a/web/lib/api/types.gen.ts
+++ b/web/lib/api/types.gen.ts
@@ -8045,12 +8045,15 @@ export interface components {
             /** Body */
             body: string;
         };
-        /** LessonStartRequest */
+        /**
+         * LessonStartRequest
+         * @description `curriculum_id` is accepted for older clients and ignored — see #524.
+         */
         LessonStartRequest: {
             /** Unit Id */
             unit_id: string;
             /** Curriculum Id */
-            curriculum_id: string;
+            curriculum_id?: string | null;
         };
         /** LessonStartResponse */
         LessonStartResponse: {
@@ -9523,12 +9526,25 @@ export interface components {
             /** Snapshots */
             snapshots: components["schemas"]["SnapshotItem"][];
         };
-        /** StartSessionRequest */
+        /**
+         * StartSessionRequest
+         * @description Open a quiz session.
+         *
+         *     `curriculum_id` is accepted for backwards compatibility with older clients
+         *     and then IGNORED — the server resolves the student's curriculum itself. The
+         *     web client used to send a hardcoded "default", which the session stored and
+         *     grading later looked the answer key up under; nothing resolves under that id,
+         *     so every answer 404'd (#524). Same rule as locale: authoritative server-side,
+         *     never taken from the request.
+         */
         StartSessionRequest: {
             /** Unit Id */
             unit_id: string;
-            /** Curriculum Id */
-            curriculum_id: string;
+            /**
+             * Curriculum Id
+             * @deprecated
+             */
+            curriculum_id?: string | null;
         };
         /** StartSessionResponse */
         StartSessionResponse: {

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -21433,16 +21433,23 @@
             "title": "Unit Id"
           },
           "curriculum_id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Curriculum Id"
           }
         },
         "type": "object",
         "required": [
-          "unit_id",
-          "curriculum_id"
+          "unit_id"
         ],
-        "title": "LessonStartRequest"
+        "title": "LessonStartRequest",
+        "description": "`curriculum_id` is accepted for older clients and ignored \u2014 see #524."
       },
       "LessonStartResponse": {
         "properties": {
@@ -25288,18 +25295,25 @@
             "title": "Unit Id"
           },
           "curriculum_id": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Curriculum Id"
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Curriculum Id",
+            "deprecated": true
           }
         },
         "type": "object",
         "required": [
-          "unit_id",
-          "curriculum_id"
+          "unit_id"
         ],
-        "title": "StartSessionRequest"
+        "title": "StartSessionRequest",
+        "description": "Open a quiz session.\n\n`curriculum_id` is accepted for backwards compatibility with older clients\nand then IGNORED \u2014 the server resolves the student's curriculum itself. The\nweb client used to send a hardcoded \"default\", which the session stored and\ngrading later looked the answer key up under; nothing resolves under that id,\nso every answer 404'd (#524). Same rule as locale: authoritative server-side,\nnever taken from the request."
       },
       "StartSessionResponse": {
         "properties": {


### PR DESCRIPTION
Closes #524. Blocker from the 2026-07-31 QA report (Venki) — *"In Quiz - Submit is not taking me to the next question."* It stopped the rest of that test pass.

## The bug

The quiz page opened the session with a hardcoded curriculum id:

```ts
// web/app/(student)/quiz/[unit_id]/page.tsx:27
startSession(unit_id, "default")
```

`create_session` stored it verbatim, and `record_answer` graded against it:

```python
# backend/src/progress/router.py:160-167
answer_key = await get_quiz_answer_key(
    curriculum_id=session["curriculum_id"],   # ← "default"
    unit_id=session["unit_id"], …
)
```

Nothing resolves under `"default"` in the content store — the real id is `default-2026-g10` — so `get_quiz_answer_key` raised `FileNotFoundError` and the endpoint returned **404 `quiz_not_found`**. `handleSubmit` had no `catch`, so the rejection was swallowed, no state was dispatched, and the button sat there doing nothing.

**Why the quiz still rendered:** `GET /content/{unit_id}/quiz` resolves the curriculum properly via `resolve_curriculum_id`. Only the grading path trusted the client's value, so serving and grading disagreed about which curriculum the student was in.

**Latent since #506.** Before server-side grading the browser graded itself from `correct_index` and never needed a curriculum id, so the hardcode was inert. #506 moved grading to the server but left the *lookup key for grading* client-supplied.

## The fix

**1. The server resolves it.** `POST /progress/session` ignores any `curriculum_id` in the body and calls `resolve_curriculum_id` — the same 3-step resolver the content path uses. This also repairs `create_session`'s unit lookup, which was missing and writing every session with `grade=0, subject="unknown"`.

This is the rule CLAUDE.md already states for locale — *"Locale is authoritative from the JWT. Content endpoints never accept `?lang=`"* — applied to the value of the same class. The field stays accepted-and-ignored (now `str | None`, marked deprecated) so the Kivy client keeps working unchanged.

**2. Same treatment for `POST /analytics/lesson/start`**, which had the identical hardcode — every `lesson_views` row was attributed to `"default"`.

**3. The client stops sending it, and a failed submit says so.** A bare `catch` leaving a dead button is why this survived a QA pass. The player now shows "Checking…" while in flight and a plain-language message on failure (Content Rule #5 — no status codes or ids in student-facing text), with the button offering "Try again". Also drops the unused `curriculumId` prop from `QuizPlayer`.

## Knock-on effect

The **0% pass rate / 0% average score** in the second screenshot of the same report should resolve with this — no answer was ever graded, so every session scored zero. The *chart labelling* problem in that screenshot is separate and tracked in #525.

## Test plan

Three new cases in `backend/tests/test_progress.py`, written failing first:

| Test | Asserts |
|---|---|
| `test_session_curriculum_is_resolved_server_side` | body says `"default"` → session returns `default-2026-g8` |
| `test_grading_uses_the_resolved_curriculum_not_the_clients` | the `curriculum_id` **kwarg** reaching `get_quiz_answer_key` is the resolved one |
| `test_start_session_without_curriculum_id_is_accepted` | the field is optional |

The middle one is the important one. Every existing test stubbed `get_quiz_answer_key` and never checked what it was called with — that blind spot is exactly how #524 shipped green. Before the fix all three failed with `assert 'default' == 'default-2026-g8'` / `422`.

Run locally:

- **Backend full suite: 1178 passed, 2 skipped** (`pytest -q`)
- **Frontend unit: 839 passed** across 66 files (`vitest run`)
- `npm run format:check`, `npm run lint` — clean
- `npm run typecheck` — 4 errors, all in gitignored generated `.next/dev/**`, **identical on a clean tree** (verified by stashing); CI builds fresh and does not see them
- Playwright `student_flow` fails 3 locally — also **identical on a clean tree**, including the "public landing page" case this diff cannot touch. Environmental; the same job passes in CI.

Schema changed, so `web/openapi.json` + `lib/api/types.gen.ts` were regenerated (`export_openapi.py` → `npm run gen:types`) for the API-contract job. The type diff touches only `StartSessionRequest` and `LessonStartRequest`.

## Post-merge verification

Reproducing live was not possible from here: the demo passwords for `kt.shanvenki@` (G10 student) and `venki.kt@` (school admin) changed during the 07-31 test pass and were deliberately **not** reset, to avoid locking Venki out mid-test. After deploy, the check is Venki's original repro — take a G10 quiz, confirm Submit reveals the verdict and advances, and confirm the result screen shows a real score.

## Not backfilled

Historical `lesson_views` rows keep `curriculum_id = "default"`, so past analytics stay mis-attributed. Sessions are created per attempt, so no session migration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
