### PR TITLE
ci(e2e): fix Playwright webServer boot — v4 Auth0 env names (#535)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,11 +39,14 @@ jobs:
         env:
           BASE_URL: http://localhost:3000
           # Fake Auth0 env vars — no real tenant needed.
-          # The Next.js dev server uses these so auth0.getSession() initialises
-          # without crashing; tests use sb_dev_session cookie instead.
+          # The Next.js dev server uses these so the @auth0/nextjs-auth0 v4
+          # Auth0Client initialises without crashing; tests use the
+          # sb_dev_session cookie instead. v4 renamed the config env vars —
+          # AUTH0_DOMAIN (not AUTH0_ISSUER_BASE_URL) and APP_BASE_URL (not
+          # AUTH0_BASE_URL); a missing AUTH0_DOMAIN aborts webServer boot.
           AUTH0_SECRET: e2e-placeholder-secret-not-used-in-prod-aaaaaaaaaa
-          AUTH0_BASE_URL: http://localhost:3000
-          AUTH0_ISSUER_BASE_URL: https://test.auth0.example.com
+          AUTH0_DOMAIN: test.auth0.com
+          APP_BASE_URL: http://localhost:3000
           AUTH0_CLIENT_ID: test_client_id
           AUTH0_CLIENT_SECRET: test_client_secret
           NEXT_PUBLIC_API_URL: http://localhost:8000/api/v1


### PR DESCRIPTION
## What
Fixes the **Playwright — Student Flow (3 critical paths)** job, which has been red on every PR — the Next dev server it boots as `config.webServer` crashed on startup, so all 3 paths timed out before a single test ran.

## Why
`web/lib/auth0.ts` uses `@auth0/nextjs-auth0` **v4** `Auth0Client`, which reads `AUTH0_DOMAIN` + `APP_BASE_URL`. `e2e.yml` still passed the **v3** names (`AUTH0_ISSUER_BASE_URL`, `AUTH0_BASE_URL`) and no `AUTH0_DOMAIN`, so boot aborted:

```
InvalidConfigurationError: Missing: domain: Set AUTH0_DOMAIN env var
→ Error: Timed out waiting 60000ms from config.webServer
```

`test.yml` was already on the v4 names; `e2e.yml` simply drifted.

## Change
Swap the webServer env in `.github/workflows/e2e.yml` to the v4 names (`AUTH0_DOMAIN: test.auth0.com`, `APP_BASE_URL: http://localhost:3000`), dropping the stale `AUTH0_ISSUER_BASE_URL`/`AUTH0_BASE_URL`. Workflow-only; no app code touched.

## Test
Booted locally with exactly this env: `npm run dev` on **next 16.3.0** comes up clean (`✓ Ready`, `GET / 200`) with no Auth0 crash. The E2E job on this PR is the live confirmation.

## Risk
Low — CI-config only. Worst case the Playwright job stays red (its current state); it cannot regress passing jobs.

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)