### PR TITLE
fix(reports): dedupe unit rows — raw-subject GROUP BY also split teacher-facing stats

### DIFF
--- a/backend/src/analytics/service.py
+++ b/backend/src/analytics/service.py
@@ -154,12 +154,22 @@ async def get_student_metrics(
         student_id,
     )
 
-    # Per-unit breakdown: join progress_sessions + lesson_views
+    # Per-unit breakdown: join progress_sessions + lesson_views.
+    #
+    # Grouped by unit_id (plus the functionally-dependent lv.* columns, which
+    # Postgres still requires listed even though they're constant per unit_id
+    # via the pre-aggregated subquery) — NOT s.subject. progress_sessions.subject
+    # is a raw stored value that can legitimately differ across sessions for the
+    # SAME unit (pre-#524 sessions stored the "unknown" sentinel; later ones
+    # store the real code), while the response's subject is resolved from
+    # unit_id alone below (resolve_subject_labels / display_subject). Grouping
+    # on the raw column produced two rows sharing the same resolved display
+    # label — the duplicate-unit-row bug.
     unit_rows = await conn.fetch(
         """
         SELECT
             s.unit_id,
-            s.subject,
+            MAX(s.subject)                                          AS subject,
             MAX(s.attempt_number)                                   AS quiz_attempts,
             -- best_score_pct is a PERCENTAGE (issue #463): score is a raw
             -- question count, so divide by total_questions.
@@ -183,7 +193,7 @@ async def get_student_metrics(
             GROUP BY unit_id
         ) lv ON lv.unit_id = s.unit_id
         WHERE s.student_id = $1
-        GROUP BY s.unit_id, s.subject, lv.total_time_s, lv.views
+        GROUP BY s.unit_id, lv.total_time_s, lv.views
         ORDER BY s.unit_id
         """,
         student_id,
@@ -296,11 +306,20 @@ async def get_class_metrics(
         params.append(subject)
         subject_filter = f"AND ps.subject = ${len(params)}"
 
+    # Grouped by unit_id ONLY — see the identical comment in
+    # get_curriculum_health (reports/service.py). This aggregates across the
+    # whole enrolled cohort, so grouping on the raw (possibly-"unknown")
+    # subject silently split one unit's class metrics into two partial rows —
+    # each with its own wrong, partial pass rate / mean score / attempt counts.
+    # This field is NOT run through resolve_subject_labels / display_subject
+    # downstream, so MAX(ps.subject) is the actual value shown. When the
+    # caller passes `subject=`, the WHERE filter already restricts every
+    # remaining row to that one raw value, so this is a no-op in that case.
     rows = await conn.fetch(
         f"""
         SELECT
             ps.unit_id,
-            ps.subject,
+            MAX(ps.subject)                                                      AS subject,
             COUNT(DISTINCT lv.view_id)                                           AS students_with_lesson_view,
             COUNT(DISTINCT ps.session_id)                                        AS total_quiz_attempts,
             COUNT(DISTINCT ps.student_id) FILTER (WHERE ps.completed)           AS unique_students_attempted,
@@ -317,7 +336,7 @@ async def get_class_metrics(
         WHERE ps.student_id = ANY(ARRAY[{placeholders}]::uuid[])
               {grade_filter}
               {subject_filter}
-        GROUP BY ps.unit_id, ps.subject
+        GROUP BY ps.unit_id
         ORDER BY ps.unit_id
         """,
         *params,

--- a/backend/src/reports/service.py
+++ b/backend/src/reports/service.py
@@ -507,12 +507,24 @@ async def get_student_report(
     )
     units_in_progress = in_progress_row["cnt"] or 0
 
-    # Per-unit breakdown
+    # Per-unit breakdown.
+    #
+    # Grouped by unit_id ONLY (not ps.subject, issue: duplicate unit rows).
+    # progress_sessions.subject is a raw stored value that can legitimately
+    # differ across sessions for the SAME unit — pre-#524 sessions stored the
+    # "unknown" sentinel, later sessions store the real subject code — while
+    # the response's display subject is resolved from unit_id alone
+    # (resolve_subject_labels / display_subject, below). Grouping on the raw
+    # column produced two rows sharing an identical resolved display label,
+    # which is exactly the "same unit shown twice" bug a QA tester reported.
+    # MAX(ps.subject) just picks a representative raw value for the fallback
+    # path in display_subject() — it is never the value actually shown when a
+    # curriculum-derived label exists.
     unit_rows = await conn.fetch(
         """
         SELECT
             ps.unit_id,
-            ps.subject,
+            MAX(ps.subject)                                      AS subject,
             MAX(ps.attempt_number)                               AS quiz_attempts,
             -- best_score is a PERCENTAGE (issue #463): score is a raw question
             -- count, so divide by total_questions. NULLIF guards divide-by-zero.
@@ -525,7 +537,7 @@ async def get_student_report(
         FROM progress_sessions ps
         LEFT JOIN lesson_views lv ON lv.student_id = ps.student_id AND lv.unit_id = ps.unit_id
         WHERE ps.student_id = $1
-        GROUP BY ps.unit_id, ps.subject
+        GROUP BY ps.unit_id
         ORDER BY ps.unit_id
         """,
         uuid.UUID(student_id),
@@ -610,12 +622,21 @@ async def get_curriculum_health(
     id_uuids = [uuid.UUID(s) for s in enrolled]
     placeholders = ", ".join(f"${i + 1}" for i in range(len(id_uuids)))
 
-    # All units these students have interacted with
+    # All units these students have interacted with.
+    #
+    # Grouped by unit_id ONLY — see the identical comment in get_student_report
+    # above. Here it matters even more: this query aggregates across MANY
+    # students, so grouping on the raw (possibly-"unknown") subject silently
+    # split a single unit's health stats into two partial rows — each with its
+    # own (wrong, partial) pass rate / avg score / avg attempts — and inflated
+    # total_units / healthy_count / watch_count / struggling_count by double-
+    # counting the unit. This field is NOT run through resolve_subject_labels /
+    # display_subject downstream, so MAX(ps.subject) is the actual value shown.
     rows = await conn.fetch(
         f"""
         SELECT
             ps.unit_id,
-            ps.subject,
+            MAX(ps.subject)                                    AS subject,
             ROUND(
                 100.0 * COUNT(*) FILTER (WHERE ps.attempt_number = 1 AND ps.passed AND ps.completed)
                 / NULLIF(COUNT(DISTINCT ps.student_id) FILTER (WHERE ps.attempt_number = 1 AND ps.completed), 0),
@@ -627,7 +648,7 @@ async def get_curriculum_health(
         FROM progress_sessions ps
         LEFT JOIN lesson_views lv ON lv.student_id = ps.student_id AND lv.unit_id = ps.unit_id
         WHERE ps.student_id = ANY(ARRAY[{placeholders}]::uuid[])
-        GROUP BY ps.unit_id, ps.subject
+        GROUP BY ps.unit_id
         ORDER BY ps.unit_id
         """,
         *id_uuids,

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -293,6 +293,79 @@ async def test_student_report_not_enrolled_returns_404(client, db_conn):
     assert r.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_student_report_dedupes_unit_with_mixed_raw_subject(client, db_conn):
+    """
+    Regression for the QA-reported duplicate-unit-row bug (student detail page,
+    "Unit progress" table showing the same unit twice).
+
+    Two progress_sessions for the SAME unit_id but DIFFERENT raw `subject`
+    values (one is the pre-#524 'unknown' sentinel, one is the real subject
+    code) must collapse into exactly ONE `per_unit` row. The response's
+    `subject` field is resolved from `unit_id` alone (`resolve_subject_labels` /
+    `display_subject`), so the two raw values already render as the SAME
+    display label — grouping the underlying SQL on the raw `subject` column
+    (instead of `unit_id`) produced two rows with identical-looking text.
+    """
+    school = await _register_school(client, "_sr_dedupe")
+    school_id = school["school_id"]
+    token = school["access_token"]
+
+    sid = "a1000000-0000-0000-0000-000000000009"
+    email = "sr-dedupe@test.invalid"
+    await _insert_student(client, sid, email)
+    await _enrol_student(client, school_id, sid, email)
+
+    # Curriculum metadata so the unit resolves to a real display label
+    # regardless of which raw `subject` value a given session happened to store.
+    # Must go through the app's own pool (not the `db_conn` fixture, which is a
+    # separate connection wrapped in an uncommitted transaction) so the rows
+    # are visible to the HTTP request below.
+    pool = client._transport.app.state.pool
+    cid = f"test-cur-dedupe-{sid[-4:]}"
+    await pool.execute(
+        "INSERT INTO curricula (curriculum_id, grade, year, name) VALUES ($1, 10, 2026, $2)",
+        cid, "Dedupe Test Curriculum",
+    )
+    await pool.execute(
+        "INSERT INTO curriculum_units (unit_id, curriculum_id, subject, title, unit_name) "
+        "VALUES ($1, $2, $3, $4, $4)",
+        "G10-ENG-001", cid, "G10-ENG", "Essay Structure",
+    )
+    await pool.execute(
+        """
+        INSERT INTO content_subject_versions (curriculum_id, subject, subject_name, version_number, status)
+        VALUES ($1, $2, $3, 1, 'published')
+        """,
+        cid, "G10-ENG", "English",
+    )
+
+    # Two sessions, same unit_id, different raw subject — the pre-/post-#524 split.
+    await _insert_session(
+        client, sid, unit_id="G10-ENG-001", subject="unknown",
+        curriculum_id="default-2026-g10", attempt_number=1, score=60, passed=False,
+    )
+    await _insert_session(
+        client, sid, unit_id="G10-ENG-001", subject="G10-ENG",
+        curriculum_id="default-2026-g10", attempt_number=2, score=90, passed=True,
+    )
+
+    r = await client.get(
+        f"/api/v1/reports/school/{school_id}/student/{sid}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    unit_rows = [u for u in data["per_unit"] if u["unit_id"] == "G10-ENG-001"]
+    assert len(unit_rows) == 1, f"expected exactly one row for G10-ENG-001, got {unit_rows}"
+    row = unit_rows[0]
+    assert row["subject"] == "English"
+    # The merged row must reflect the true totals across BOTH sessions, not
+    # whatever a single raw-subject partition happened to show alone.
+    assert row["quiz_attempts"] == 2
+    assert row["passed"] is True
+
+
 # ── Curriculum health ─────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Reported by Venki on 2026-08-04: the school portal's student detail page shows the same unit twice, with identical subject text.

Confirmed at the API level before touching anything — `GET /reports/school/{id}/student/{id}` returned **9 `per_unit` rows for 6 unique units** (`G10-ENG-001`, `G10-MATH-001`, `G10-TECH-004` each duplicated).

## Cause

`GROUP BY ps.unit_id, ps.subject` groups on the **raw stored** `progress_sessions.subject`, while the response returns the **resolved display label** (`display_subject()` / `resolve_subject_labels()`, which resolve by `unit_id` alone per the #462 fix).

Sessions created before #524's fix stored `subject = "unknown"` — the old `create_session` looked the unit up under a hardcoded `curriculum_id: "default"` that resolves to nothing. Sessions created after store the real subject. Two distinct raw values, one display label, two identical-looking rows.

This is #524's residue surfacing in a second place. It also explains the shape of the screenshot: each duplicated unit shows one row with a score and one with `—`. The scored row is post-fix sessions; the blank one is the pre-fix sessions that could never be graded.

## It was worse than the reported symptom

Five sites shared the grouping. Four were genuine bugs, and on two of them the damage was **wrong numbers, not just duplicate rows**:

| Site | Verdict |
|---|---|
| `reports/service.py:528` `get_student_report` | **Fixed** — the reported bug; rows go straight into `per_unit` |
| `reports/service.py:630` `get_curriculum_health` | **Fixed** — duplicates also double-counted `total_units` and split health tiers into two wrong partial numbers |
| `analytics/service.py:186` `get_student_metrics` | **Fixed** — same shape as the reported bug |
| `analytics/service.py:320` `get_class_metrics` | **Fixed** — **teacher-facing**; cohort pass rate, mean score and attempt counts were computed over only part of each student's sessions |
| `analytics/router.py:271` trends breakdown | **Left alone** — folds rows into a dict keyed by resolved label before returning, so duplicates merge by design (the existing comment documents that intent) |

## The fix

`GROUP BY unit_id, subject` → `GROUP BY unit_id`, with `MAX(subject)` as the representative raw value — the display label is resolved from `unit_id` downstream regardless, and the raw value only survives as a fallback.

Every existing aggregate was checked for meaning across the merged set, not just for compiling:

- `AVG(lv.duration_s)` — already identical on both duplicate rows pre-fix, so unchanged.
- `MAX(attempt_number)`, `BOOL_OR(passed)`, and the `best_score` percentage (with its `NULLIF` guard and FILTER clause) — previously computed over a *partial* session set per duplicate row. Merging makes these **more correct**, not merely fewer.
- The cohort-wide pass-rate and score aggregates in the two `_metrics`/`health` sites — same story: the statistic itself was wrong before, not only its presentation.

## Not doing: the data backfill

Legacy rows still carry `subject = 'unknown'`. **Recommend against backfilling**, at least not as part of this:

- Display resolution already masks the bad value for any unit with a `curriculum_units` row, and with this fix reporting is correct without touching stored data.
- A bulk `UPDATE progress_sessions` on a FERPA-relevant table relies on an `unit_id → curriculum_id` join that isn't guaranteed clean for historical rows. A wrong value silently mis-tags educational records — worse than an honest `'unknown'`.

If it's ever wanted, it should be a reviewed migration with a dry run, not an ad hoc update.

## Test plan

New regression test `test_student_report_dedupes_unit_with_mixed_raw_subject` in `backend/tests/test_reports.py`: two sessions, same `unit_id`, different raw `subject` values, assert exactly one row returns.

Verified it actually bites — re-breaking only the reports `GROUP BY` fails it with:

```
E    +  where 2 = len([{...'passed': True...}, {...'passed': False...}])
FAILED tests/test_reports.py::test_student_report_dedupes_unit_with_mixed_raw_subject
```

Restoring the fix returns 20/20 green in that file.

- `backend/tests/test_reports.py` — 20 passed
- Full backend suite — 1180 passed, 2 skipped (1179 before, +1 for the new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
