### PR TITLE
feat(quiz): defer results, skip-and-return, summary screen (#532)

### DIFF
--- a/backend/quiz_suite/test_anticheat.py
+++ b/backend/quiz_suite/test_anticheat.py
@@ -72,6 +72,39 @@ async def test_client_cannot_post_its_own_score(api, auth_a, fixture_data):
 
 
 @pytest.mark.asyncio
+async def test_revisiting_a_question_does_not_inflate_the_score(api, auth_a, fixture_data):
+    """
+    #532: the skip-and-return UI lets a student re-answer a question, so the
+    server tally must be idempotent per question. Answer two of three correctly,
+    then re-submit a correct answer a second time — the score must stay at 2, not
+    climb to 3. Before the per-question hash (the old blind INCR tally) this
+    re-submit double-counted, and end_session's clamp only capped it at the total,
+    so a 2/3 run could present as 3/3.
+    """
+    quiz = await serve_quiz(api, auth_a)
+    key = fixture_data["answer_key"][str(quiz["set_number"])]
+    session = await start_session(api, auth_a)
+    sid = session["session_id"]
+
+    async def answer(qid: str, index: int) -> None:
+        r = await api.post(
+            f"/progress/session/{sid}/answer",
+            json={"question_id": qid, "student_answer": index, "ms_taken": 10},
+            headers=auth_a,
+        )
+        assert r.status_code == 200, r.text
+
+    await answer("q1", key["q1"])  # correct
+    await answer("q2", key["q2"])  # correct
+    await answer("q3", (key["q3"] + 1) % 3)  # wrong
+    await answer("q1", key["q1"])  # revisit q1, still correct — must not count twice
+
+    r = await api.post(f"/progress/session/{sid}/end", json={}, headers=auth_a)
+    assert r.status_code == 200, r.text
+    assert r.json()["score"] == 2, "revisiting a correct answer inflated the score"
+
+
+@pytest.mark.asyncio
 async def test_graded_set_is_pinned_for_the_session(api, auth_a, fixture_data):
     """
     Answer q1, force the rotation pointer forward by re-fetching the quiz, then

--- a/backend/src/core/cache_keys.py
+++ b/backend/src/core/cache_keys.py
@@ -101,16 +101,27 @@ def quiz_set_key(student_id: str, unit_id: str) -> str:
     return f"quiz_set:{student_id}:{unit_id}"
 
 
-def quiz_score_key(session_id: str) -> str:
+def quiz_answers_key(session_id: str) -> str:
     """
-    quizscore:{session_id} — running count of server-graded correct answers.
+    quizanswers:{session_id} — Redis HASH of question_id → "1"/"0" (server-graded
+    correctness), one field per answered question.
 
     The score has to be authoritative but the answer write is fire-and-forget
     (perf rule #4), so `progress_answers` may not be persisted yet when the
     session ends. Tally the graded result in Redis as each answer arrives and
     read it back at end-of-session instead of trusting a client-supplied score.
+
+    A hash (not a counter) so re-answering a question is idempotent: revisiting a
+    question overwrites its field instead of incrementing a blind total. Without
+    this, once the UI allows skip-and-return (#532) a student who re-confirms a
+    correct answer would score it twice. The score is the count of "1" fields.
+
+    NB: the key STRING changed from the old integer `quizscore:{session_id}` on
+    purpose — reusing that name would raise WRONGTYPE against any in-flight
+    integer key across the deploy. Sessions mid-flight at deploy time simply lose
+    their Redis tally and fall back to the persisted answers (the documented path).
     """
-    return f"quizscore:{session_id}"
+    return f"quizanswers:{session_id}"
 
 
 def quiz_session_set_key(session_id: str) -> str:

--- a/backend/src/progress/router.py
+++ b/backend/src/progress/router.py
@@ -216,9 +216,7 @@ async def record_answer(
     # may not exist yet when the session ends. This is what end_session reads.
     # Keyed by question_id so re-answering (skip-and-return, #532) can't inflate
     # the score — the field is overwritten, not counted twice.
-    await tally_answer(
-        redis, session_id=session_id, question_id=body.question_id, correct=correct
-    )
+    await tally_answer(redis, session_id=session_id, question_id=body.question_id, correct=correct)
 
     # Fire-and-forget Celery task for the actual write — with the SERVER's verdict
     from src.core.celery_app import celery_app

--- a/backend/src/progress/router.py
+++ b/backend/src/progress/router.py
@@ -214,7 +214,11 @@ async def record_answer(
 
     # Running tally in Redis: the DB write below is fire-and-forget, so the rows
     # may not exist yet when the session ends. This is what end_session reads.
-    await tally_answer(redis, session_id=session_id, correct=correct)
+    # Keyed by question_id so re-answering (skip-and-return, #532) can't inflate
+    # the score — the field is overwritten, not counted twice.
+    await tally_answer(
+        redis, session_id=session_id, question_id=body.question_id, correct=correct
+    )
 
     # Fire-and-forget Celery task for the actual write — with the SERVER's verdict
     from src.core.celery_app import celery_app

--- a/backend/src/progress/service.py
+++ b/backend/src/progress/service.py
@@ -18,7 +18,6 @@ from datetime import UTC, datetime
 import asyncpg
 
 from src.core.cache_keys import (
-    quiz_score_key,
     quiz_session_set_key,
     quiz_set_key,
 )
@@ -79,45 +78,58 @@ async def resolve_session_quiz_set(
     return set_number
 
 
-async def tally_answer(redis, session_id: str, correct: bool) -> None:
+async def tally_answer(redis, session_id: str, question_id: str, correct: bool) -> None:
     """
-    Record one graded answer against the session's running tally.
+    Record one graded answer against the session's per-question tally.
 
-    Both counters are kept so end_session can report a score without waiting on
-    the fire-and-forget DB write (perf rule #4).
+    Stored as a Redis HASH field (question_id → "1"/"0") rather than a counter so
+    the write is idempotent: answering the same question again — which the
+    skip-and-return UI (#532) makes possible — overwrites its verdict instead of
+    incrementing a blind total. end_session reads this back without waiting on the
+    fire-and-forget DB write (perf rule #4).
     """
-    key = quiz_score_key(session_id)
-    if correct:
-        await redis.incr(key)
-    else:
-        # Ensure the key exists even for an all-wrong run, so end_session can tell
-        # "graded, scored zero" apart from "no tally at all".
-        await redis.setnx(key, 0)
+    key = quiz_answers_key(session_id)
+    await redis.hset(key, question_id, "1" if correct else "0")
     await redis.expire(key, _TALLY_TTL)
 
 
 async def read_tally(redis, session_id: str) -> int | None:
-    """Server-graded correct count for the session, or None if no tally exists."""
-    raw = await redis.get(quiz_score_key(session_id))
-    if raw is None:
+    """
+    Server-graded correct count for the session, or None if no tally exists.
+
+    Counts the "1" fields in the per-question hash, so a question re-answered any
+    number of times contributes at most once and only its latest verdict counts.
+    An absent key (no answers graded, or the hash expired) returns None so the
+    caller can fall back to the persisted answers.
+    """
+    values = await redis.hvals(quiz_answers_key(session_id))
+    if not values:
         return None
-    try:
-        return int(raw)
-    except (ValueError, TypeError):
-        return None
+    return sum(1 for v in values if (v.decode() if isinstance(v, bytes) else v) == "1")
 
 
 async def count_correct_answers(conn: asyncpg.Connection, session_id: str) -> int:
     """
     Fallback score source: count graded-correct answers already persisted.
 
-    Only used when the Redis tally is gone (restart / TTL). May undercount if the
-    fire-and-forget writes are still in flight, which is exactly why the Redis
-    tally is preferred.
+    Only used when the Redis tally is gone (restart / TTL). Because answers are
+    appended (a new row per submission, no upsert) the same question can have
+    several rows once revisiting is allowed, so we take only the LATEST row per
+    question — matching the Redis hash's "last verdict wins" — and count the ones
+    that are correct. May undercount if the fire-and-forget writes are still in
+    flight, which is exactly why the Redis tally is preferred.
     """
     return (
         await conn.fetchval(
-            "SELECT COUNT(*) FROM progress_answers WHERE session_id = $1 AND correct IS TRUE",
+            """
+            SELECT COUNT(*) FROM (
+                SELECT DISTINCT ON (question_id) correct
+                FROM progress_answers
+                WHERE session_id = $1
+                ORDER BY question_id, recorded_at DESC
+            ) latest
+            WHERE correct IS TRUE
+            """,
             session_id,
         )
         or 0

--- a/backend/src/progress/service.py
+++ b/backend/src/progress/service.py
@@ -18,6 +18,7 @@ from datetime import UTC, datetime
 import asyncpg
 
 from src.core.cache_keys import (
+    quiz_answers_key,
     quiz_session_set_key,
     quiz_set_key,
 )

--- a/backend/tests/test_progress_server_side_grading.py
+++ b/backend/tests/test_progress_server_side_grading.py
@@ -71,8 +71,9 @@ QUIZ_SET_2 = {
 
 
 def _redis_store() -> MagicMock:
-    """A MagicMock redis with a real dict behind it, so INCR/GET actually work."""
-    data: dict[str, str] = {}
+    """A MagicMock redis with a real dict behind it, so GET/SET and the per-question
+    HSET/HVALS tally actually work. Hash values are stored as a nested dict."""
+    data: dict[str, object] = {}
 
     async def _get(k):
         return data.get(k)
@@ -90,15 +91,29 @@ def _redis_store() -> MagicMock:
             return True
         return False
 
+    async def _hset(k, field, value):
+        h = data.get(k)
+        if not isinstance(h, dict):
+            h = {}
+            data[k] = h
+        h[field] = str(value)
+        return 1
+
+    async def _hvals(k):
+        h = data.get(k)
+        return list(h.values()) if isinstance(h, dict) else []
+
     async def _expire(k, ttl):
         return True
 
     r = MagicMock()
-    r.get, r.set, r.incr, r.setnx, r.expire = (
+    r.get, r.set, r.incr, r.setnx, r.hset, r.hvals, r.expire = (
         AsyncMock(side_effect=_get),
         AsyncMock(side_effect=_set),
         AsyncMock(side_effect=_incr),
         AsyncMock(side_effect=_setnx),
+        AsyncMock(side_effect=_hset),
+        AsyncMock(side_effect=_hvals),
         AsyncMock(side_effect=_expire),
     )
     r._data = data
@@ -176,9 +191,9 @@ async def test_tally_counts_only_server_graded_correct_answers():
     redis = _redis_store()
     session = "11111111-1111-1111-1111-111111111111"
 
-    await tally_answer(redis, session_id=session, correct=True)
-    await tally_answer(redis, session_id=session, correct=False)
-    await tally_answer(redis, session_id=session, correct=True)
+    await tally_answer(redis, session_id=session, question_id="q1", correct=True)
+    await tally_answer(redis, session_id=session, question_id="q2", correct=False)
+    await tally_answer(redis, session_id=session, question_id="q3", correct=True)
 
     assert await read_tally(redis, session) == 2
 
@@ -193,8 +208,8 @@ async def test_all_wrong_run_tallies_zero_not_missing():
     redis = _redis_store()
     session = "22222222-2222-2222-2222-222222222222"
 
-    await tally_answer(redis, session_id=session, correct=False)
-    await tally_answer(redis, session_id=session, correct=False)
+    await tally_answer(redis, session_id=session, question_id="q1", correct=False)
+    await tally_answer(redis, session_id=session, question_id="q2", correct=False)
 
     assert await read_tally(redis, session) == 0
 
@@ -202,6 +217,47 @@ async def test_all_wrong_run_tallies_zero_not_missing():
 @pytest.mark.asyncio
 async def test_read_tally_is_none_when_session_never_graded():
     assert await read_tally(_redis_store(), "33333333-3333-3333-3333-333333333333") is None
+
+
+@pytest.mark.asyncio
+async def test_revisiting_a_question_does_not_inflate_the_score():
+    """
+    #532 acceptance: a student who answers 3 of 4 correctly scores 3/4 no matter
+    how many times they revisit a question. Re-confirming a correct answer must
+    not count it twice (the old blind INCR tally's flaw).
+    """
+    redis = _redis_store()
+    session = "44444444-4444-4444-4444-444444444444"
+
+    await tally_answer(redis, session_id=session, question_id="q1", correct=True)
+    await tally_answer(redis, session_id=session, question_id="q2", correct=True)
+    await tally_answer(redis, session_id=session, question_id="q3", correct=True)
+    await tally_answer(redis, session_id=session, question_id="q4", correct=False)
+    assert await read_tally(redis, session) == 3
+
+    # Revisit q1 and re-submit the same correct answer — still 3, not 4.
+    await tally_answer(redis, session_id=session, question_id="q1", correct=True)
+    assert await read_tally(redis, session) == 3
+
+
+@pytest.mark.asyncio
+async def test_changing_an_answer_takes_only_the_latest_verdict():
+    """Revisiting to change an answer overwrites its verdict — a right answer
+    later changed to wrong drops the score, and vice-versa."""
+    redis = _redis_store()
+    session = "55555555-5555-5555-5555-555555555555"
+
+    await tally_answer(redis, session_id=session, question_id="q1", correct=True)
+    await tally_answer(redis, session_id=session, question_id="q2", correct=True)
+    assert await read_tally(redis, session) == 2
+
+    # Change q2 from correct to wrong.
+    await tally_answer(redis, session_id=session, question_id="q2", correct=False)
+    assert await read_tally(redis, session) == 1
+
+    # Change it back.
+    await tally_answer(redis, session_id=session, question_id="q2", correct=True)
+    assert await read_tally(redis, session) == 2
 
 
 # ── The graded set is pinned for the life of the session ──────────────────────

--- a/web/components/content/QuizPlayer.tsx
+++ b/web/components/content/QuizPlayer.tsx
@@ -1,77 +1,107 @@
 "use client";
 
-import { useReducer } from "react";
+import { useReducer, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import type { QuizContent, AnswerResponse, SessionEndResponse } from "@/lib/types/api";
 import { Button } from "@/components/ui/button";
 import { LinkButton } from "@/components/ui/link-button";
-import { CheckCircle2, XCircle, Trophy, RefreshCw } from "lucide-react";
+import {
+  CheckCircle2,
+  XCircle,
+  Trophy,
+  RefreshCw,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { submitAnswer, endSession } from "@/lib/api/progress";
 
 // ─── State machine ────────────────────────────────────────────────────────────
+//
+// The quiz no longer grades in front of the student. Every answer is still
+// submitted as it is picked (the server keeps its own tally, #532 blocker), but
+// the verdict is withheld: the student answers everything at their own pace,
+// moving freely between questions, then sees one summary at the end. The cached
+// AnswerResponse per question feeds that summary — it is never rendered mid-quiz.
 
-type Phase = "answering" | "reviewing" | "scoring";
+type SaveStatus = "idle" | "saving" | "saved" | "error";
+
+interface QuestionState {
+  selectedIndex: number | null;
+  /** Server verdict — held back until the summary; also drives the retry-on-error hint. */
+  result: AnswerResponse | null;
+  save: SaveStatus;
+}
 
 interface State {
-  phase: Phase;
-  questionIndex: number;
-  selectedIndex: number | null;
-  answerResult: AnswerResponse | null;
-  correctCount: number;
+  phase: "answering" | "summary";
+  current: number;
+  questions: QuestionState[];
+  /** Blank-warning confirmation is open. */
+  confirming: boolean;
+  finishing: boolean;
+  finishError: boolean;
   result: SessionEndResponse | null;
-  /** Set when a submit/finish request fails, so the student is told something
-   *  happened instead of facing a button that does nothing (#524). */
-  failed: boolean;
-  busy: boolean;
 }
 
 type Action =
-  | { type: "SELECT"; index: number }
-  | { type: "SUBMITTING" }
-  | { type: "FAILED" }
-  | { type: "REVIEWED"; result: AnswerResponse }
-  | { type: "NEXT" }
-  | { type: "SCORE"; result: SessionEndResponse };
+  | { type: "GOTO"; index: number }
+  | { type: "SELECT"; index: number; choice: number }
+  | { type: "SAVED"; index: number; result: AnswerResponse }
+  | { type: "SAVE_ERROR"; index: number }
+  | { type: "OPEN_CONFIRM" }
+  | { type: "CLOSE_CONFIRM" }
+  | { type: "FINISHING" }
+  | { type: "FINISH_ERROR" }
+  | { type: "FINISHED"; result: SessionEndResponse };
+
+function patchQuestion(
+  state: State,
+  index: number,
+  patch: Partial<QuestionState>,
+): QuestionState[] {
+  return state.questions.map((q, i) => (i === index ? { ...q, ...patch } : q));
+}
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
+    case "GOTO":
+      return { ...state, current: action.index };
     case "SELECT":
-      return { ...state, selectedIndex: action.index, failed: false };
-    case "SUBMITTING":
-      return { ...state, busy: true, failed: false };
-    case "FAILED":
-      return { ...state, busy: false, failed: true };
-    case "REVIEWED":
       return {
         ...state,
-        phase: "reviewing",
-        busy: false,
-        failed: false,
-        answerResult: action.result,
-        // Local tally is for display only. The score on the result screen is the
-        // server's — it grades each answer and keeps its own count.
-        correctCount: action.result.correct ? state.correctCount + 1 : state.correctCount,
+        // Optimistic: highlight immediately, clear any prior verdict (it is being
+        // re-graded), and drop a stale error so the option looks live again.
+        questions: patchQuestion(state, action.index, {
+          selectedIndex: action.choice,
+          result: null,
+          save: "saving",
+        }),
       };
-    case "NEXT":
+    case "SAVED":
       return {
         ...state,
-        phase: "answering",
-        questionIndex: state.questionIndex + 1,
-        selectedIndex: null,
-        answerResult: null,
-        busy: false,
-        failed: false,
+        questions: patchQuestion(state, action.index, {
+          result: action.result,
+          save: "saved",
+        }),
       };
-    case "SCORE":
+    case "SAVE_ERROR":
       return {
         ...state,
-        phase: "scoring",
-        busy: false,
-        failed: false,
-        result: action.result,
+        questions: patchQuestion(state, action.index, { save: "error" }),
       };
+    case "OPEN_CONFIRM":
+      return { ...state, confirming: true };
+    case "CLOSE_CONFIRM":
+      return { ...state, confirming: false };
+    case "FINISHING":
+      return { ...state, finishing: true, finishError: false, confirming: false };
+    case "FINISH_ERROR":
+      return { ...state, finishing: false, finishError: true };
+    case "FINISHED":
+      return { ...state, phase: "summary", finishing: false, result: action.result };
     default:
       return state;
   }
@@ -82,98 +112,183 @@ function reducer(state: State, action: Action): State {
 interface QuizPlayerProps {
   quiz: QuizContent;
   sessionId: string;
-  /** Restart the quiz with a fresh session. The score screen "Try Again" button
-   *  calls this instead of navigating to the same URL (which did nothing — #459). */
+  /** Restart the quiz with a fresh session. The summary "Try Again" button calls
+   *  this instead of navigating to the same URL (which did nothing — #459). */
   onRetry?: () => void;
 }
 
 export function QuizPlayer({ quiz, sessionId, onRetry }: QuizPlayerProps) {
   const t = useTranslations("result_screen");
+  const tq = useTranslations("quiz_screen");
   const queryClient = useQueryClient();
+
   const [state, dispatch] = useReducer(reducer, {
     phase: "answering",
-    questionIndex: 0,
-    selectedIndex: null,
-    answerResult: null,
-    correctCount: 0,
+    current: 0,
+    questions: quiz.questions.map(() => ({
+      selectedIndex: null,
+      result: null,
+      save: "idle" as SaveStatus,
+    })),
+    confirming: false,
+    finishing: false,
+    finishError: false,
     result: null,
-    failed: false,
-    busy: false,
   });
 
-  const question = quiz.questions[state.questionIndex];
-  const isLast = state.questionIndex === quiz.questions.length - 1;
+  // Answers are submitted as they are picked; end_session reads the server tally
+  // those requests build. Await any still in flight before finishing so the tally
+  // reflects the final selections (submitAnswer updates it synchronously).
+  const pendingSaves = useRef<Promise<unknown>[]>([]);
 
-  async function handleSubmit() {
-    if (state.selectedIndex === null || state.busy) return;
-    dispatch({ type: "SUBMITTING" });
+  const total = quiz.questions.length;
+  const blanks = state.questions.filter((q) => q.selectedIndex === null).length;
+
+  function handleSelect(choice: number) {
+    const index = state.current;
+    const question = quiz.questions[index];
+    // Re-picking the same option is a no-op; the server would just overwrite it.
+    if (state.questions[index].selectedIndex === choice) return;
+
+    dispatch({ type: "SELECT", index, choice });
+    const p = submitAnswer({
+      session_id: sessionId,
+      question_id: question.question_id,
+      answer_index: choice,
+    })
+      .then((result) => dispatch({ type: "SAVED", index, result }))
+      .catch(() => dispatch({ type: "SAVE_ERROR", index }));
+    pendingSaves.current.push(p);
+  }
+
+  async function doFinish() {
+    dispatch({ type: "FINISHING" });
     try {
-      // The server grades this. We send the choice; it returns the verdict, the
-      // correct option and the explanation — none of which we had beforehand.
-      const res = await submitAnswer({
-        session_id: sessionId,
-        question_id: question.question_id,
-        answer_index: state.selectedIndex,
-      });
-      dispatch({ type: "REVIEWED", result: res });
+      // Let every in-flight answer land so the tally is complete before we read it.
+      await Promise.allSettled(pendingSaves.current);
+      const result = await endSession(sessionId);
+      // Completion is written synchronously, so stats/history reads are fresh —
+      // refresh them now rather than waiting for a manual reload (#466).
+      queryClient.invalidateQueries({ queryKey: ["stats"] });
+      queryClient.invalidateQueries({ queryKey: ["progress"] });
+      dispatch({ type: "FINISHED", result });
     } catch {
-      // Never leave the button silently dead — that is how #524 reached a QA
-      // pass unnoticed. The message stays non-technical (Content Rule #5).
-      dispatch({ type: "FAILED" });
+      dispatch({ type: "FINISH_ERROR" });
     }
   }
 
-  async function handleNext() {
-    if (state.busy) return;
-    if (isLast) {
-      dispatch({ type: "SUBMITTING" });
-      try {
-        // No score is sent: the backend reports what it graded during the session.
-        const res = await endSession(sessionId);
-        // Session completion is written synchronously by endSession, so the
-        // stats/history reads are fresh — refresh them now instead of waiting for
-        // a manual browser reload (#466).
-        queryClient.invalidateQueries({ queryKey: ["stats"] });
-        queryClient.invalidateQueries({ queryKey: ["progress"] });
-        dispatch({ type: "SCORE", result: res });
-      } catch {
-        dispatch({ type: "FAILED" });
-      }
-    } else {
-      dispatch({ type: "NEXT" });
+  function handleFinish() {
+    if (state.finishing) return;
+    if (blanks > 0) {
+      dispatch({ type: "OPEN_CONFIRM" });
+      return;
     }
+    void doFinish();
   }
 
-  // Score screen
-  if (state.phase === "scoring" && state.result) {
+  // ── Summary screen ──────────────────────────────────────────────────────────
+  if (state.phase === "summary" && state.result) {
     const { score: rawScore, total: rawTotal, passed, attempt_number } = state.result;
     // Defensive clamp: never render an impossible result (e.g. 8/5 = 160%).
-    // The backend also clamps on write — this guards any legacy/stale data too.
-    const total = rawTotal > 0 ? rawTotal : 1;
-    const score = Math.max(0, Math.min(rawScore, total));
-    const pct = Math.round((score / total) * 100);
+    const totalQ = rawTotal > 0 ? rawTotal : 1;
+    const score = Math.max(0, Math.min(rawScore, totalQ));
+    const pct = Math.round((score / totalQ) * 100);
+
     return (
-      <div className="space-y-6 py-8 text-center">
-        <div className="flex justify-center">
-          {passed ? (
-            <Trophy className="h-16 w-16 text-yellow-400" />
-          ) : (
-            <RefreshCw className="h-16 w-16 text-gray-400" />
+      <div className="space-y-6 py-2">
+        {/* Score header */}
+        <div className="space-y-3 py-4 text-center">
+          <div className="flex justify-center">
+            {passed ? (
+              <Trophy className="h-16 w-16 text-yellow-400" />
+            ) : (
+              <RefreshCw className="h-16 w-16 text-gray-400" />
+            )}
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900">
+            {passed ? t("passed_heading") : t("try_again_heading")}
+          </h2>
+          {quiz.subject && (
+            <p className="text-xs font-medium tracking-wide text-gray-400 uppercase">
+              {quiz.subject}
+            </p>
           )}
-        </div>
-        <h2 className="text-2xl font-bold text-gray-900">
-          {passed ? t("passed_heading") : t("try_again_heading")}
-        </h2>
-        {quiz.subject && (
-          <p className="text-xs font-medium tracking-wide text-gray-400 uppercase">
-            {quiz.subject}
+          <p className="text-gray-500">
+            {t("score_label", { score, total: totalQ, pct })}
           </p>
-        )}
-        <p className="text-gray-500">{t("score_label", { score, total, pct })}</p>
-        <p className="text-sm text-gray-400">
-          {t("attempt_label", { attempt: attempt_number })}
-        </p>
-        <div className="flex justify-center gap-3">
+          <p className="text-sm text-gray-400">
+            {t("attempt_label", { attempt: attempt_number })}
+          </p>
+        </div>
+
+        {/* Per-question review */}
+        <h3 className="text-sm font-semibold tracking-wide text-gray-500 uppercase">
+          {tq("summary_heading")}
+        </h3>
+        <ol className="space-y-4">
+          {quiz.questions.map((question, qi) => {
+            const { selectedIndex, result } = state.questions[qi];
+            const answered = selectedIndex !== null;
+            const correctIndex = result?.correct_index ?? null;
+
+            return (
+              <li
+                key={question.question_id}
+                className="rounded-lg border bg-white p-4 shadow-sm"
+              >
+                <p className="mb-3 font-medium text-gray-900">
+                  <span className="text-gray-400">{qi + 1}. </span>
+                  {question.question}
+                </p>
+                <ul className="space-y-2">
+                  {question.options.map((option, oi) => {
+                    const isChosen = selectedIndex === oi;
+                    const isCorrect = correctIndex === oi;
+                    return (
+                      <li
+                        key={oi}
+                        className={cn(
+                          "flex items-center gap-2 rounded-md border px-3 py-2 text-sm",
+                          isCorrect
+                            ? "border-green-500 bg-green-50 text-green-800"
+                            : isChosen
+                              ? "border-red-500 bg-red-50 text-red-800"
+                              : "border-gray-100 text-gray-600",
+                        )}
+                      >
+                        {isCorrect ? (
+                          <CheckCircle2 className="h-4 w-4 shrink-0 text-green-600" />
+                        ) : isChosen ? (
+                          <XCircle className="h-4 w-4 shrink-0 text-red-500" />
+                        ) : (
+                          <span className="h-4 w-4 shrink-0" />
+                        )}
+                        <span>{option}</span>
+                        {isChosen && (
+                          <span className="ml-auto text-xs font-medium text-gray-400">
+                            {tq("your_answer")}
+                          </span>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+                {!answered && (
+                  <p className="mt-2 text-xs font-medium text-amber-600">
+                    {tq("not_answered")}
+                  </p>
+                )}
+                {result?.explanation && (
+                  <div className="mt-3 rounded-md border bg-gray-50 p-3 text-sm text-gray-600">
+                    {result.explanation}
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+
+        <div className="flex justify-center gap-3 pt-2">
           {!passed && onRetry && (
             <Button variant="outline" onClick={onRetry}>
               {t("try_again_btn")}
@@ -185,30 +300,45 @@ export function QuizPlayer({ quiz, sessionId, onRetry }: QuizPlayerProps) {
     );
   }
 
-  // Question screen
+  // ── Answering screen ────────────────────────────────────────────────────────
+  const question = quiz.questions[state.current];
+  const currentState = state.questions[state.current];
+  const isFirst = state.current === 0;
+  const isLast = state.current === total - 1;
+
   return (
     <div className="space-y-6">
-      {/* Progress */}
-      <div className="flex items-center justify-between text-sm text-gray-500">
-        <span>
-          Question {state.questionIndex + 1} of {quiz.questions.length}
-        </span>
-        <div className="flex gap-1">
-          {quiz.questions.map((_, i) => (
-            <div
+      {/* Question-number row: answered / current / blank, tappable to jump */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        {quiz.questions.map((_, i) => {
+          const answered = state.questions[i].selectedIndex !== null;
+          const isCurrent = i === state.current;
+          return (
+            <button
               key={i}
+              type="button"
+              onClick={() => dispatch({ type: "GOTO", index: i })}
+              aria-label={tq("jump_to_question", { n: i + 1 })}
+              aria-current={isCurrent ? "step" : undefined}
               className={cn(
-                "h-1.5 w-6 rounded-full",
-                i < state.questionIndex
-                  ? "bg-blue-500"
-                  : i === state.questionIndex
-                    ? "bg-blue-300"
-                    : "bg-gray-100",
+                "h-8 w-8 rounded-full border text-xs font-semibold transition-colors",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+                isCurrent
+                  ? "border-blue-500 bg-blue-500 text-white"
+                  : answered
+                    ? "border-blue-300 bg-blue-50 text-blue-700"
+                    : "border-gray-200 bg-white text-gray-400 hover:bg-gray-50",
               )}
-            />
-          ))}
-        </div>
+            >
+              {i + 1}
+            </button>
+          );
+        })}
       </div>
+
+      <p className="text-sm text-gray-500">
+        {tq("question_progress", { current: state.current + 1, total })}
+      </p>
 
       {/* Question */}
       <div className="rounded-lg border bg-white p-6 shadow-sm">
@@ -216,76 +346,93 @@ export function QuizPlayer({ quiz, sessionId, onRetry }: QuizPlayerProps) {
 
         <div className="space-y-3">
           {question.options.map((option, i) => {
-            const isSelected = state.selectedIndex === i;
-            const reviewed = state.phase === "reviewing";
-            // Which option is right is only known once the server has told us —
-            // it isn't in the quiz payload.
-            const isCorrect = reviewed && i === state.answerResult?.correct_index;
-
-            const variant = "outline";
-            let extra = "";
-            if (reviewed && isCorrect)
-              extra = "border-green-500 bg-green-50 text-green-800";
-            else if (reviewed && isSelected && !isCorrect)
-              extra = "border-red-500 bg-red-50 text-red-800";
-            else if (isSelected) extra = "border-blue-500 bg-blue-50 text-blue-800";
-
+            const isSelected = currentState.selectedIndex === i;
+            // No verdict mid-quiz: the only state shown is which option is picked.
             return (
               <button
                 key={i}
-                disabled={reviewed}
-                onClick={() => dispatch({ type: "SELECT", index: i })}
+                type="button"
+                onClick={() => handleSelect(i)}
+                aria-pressed={isSelected}
                 className={cn(
                   "w-full rounded-lg border px-4 py-3 text-left text-sm font-medium transition-colors",
                   "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
-                  extra || (isSelected ? "" : "hover:bg-gray-50"),
-                  variant,
+                  isSelected
+                    ? "border-blue-500 bg-blue-50 text-blue-800"
+                    : "border-border bg-background hover:bg-gray-50",
                 )}
               >
-                <span className="flex items-center gap-2">
-                  {reviewed && isCorrect && (
-                    <CheckCircle2 className="h-4 w-4 text-green-600" />
-                  )}
-                  {reviewed && isSelected && !isCorrect && (
-                    <XCircle className="h-4 w-4 text-red-500" />
-                  )}
-                  {option}
-                </span>
+                {option}
               </button>
             );
           })}
         </div>
 
-        {/* Explanation — supplied by the server with the verdict */}
-        {state.phase === "reviewing" && state.answerResult?.explanation && (
-          <div className="mt-4 rounded-lg border bg-gray-50 p-3 text-sm text-gray-600">
-            {state.answerResult.explanation}
-          </div>
+        {/* Answer failed to save. Plain language, no status codes or ids — this is
+            student-facing (Content Rule #5). Re-tapping the option retries. */}
+        {currentState.save === "error" && (
+          <p role="alert" className="mt-4 text-sm text-red-600">
+            {tq("save_error")}
+          </p>
         )}
       </div>
 
-      {/* Something went wrong on the way to the server. Plain language, no
-          status codes or ids — this is a student-facing message. */}
-      {state.failed && (
+      {/* Blank-warning confirmation */}
+      {state.confirming && (
+        <div
+          role="alertdialog"
+          aria-labelledby="quiz-confirm-title"
+          aria-describedby="quiz-confirm-body"
+          className="rounded-lg border border-amber-300 bg-amber-50 p-4"
+        >
+          <p id="quiz-confirm-title" className="font-medium text-amber-900">
+            {tq("blank_warning_title")}
+          </p>
+          <p id="quiz-confirm-body" className="mt-1 text-sm text-amber-800">
+            {tq("blank_warning_body", { count: blanks })}
+          </p>
+          <div className="mt-3 flex justify-end gap-2">
+            <Button variant="outline" onClick={() => dispatch({ type: "CLOSE_CONFIRM" })}>
+              {tq("blank_warning_cancel")}
+            </Button>
+            <Button onClick={() => void doFinish()} disabled={state.finishing}>
+              {tq("blank_warning_confirm")}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {state.finishError && (
         <p role="alert" className="text-sm text-red-600">
-          We couldn&apos;t save that answer. Check your connection and try again.
+          {tq("finish_error")}
         </p>
       )}
 
-      {/* Action button */}
-      <div className="flex justify-end">
-        {state.phase === "answering" ? (
-          <Button
-            onClick={handleSubmit}
-            disabled={state.selectedIndex === null || state.busy}
-          >
-            {state.busy ? "Checking…" : state.failed ? "Try again" : "Submit answer"}
+      {/* Navigation + finish */}
+      <div className="flex items-center justify-between">
+        <Button
+          variant="outline"
+          onClick={() => dispatch({ type: "GOTO", index: state.current - 1 })}
+          disabled={isFirst}
+        >
+          <ChevronLeft className="h-4 w-4" />
+          {tq("back")}
+        </Button>
+
+        <div className="flex gap-2">
+          {!isLast && (
+            <Button
+              variant="outline"
+              onClick={() => dispatch({ type: "GOTO", index: state.current + 1 })}
+            >
+              {tq("next")}
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          )}
+          <Button onClick={handleFinish} disabled={state.finishing}>
+            {state.finishing ? tq("finishing") : tq("finish")}
           </Button>
-        ) : (
-          <Button onClick={handleNext} disabled={state.busy}>
-            {isLast ? "See results" : "Next question"}
-          </Button>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -217,6 +217,23 @@
     "try_again_btn": "Try Again",
     "back_to_curriculum_btn": "Back to Curriculum"
   },
+  "quiz_screen": {
+    "question_progress": "Question {current} of {total}",
+    "back": "Back",
+    "next": "Next",
+    "finish": "Finish quiz",
+    "finishing": "Finishing…",
+    "save_error": "We couldn't save that answer. Check your connection and tap the option again.",
+    "jump_to_question": "Go to question {n}",
+    "blank_warning_title": "Finish with unanswered questions?",
+    "blank_warning_body": "You have {count} unanswered question(s). They'll be marked as incorrect.",
+    "blank_warning_confirm": "Finish anyway",
+    "blank_warning_cancel": "Keep going",
+    "finish_error": "We couldn't finish the quiz. Check your connection and try again.",
+    "summary_heading": "Your answers",
+    "your_answer": "Your answer",
+    "not_answered": "You didn't answer this question."
+  },
   "dashboard_screen": {
     "title": "Dashboard",
     "greeting": "Hello, {name}!",

--- a/web/i18n/es.json
+++ b/web/i18n/es.json
@@ -123,6 +123,23 @@
     "try_again_btn": "Intentar de nuevo",
     "back_to_curriculum_btn": "Volver al currículo"
   },
+  "quiz_screen": {
+    "question_progress": "Pregunta {current} de {total}",
+    "back": "Atrás",
+    "next": "Siguiente",
+    "finish": "Finalizar el examen",
+    "finishing": "Finalizando…",
+    "save_error": "No pudimos guardar esa respuesta. Revisa tu conexión y vuelve a tocar la opción.",
+    "jump_to_question": "Ir a la pregunta {n}",
+    "blank_warning_title": "¿Finalizar con preguntas sin responder?",
+    "blank_warning_body": "Tienes {count} pregunta(s) sin responder. Se marcarán como incorrectas.",
+    "blank_warning_confirm": "Finalizar de todos modos",
+    "blank_warning_cancel": "Seguir",
+    "finish_error": "No pudimos finalizar el examen. Revisa tu conexión e inténtalo de nuevo.",
+    "summary_heading": "Tus respuestas",
+    "your_answer": "Tu respuesta",
+    "not_answered": "No respondiste esta pregunta."
+  },
   "dashboard_screen": {
     "title": "Panel",
     "greeting": "¡Hola, {name}!",

--- a/web/i18n/fr.json
+++ b/web/i18n/fr.json
@@ -123,6 +123,23 @@
     "try_again_btn": "Réessayer",
     "back_to_curriculum_btn": "Retour au programme"
   },
+  "quiz_screen": {
+    "question_progress": "Question {current} sur {total}",
+    "back": "Précédent",
+    "next": "Suivant",
+    "finish": "Terminer le quiz",
+    "finishing": "Finalisation…",
+    "save_error": "Nous n'avons pas pu enregistrer cette réponse. Vérifie ta connexion et retouche l'option.",
+    "jump_to_question": "Aller à la question {n}",
+    "blank_warning_title": "Terminer avec des questions sans réponse ?",
+    "blank_warning_body": "Il te reste {count} question(s) sans réponse. Elles seront comptées comme incorrectes.",
+    "blank_warning_confirm": "Terminer quand même",
+    "blank_warning_cancel": "Continuer",
+    "finish_error": "Nous n'avons pas pu terminer le quiz. Vérifie ta connexion et réessaie.",
+    "summary_heading": "Tes réponses",
+    "your_answer": "Ta réponse",
+    "not_answered": "Tu n'as pas répondu à cette question."
+  },
   "dashboard_screen": {
     "title": "Tableau de bord",
     "greeting": "Bonjour, {name} !",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -91,13 +91,17 @@ export default defineConfig({
     command: "npm run dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
-    // Fake Auth0 env vars so auth0.getSession() initialises without crashing.
-    // With no real session cookie present it returns null → layout redirects as expected.
-    // Dev-session cookie is used instead in persona tests.
+    // Fake Auth0 env vars so the @auth0/nextjs-auth0 v4 Auth0Client initialises
+    // without crashing. With no real session cookie present getSession() returns
+    // null → layout redirects as expected; persona tests use the dev-session
+    // cookie instead. v4 renamed these: AUTH0_DOMAIN (not AUTH0_ISSUER_BASE_URL)
+    // and APP_BASE_URL (not AUTH0_BASE_URL); a missing AUTH0_DOMAIN aborts boot
+    // (same fix as CI's e2e.yml, #535) so local `npx playwright test` never
+    // started the dev server.
     env: {
       AUTH0_SECRET: "test-auth0-secret-for-e2e-testing-only-placeholder",
-      AUTH0_BASE_URL: "http://localhost:3000",
-      AUTH0_ISSUER_BASE_URL: "https://test.auth0.example.com",
+      AUTH0_DOMAIN: "test.auth0.com",
+      APP_BASE_URL: "http://localhost:3000",
       AUTH0_CLIENT_ID: "test_client_id",
       AUTH0_CLIENT_SECRET: "test_client_secret",
       NEXT_PUBLIC_API_URL: "http://localhost:8000/api/v1",

--- a/web/tests/e2e/data/quiz-page.ts
+++ b/web/tests/e2e/data/quiz-page.ts
@@ -182,9 +182,15 @@ export const MOCK_SESSION_END_FAILED: SessionEndResponse = {
 // ---------------------------------------------------------------------------
 
 export const QUIZ_STRINGS = {
-  submitBtn: "Submit answer",
-  nextBtn: "Next question",
-  seeResultsBtn: "See results",
+  // #532 flow: answers submit on pick (no per-question Submit button); Next/Back
+  // navigate; Finish ends the quiz; verdicts appear only on the summary.
+  nextBtn: "Next",
+  backBtn: "Back",
+  finishBtn: "Finish quiz",
+  summaryHeading: "Your answers",
+  yourAnswer: "Your answer",
+  saveError:
+    "We couldn't save that answer. Check your connection and tap the option again.",
   passedHeading: "passed_heading",
   tryAgainHeading: "try_again_heading",
   backToCurriculum: "back_to_curriculum_btn",

--- a/web/tests/e2e/quiz-suite/quiz-failure.spec.ts
+++ b/web/tests/e2e/quiz-suite/quiz-failure.spec.ts
@@ -13,14 +13,15 @@
  *
  *  2. "mid-quiz" — the quiz loads fine and <QuizPlayer> IS mounted and
  *     answering, but the grading call (POST /progress/session/{id}/answer)
- *     fails while the student is mid-quiz. This is the LITERAL #524 symptom
- *     ("Submit is not taking me to the next question"): before PR #528,
- *     `handleSubmit`'s rejection was swallowed and the button just sat there.
- *     #528 added QuizPlayer's `failed` state — the message "We couldn't save
- *     that answer. Check your connection and try again." and the action
- *     button relabeling from "Submit answer" to "Try again"
- *     (web/components/content/QuizPlayer.tsx). Nothing under web/tests
- *     exercised this path before this spec.
+ *     fails while the student is mid-quiz. This is the descendant of the #524
+ *     symptom ("Submit is not taking me to the next question"): a swallowed
+ *     rejection would leave the student stuck with no feedback. In the #532
+ *     defer-results flow answers submit on pick, so on failure QuizPlayer marks
+ *     that question's save as errored and shows the message "We couldn't save
+ *     that answer. Check your connection and tap the option again."
+ *     (web/i18n/en.json → quiz_screen.save_error); the option stays interactive
+ *     so re-tapping retries. Nothing under web/tests exercised this path before
+ *     this spec.
  *
  * No route mocks in either test: failures are induced by mutating the real
  * content store / cache so the real backend call really fails.
@@ -104,19 +105,26 @@ test.describe("mid-quiz grading failure", () => {
     // confirm an answer grades successfully (the player advances past
     // "answering" instead of showing the FAILED state this spec induces).
     const fixture = loadFixture();
+    // Prove the unit grades again by running the full loop: answer all three
+    // questions (#532 submits on pick) and finish to a summary with a real score.
+    // If the restore had failed, picking an option would surface the save-error
+    // message instead.
     await page.goto(`/quiz/${fixture.unit_quiz}`);
     await expect(page.getByText(/question 1 of/i)).toBeVisible({ timeout: 15000 });
-    await page
-      .getByRole("button", { name: /^Option /i })
-      .first()
-      .click();
-    await page.getByRole("button", { name: /submit answer/i }).click();
-    await expect(
-      page.getByRole("button", { name: /next question|see results/i }),
-    ).toBeVisible({ timeout: 15000 });
+    for (let i = 0; i < 3; i++) {
+      await page
+        .getByRole("button", { name: /^Option /i })
+        .first()
+        .click();
+      if (i < 2) await page.getByRole("button", { name: /^next$/i }).click();
+    }
+    await page.getByRole("button", { name: /finish quiz/i }).click();
+    await expect(page.getByText(/score:\s*\d+\s*\/\s*3/i)).toBeVisible({
+      timeout: 15000,
+    });
   });
 
-  test("a grading failure mid-quiz shows the failure message and 'Try again', not a dead button", async ({
+  test("a grading failure mid-quiz shows the save-error message and keeps the option live, not a dead button", async ({
     page,
   }) => {
     const fixture = loadFixture();
@@ -200,24 +208,25 @@ test.describe("mid-quiz grading failure", () => {
       { cwd: REPO_ROOT },
     );
 
-    // Answer the now-ungraded question. The real POST 404s ("quiz_not_found" —
-    // backend/src/progress/router.py's FileNotFoundError handler); QuizPlayer's
-    // catch dispatches FAILED (#528).
+    // Answer the now-ungraded question. Picking an option submits it (#532);
+    // the real POST 404s ("quiz_not_found" — backend/src/progress/router.py's
+    // FileNotFoundError handler) and QuizPlayer marks that question's save as
+    // errored instead of failing silently (the #524 lesson).
     await page
       .getByRole("button", { name: /^Option /i })
       .first()
       .click();
-    await page.getByRole("button", { name: /submit answer/i }).click();
 
-    // The exact copy from QuizPlayer.tsx — not a generic truthy check.
+    // The exact copy from QuizPlayer.tsx (quiz_screen.save_error) — not a generic
+    // truthy check. Retry is by re-tapping the option, so the option stays live.
     await expect(
       page.getByText(
-        "We couldn't save that answer. Check your connection and try again.",
+        "We couldn't save that answer. Check your connection and tap the option again.",
       ),
     ).toBeVisible({ timeout: 15000 });
 
-    // The button must offer a real retry, not stay dead on "Submit answer".
-    await expect(page.getByRole("button", { name: /^try again$/i })).toBeVisible();
+    // The option must remain interactive so re-tapping can retry — not a dead end.
+    await expect(page.getByRole("button", { name: /^Option /i }).first()).toBeEnabled();
 
     // Whatever is shown must be student-safe: no status codes, no stack traces,
     // no internal error codes.

--- a/web/tests/e2e/quiz-suite/quiz-journey.spec.ts
+++ b/web/tests/e2e/quiz-suite/quiz-journey.spec.ts
@@ -1,6 +1,7 @@
 /**
- * The reported symptom of #524, asserted in a real browser:
- * "In Quiz - Submit is not taking me to the next question."
+ * The reported symptom of #524, re-cast for the #532 defer-results flow and
+ * asserted in a real browser: picking an option records the answer and Next
+ * advances — navigation is never a dead end.
  *
  * No route mocks: this drives the real /signin form, the real
  * /quiz/{unit_id} page, and the real backend (POST /progress/answer,
@@ -12,10 +13,10 @@
  *   - option buttons render as `Option {option_id}` (from the fixture's
  *     quiz content in backend/quiz_suite/seed.py), no other accessible
  *     name prefix
- *   - the action button reads "Submit answer" while answering, then
- *     "Next question" (or "See results" on the last question) once the
- *     server has graded the answer
- *   - the score screen renders "Score: {score}/{total} ({pct}%)"
+ *   - answers submit on pick (no per-question Submit button); "Next"/"Back"
+ *     navigate and "Finish quiz" ends the session — the verdict is withheld
+ *     until the end-of-quiz summary ("Your answers")
+ *   - the summary renders "Score: {score}/{total} ({pct}%)"
  *     (web/i18n/en.json → result_screen.score_label) and
  *     "Attempt #{attempt}" (attempt_label)
  */
@@ -23,7 +24,7 @@ import { test, expect } from "@playwright/test";
 import { loadFixture, loginAsStudentA } from "./fixture";
 
 test.describe("quiz journey (live stack)", () => {
-  test("submit reveals the verdict and advances to the next question", async ({
+  test("picking an option records it and Next advances to the following question", async ({
     page,
   }) => {
     const fixture = loadFixture();
@@ -32,42 +33,45 @@ test.describe("quiz journey (live stack)", () => {
 
     await expect(page.getByText(/question 1 of/i)).toBeVisible({ timeout: 15000 });
 
-    // Pick any option and submit.
+    // Pick any option — it submits in the background; no verdict is shown.
     await page
       .getByRole("button", { name: /^Option /i })
       .first()
       .click();
-    await page.getByRole("button", { name: /submit answer/i }).click();
 
-    // The verdict comes back from the real server, so the action button must
-    // become "Next question". Before the fix this stayed on "Submit answer".
-    await expect(page.getByRole("button", { name: /next question/i })).toBeVisible({
-      timeout: 15000,
-    });
+    // No mid-quiz reveal: the summary heading must not be present yet.
+    await expect(page.getByRole("heading", { name: /your answers/i })).toHaveCount(0);
 
-    await page.getByRole("button", { name: /next question/i }).click();
+    // Navigation advances. Before #524's fix the equivalent action was a dead button.
+    await page.getByRole("button", { name: /^next$/i }).click();
     await expect(page.getByText(/question 2 of/i)).toBeVisible();
   });
 
-  test("completing the quiz reaches a result screen with a real score", async ({
-    page,
-  }) => {
+  test("completing the quiz reaches a summary with a real score", async ({ page }) => {
     const fixture = loadFixture();
     await loginAsStudentA(page);
     await page.goto(`/quiz/${fixture.unit_quiz}`);
     await expect(page.getByText(/question 1 of/i)).toBeVisible({ timeout: 15000 });
 
-    // Walk all three questions.
+    // Answer all three questions, moving with Next.
     for (let i = 0; i < 3; i++) {
       await page
         .getByRole("button", { name: /^Option /i })
         .first()
         .click();
-      await page.getByRole("button", { name: /submit answer/i }).click();
-      const next = page.getByRole("button", { name: /next question|see results/i });
-      await expect(next).toBeVisible({ timeout: 15000 });
-      await next.click();
+      if (i < 2) {
+        await page.getByRole("button", { name: /^next$/i }).click();
+        await expect(
+          page.getByText(new RegExp(`question ${i + 2} of`, "i")),
+        ).toBeVisible();
+      }
     }
+
+    // Every question answered, so Finish goes straight to the summary.
+    await page.getByRole("button", { name: /finish quiz/i }).click();
+    await expect(page.getByRole("heading", { name: /your answers/i })).toBeVisible({
+      timeout: 15000,
+    });
 
     // The brief's original assertion here was `getByText(/\d+\s*\/\s*3|attempt/i)`,
     // matched against a single locator. Playwright's getByText runs in strict

--- a/web/tests/e2e/student_flow.spec.ts
+++ b/web/tests/e2e/student_flow.spec.ts
@@ -281,9 +281,10 @@ test("student learning loop: lesson → quiz → result → progress", async ({ 
     // No verdict mid-quiz: the explanation must NOT appear yet.
     await expect(page.getByText(QUIZ_EXPLANATIONS[i])).toHaveCount(0);
 
-    // Advance (Next) until the last question, then finish.
+    // Advance (Next) until the last question, then finish. `exact` avoids the
+    // Next.js dev-tools button, whose accessible name also contains "Next".
     if (!isLast) {
-      await page.getByRole("button", { name: QUIZ_STRINGS.nextBtn }).click();
+      await page.getByRole("button", { name: QUIZ_STRINGS.nextBtn, exact: true }).click();
     }
   }
   // All questions answered, so Finish goes straight to the summary (no blank warning).

--- a/web/tests/e2e/student_flow.spec.ts
+++ b/web/tests/e2e/student_flow.spec.ts
@@ -263,7 +263,9 @@ test("student learning loop: lesson → quiz → result → progress", async ({ 
   // Quiz title — getQuiz() constructs "Quiz — Set {n}" from the backend set_number
   await expect(page.getByText(MOCK_QUIZ_DISPLAY_TITLE)).toBeVisible();
 
-  // ── Step 3: answer all 3 questions correctly ──────────────────────────────
+  // ── Step 3: answer all 3 questions correctly (#532 defer-results flow) ─────
+  // Answers submit as they are picked; no verdict is shown mid-quiz. The student
+  // moves with Next, then finishes.
   for (let i = 0; i < MOCK_QUIZ.questions.length; i++) {
     const q = MOCK_QUIZ.questions[i];
     const isLast = i === MOCK_QUIZ.questions.length - 1;
@@ -273,26 +275,29 @@ test("student learning loop: lesson → quiz → result → progress", async ({ 
 
     // Select the correct option. The quiz payload no longer carries the answer
     // key, so the fixture supplies it — the page itself cannot know it yet.
+    // Picking the option submits it in the background; nothing is revealed.
     await page.getByRole("button", { name: correctOptionText(i) }).click();
 
-    // Submit
-    await page.getByRole("button", { name: QUIZ_STRINGS.submitBtn }).click();
+    // No verdict mid-quiz: the explanation must NOT appear yet.
+    await expect(page.getByText(QUIZ_EXPLANATIONS[i])).toHaveCount(0);
 
-    // Explanation appears — it arrives with the server's verdict, not with the quiz
-    await expect(page.getByText(QUIZ_EXPLANATIONS[i])).toBeVisible();
-
-    // Advance to next question or results
-    if (isLast) {
-      await page.getByRole("button", { name: QUIZ_STRINGS.seeResultsBtn }).click();
-    } else {
+    // Advance (Next) until the last question, then finish.
+    if (!isLast) {
       await page.getByRole("button", { name: QUIZ_STRINGS.nextBtn }).click();
     }
   }
+  // All questions answered, so Finish goes straight to the summary (no blank warning).
+  await page.getByRole("button", { name: QUIZ_STRINGS.finishBtn }).click();
 
-  // ── Step 4: result screen shows a passing score ───────────────────────────
+  // ── Step 4: summary shows a passing score and the withheld verdicts ───────
   // score_label = "Score: {score}/{total} ({pct}%)" → "Score: 3/3 (100%)"
   // Use regex to avoid strict-mode violation from other elements containing "3".
   await expect(page.getByText(/Score: 3\/3/)).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: QUIZ_STRINGS.summaryHeading }),
+  ).toBeVisible();
+  // Explanations, withheld during the quiz, are now revealed on the summary.
+  await expect(page.getByText(QUIZ_EXPLANATIONS[0])).toBeVisible();
 
   // ── Step 5: progress history reflects the completed unit ─────────────────
   await stubProgressApis(page);

--- a/web/tests/unit/quiz-page.test.tsx
+++ b/web/tests/unit/quiz-page.test.tsx
@@ -1,13 +1,22 @@
 /**
- * Unit tests for section 2.5 — Quiz Page components
+ * Unit tests for section 2.5 — Quiz Page (the #532 defer-results flow)
  * Covers TC-IDs: STU-19, STU-20, STU-21, STU-22, STU-23, STU-24
+ *
+ * The quiz now submits each answer as it is picked but WITHHOLDS the verdict
+ * until an end-of-quiz summary. There is no per-question Submit button and no
+ * mid-quiz green/red reveal. These tests pin that behaviour.
  *
  * Run with:
  *   npm test -- quiz-page
+ *
+ * next-intl is mocked to the identity function, so rendered button labels are
+ * the i18n KEYS (e.g. "next", "finish"), not the English strings. The
+ * quiz_screen keys are referenced directly below; the result_screen constants in
+ * QUIZ_STRINGS already hold their keys.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { QuizPlayer } from "@/components/content/QuizPlayer";
 import {
   MOCK_QUIZ,
@@ -20,6 +29,15 @@ import {
   MOCK_SESSION_END_FAILED,
   QUIZ_STRINGS,
 } from "../e2e/data/quiz-page";
+
+// quiz_screen i18n keys, as rendered under the identity mock below.
+const KEY = {
+  next: "next",
+  finish: "finish",
+  summaryHeading: "summary_heading",
+  saveError: "save_error",
+  confirm: "blank_warning_confirm",
+} as const;
 
 // ---------------------------------------------------------------------------
 // Shared mocks
@@ -53,387 +71,156 @@ vi.mock("@tanstack/react-query", async (importOriginal) => {
   };
 });
 
+beforeEach(() => {
+  mockSubmitAnswer.mockReset().mockResolvedValue(MOCK_ANSWER_CORRECT);
+  mockEndSession.mockReset().mockResolvedValue(MOCK_SESSION_END_PASSED);
+});
+
+function renderQuiz() {
+  return render(<QuizPlayer quiz={MOCK_QUIZ} sessionId={MOCK_SESSION_ID} />);
+}
+
+function optionButton(text: string) {
+  return screen.getByRole("button", { name: text });
+}
+
 // ---------------------------------------------------------------------------
 // STU-19 — Quiz question renders with options
 // ---------------------------------------------------------------------------
 
 describe("STU-19 — Quiz question renders", () => {
   it("renders the first question text", () => {
-    render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
+    renderQuiz();
     expect(screen.getByText(MOCK_QUIZ.questions[0].question)).toBeInTheDocument();
   });
 
-  it("renders all 4 answer option buttons", () => {
-    render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
+  it("renders all answer option buttons", () => {
+    renderQuiz();
     for (const option of MOCK_QUIZ.questions[0].options) {
-      expect(
-        screen.getByRole("button", { name: new RegExp(option) }),
-      ).toBeInTheDocument();
+      expect(optionButton(option)).toBeInTheDocument();
     }
   });
 
-  it("renders progress indicator showing question 1 of N", () => {
-    render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-    expect(
-      screen.getByText(`Question 1 of ${MOCK_QUIZ.questions.length}`),
-    ).toBeInTheDocument();
+  it("renders a question-number row with one entry per question", () => {
+    renderQuiz();
+    // The jump buttons share the (identity-mocked) aria-label "jump_to_question";
+    // there is exactly one per question.
+    const jumpButtons = screen.getAllByRole("button", { name: "jump_to_question" });
+    expect(jumpButtons).toHaveLength(MOCK_QUIZ.questions.length);
+    jumpButtons.forEach((btn, i) => expect(btn).toHaveTextContent(String(i + 1)));
   });
 
-  it("Submit button is initially disabled (no option selected)", () => {
-    render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-    expect(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn })).toBeDisabled();
+  it("has a Finish button and NO per-question Submit button", () => {
+    renderQuiz();
+    expect(screen.getByRole("button", { name: KEY.finish })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /submit/i })).toBeNull();
   });
 });
 
 // ---------------------------------------------------------------------------
-// STU-20 — Selecting answer enables submit button
+// STU-20 — Selecting an answer highlights it and submits it
 // ---------------------------------------------------------------------------
 
-describe("STU-20 — Selecting answer enables submit", () => {
-  it("submit button becomes enabled after clicking an option", () => {
-    render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-    const option = screen.getByRole("button", {
-      name: new RegExp(MOCK_QUIZ.questions[0].options[0]),
-    });
+describe("STU-20 — Selecting an answer", () => {
+  it("highlights the picked option and submits it (no Submit button needed)", async () => {
+    renderQuiz();
+    const option = optionButton(MOCK_QUIZ.questions[0].options[0]);
     fireEvent.click(option);
-    expect(
-      screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }),
-    ).not.toBeDisabled();
+
+    expect(option.getAttribute("aria-pressed")).toBe("true");
+    await waitFor(() =>
+      expect(mockSubmitAnswer).toHaveBeenCalledWith(
+        expect.objectContaining({ answer_index: 0 }),
+      ),
+    );
   });
 
-  it("clicking a different option still keeps submit enabled", () => {
-    render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-    fireEvent.click(
-      screen.getByRole("button", { name: new RegExp(MOCK_QUIZ.questions[0].options[0]) }),
-    );
-    fireEvent.click(
-      screen.getByRole("button", { name: new RegExp(MOCK_QUIZ.questions[0].options[2]) }),
-    );
+  it("changing the choice moves the highlight and submits again", async () => {
+    renderQuiz();
+    fireEvent.click(optionButton(MOCK_QUIZ.questions[0].options[0]));
+    await waitFor(() => expect(mockSubmitAnswer).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(optionButton(MOCK_QUIZ.questions[0].options[2]));
     expect(
-      screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }),
-    ).not.toBeDisabled();
+      optionButton(MOCK_QUIZ.questions[0].options[2]).getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      optionButton(MOCK_QUIZ.questions[0].options[0]).getAttribute("aria-pressed"),
+    ).toBe("false");
+    await waitFor(() => expect(mockSubmitAnswer).toHaveBeenCalledTimes(2));
   });
 });
 
 // ---------------------------------------------------------------------------
-// STU-21 — Correct answer highlighted green after submit
+// STU-21 / STU-22 — The verdict is WITHHELD until the summary
 // ---------------------------------------------------------------------------
 
-describe("STU-21 — Correct answer shown after submit", () => {
-  beforeEach(() => {
-    mockSubmitAnswer.mockResolvedValue(MOCK_ANSWER_CORRECT);
+describe("STU-21/22 — no mid-quiz verdict", () => {
+  it("picking the correct option shows no green highlight and no explanation", async () => {
+    const { container } = renderQuiz();
+    const correct = correctOptionText(0);
+    fireEvent.click(optionButton(correct));
+
+    // Give the (resolved) submit a chance to land — the verdict is cached, not shown.
+    await waitFor(() => expect(mockSubmitAnswer).toHaveBeenCalled());
+    expect(container.querySelector(".bg-green-50")).toBeNull();
+    expect(screen.queryByText(MOCK_ANSWER_CORRECT.explanation)).toBeNull();
   });
 
-  it("correct option gets green background class after submit", async () => {
-    const { container } = render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-
-    // Select the correct option (index 1 → "Cell")
-    const correctOption = correctOptionText(0);
-    fireEvent.click(screen.getByRole("button", { name: new RegExp(correctOption) }));
-    fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
-
-    await waitFor(() => {
-      const buttons = container.querySelectorAll("button");
-      const correctBtn = Array.from(buttons).find((b) =>
-        b.textContent?.includes(correctOption),
-      );
-      expect(correctBtn?.className).toContain("bg-green-50");
-    });
-  });
-
-  it("CheckCircle2 SVG appears on correct option after submit", async () => {
-    const { container } = render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-    const correctOption = correctOptionText(0);
-    fireEvent.click(screen.getByRole("button", { name: new RegExp(correctOption) }));
-    fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
-
-    await waitFor(() => {
-      const buttons = container.querySelectorAll("button");
-      const correctBtn = Array.from(buttons).find((b) =>
-        b.textContent?.includes(correctOption),
-      );
-      expect(correctBtn?.querySelector("svg")).toBeTruthy();
-    });
-  });
-
-  it("option buttons are disabled during reviewing phase", async () => {
-    const { container } = render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-    const correctOption = correctOptionText(0);
-    fireEvent.click(screen.getByRole("button", { name: new RegExp(correctOption) }));
-    fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
-
-    await waitFor(() => {
-      // All option buttons (not Submit/Next) should be disabled
-      const optionBtns =
-        container.querySelectorAll<HTMLButtonElement>("div.space-y-3 button");
-      optionBtns.forEach((btn) => expect(btn).toBeDisabled());
-    });
-  });
-
-  it("explanation text appears after submit", async () => {
-    render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-    const correctOption = correctOptionText(0);
-    fireEvent.click(screen.getByRole("button", { name: new RegExp(correctOption) }));
-    fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
-
-    await waitFor(() => {
-      expect(screen.getByText(MOCK_ANSWER_CORRECT.explanation)).toBeInTheDocument();
-    });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// STU-22 — Wrong answer highlighted red; correct answer revealed
-// ---------------------------------------------------------------------------
-
-describe("STU-22 — Wrong answer shown after submit", () => {
-  beforeEach(() => {
+  it("picking a wrong option shows no red highlight mid-quiz", async () => {
     mockSubmitAnswer.mockResolvedValue(MOCK_ANSWER_WRONG);
-  });
+    const { container } = renderQuiz();
+    fireEvent.click(optionButton(MOCK_QUIZ.questions[0].options[0]));
 
-  it("wrong selected option gets red background class after submit", async () => {
-    const { container } = render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-
-    // Select a wrong option (index 0 → "Atom")
-    const wrongOption = MOCK_QUIZ.questions[0].options[0]; // index 0, correct is index 1
-    fireEvent.click(screen.getByRole("button", { name: new RegExp(wrongOption) }));
-    fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
-
-    await waitFor(() => {
-      const buttons = container.querySelectorAll("button");
-      const wrongBtn = Array.from(buttons).find(
-        (b) => b.textContent?.includes(wrongOption) && !b.textContent?.includes("Cell"),
-      );
-      expect(wrongBtn?.className).toContain("bg-red-50");
-    });
-  });
-
-  it("correct option still gets green background when wrong option selected", async () => {
-    const { container } = render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-    const wrongOption = MOCK_QUIZ.questions[0].options[0];
-    fireEvent.click(screen.getByRole("button", { name: new RegExp(wrongOption) }));
-    fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
-
-    await waitFor(() => {
-      const correctOption = correctOptionText(0);
-      const buttons = container.querySelectorAll("button");
-      const correctBtn = Array.from(buttons).find((b) =>
-        b.textContent?.includes(correctOption),
-      );
-      expect(correctBtn?.className).toContain("bg-green-50");
-    });
-  });
-
-  it("XCircle SVG appears on wrong selected option", async () => {
-    const { container } = render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-    const wrongOption = MOCK_QUIZ.questions[0].options[0];
-    fireEvent.click(screen.getByRole("button", { name: new RegExp(wrongOption) }));
-    fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
-
-    await waitFor(() => {
-      const buttons = container.querySelectorAll("button");
-      const wrongBtn = Array.from(buttons).find(
-        (b) => b.textContent?.includes(wrongOption) && !b.textContent?.includes("Cell"),
-      );
-      expect(wrongBtn?.querySelector("svg")).toBeTruthy();
-    });
+    await waitFor(() => expect(mockSubmitAnswer).toHaveBeenCalled());
+    expect(container.querySelector(".bg-red-50")).toBeNull();
   });
 });
 
 // ---------------------------------------------------------------------------
-// STU-23 — Score screen renders after completing all questions
+// STU-23 — End-of-quiz summary
 // ---------------------------------------------------------------------------
 
-describe("STU-23 — Score screen after quiz completion", () => {
-  beforeEach(() => {
-    mockSubmitAnswer.mockResolvedValue(MOCK_ANSWER_CORRECT);
-  });
-
-  function clickOptionByText(optionText: string) {
-    const btn = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
-      (b) => b.textContent?.trim() === optionText,
-    );
-    if (!btn) throw new Error(`Option button not found: ${optionText}`);
-    fireEvent.click(btn);
-  }
-
-  async function completeQuiz() {
+describe("STU-23 — summary after completion", () => {
+  async function answerAllAndFinish() {
     for (let q = 0; q < MOCK_QUIZ.questions.length; q++) {
-      const correctOption = correctOptionText(q);
-
-      await waitFor(() => {
-        expect(
-          screen.getByText(`Question ${q + 1} of ${MOCK_QUIZ.questions.length}`),
-        ).toBeInTheDocument();
-      });
-
-      clickOptionByText(correctOption);
-      fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
-
-      const isLast = q === MOCK_QUIZ.questions.length - 1;
-      if (isLast) {
-        mockEndSession.mockResolvedValue(MOCK_SESSION_END_PASSED);
-        await waitFor(() => {
-          expect(
-            screen.getByRole("button", { name: QUIZ_STRINGS.seeResultsBtn }),
-          ).toBeInTheDocument();
-        });
-        fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.seeResultsBtn }));
-      } else {
-        await waitFor(() => {
-          expect(
-            screen.getByRole("button", { name: QUIZ_STRINGS.nextBtn }),
-          ).toBeInTheDocument();
-        });
-        fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.nextBtn }));
+      await screen.findByText(MOCK_QUIZ.questions[q].question);
+      fireEvent.click(optionButton(correctOptionText(q)));
+      if (q < MOCK_QUIZ.questions.length - 1) {
+        fireEvent.click(screen.getByRole("button", { name: KEY.next }));
       }
     }
+    fireEvent.click(screen.getByRole("button", { name: KEY.finish }));
   }
 
-  it("score screen shows passed heading (Trophy) when passed", async () => {
-    render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-    mockEndSession.mockResolvedValue(MOCK_SESSION_END_PASSED);
-    await completeQuiz();
+  it("shows the passed heading and Trophy, and reveals the withheld explanation", async () => {
+    const { container } = renderQuiz();
+    await answerAllAndFinish();
 
-    await waitFor(() => {
-      expect(screen.getByText(QUIZ_STRINGS.passedHeading)).toBeInTheDocument();
-    });
+    await waitFor(() =>
+      expect(screen.getByText(QUIZ_STRINGS.passedHeading)).toBeInTheDocument(),
+    );
+    expect(container.querySelector("svg.text-yellow-400")).toBeTruthy();
+    // The summary heading and the previously-withheld explanation are now shown.
+    expect(screen.getByRole("heading", { name: KEY.summaryHeading })).toBeInTheDocument();
+    expect(screen.getAllByText(MOCK_ANSWER_CORRECT.explanation).length).toBeGreaterThan(
+      0,
+    );
   });
 
-  it("score screen shows Trophy SVG when passed", async () => {
-    const { container } = render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-    mockEndSession.mockResolvedValue(MOCK_SESSION_END_PASSED);
-    await completeQuiz();
-
-    await waitFor(() => {
-      // Trophy SVG has text-yellow-400 class
-      const svg = container.querySelector("svg.text-yellow-400");
-      expect(svg).toBeTruthy();
-    });
-  });
-
-  it("score screen shows try_again heading (RefreshCw) when failed", async () => {
+  it("shows the try-again heading when the score does not pass", async () => {
     mockEndSession.mockResolvedValue(MOCK_SESSION_END_FAILED);
-    render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
+    renderQuiz();
+    await answerAllAndFinish();
+
+    await waitFor(() =>
+      expect(screen.getByText(QUIZ_STRINGS.tryAgainHeading)).toBeInTheDocument(),
     );
-
-    // Override endSession to return failed result
-    await completeQuiz();
-
-    await waitFor(() => {
-      // Either passed or try_again heading will appear
-      const heading =
-        screen.queryByText(QUIZ_STRINGS.passedHeading) ||
-        screen.queryByText(QUIZ_STRINGS.tryAgainHeading);
-      expect(heading).toBeInTheDocument();
-    });
   });
 
-  it("back to curriculum link is present on score screen", async () => {
-    render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-    mockEndSession.mockResolvedValue(MOCK_SESSION_END_PASSED);
-    await completeQuiz();
+  it("offers a back-to-curriculum link on the summary", async () => {
+    renderQuiz();
+    await answerAllAndFinish();
 
     await waitFor(() => {
       const link = screen.getByRole("link", { name: QUIZ_STRINGS.backToCurriculum });
@@ -444,69 +231,59 @@ describe("STU-23 — Score screen after quiz completion", () => {
 });
 
 // ---------------------------------------------------------------------------
-// STU-24 — Session starts: submitAnswer called with correct session_id
+// STU-23b — Finishing with blanks warns before scoring
 // ---------------------------------------------------------------------------
 
-describe("STU-24 — Session ID is passed to progress API", () => {
-  beforeEach(() => {
-    mockSubmitAnswer.mockResolvedValue(MOCK_ANSWER_CORRECT);
+describe("STU-23b — blank-answer warning", () => {
+  it("finishing with an unanswered question opens a confirmation before ending", async () => {
+    renderQuiz();
+    // Answer only the first question, leave the rest blank, then Finish.
+    fireEvent.click(optionButton(correctOptionText(0)));
+    fireEvent.click(screen.getByRole("button", { name: KEY.finish }));
+
+    // A confirmation appears and the session has NOT ended yet.
+    const dialog = await screen.findByRole("alertdialog");
+    expect(dialog).toBeInTheDocument();
+    expect(mockEndSession).not.toHaveBeenCalled();
+
+    // Confirming finishes anyway.
+    fireEvent.click(within(dialog).getByRole("button", { name: KEY.confirm }));
+    await waitFor(() => expect(mockEndSession).toHaveBeenCalledWith(MOCK_SESSION_ID));
   });
+});
 
-  it("submitAnswer is called with the provided sessionId", async () => {
-    render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
+// ---------------------------------------------------------------------------
+// STU-24 — API wiring
+// ---------------------------------------------------------------------------
 
-    const correctOption = correctOptionText(0);
-    fireEvent.click(screen.getByRole("button", { name: new RegExp(correctOption) }));
-    fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
+describe("STU-24 — progress API wiring", () => {
+  it("submitAnswer is called with the session id and the content's own question_id", async () => {
+    renderQuiz();
+    fireEvent.click(optionButton(correctOptionText(0)));
 
-    await waitFor(() => {
-      expect(mockSubmitAnswer).toHaveBeenCalledWith(
-        expect.objectContaining({ session_id: MOCK_SESSION_ID }),
-      );
-    });
-  });
-
-  it("no error is rendered when sessionId is provided", () => {
-    render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-    expect(screen.queryByRole("alert")).toBeNull();
-    expect(screen.queryByText(/error/i)).toBeNull();
-  });
-
-  it("submitAnswer is called with the content's own question_id", async () => {
-    render(
-      <QuizPlayer
-        quiz={MOCK_QUIZ}
-        sessionId={MOCK_SESSION_ID}
-        curriculumId="default-2026-g8"
-      />,
-    );
-
-    const correctOption = correctOptionText(0);
-    fireEvent.click(screen.getByRole("button", { name: new RegExp(correctOption) }));
-    fireEvent.click(screen.getByRole("button", { name: QUIZ_STRINGS.submitBtn }));
-
-    await waitFor(() => {
-      // The server grades by question_id; it must be the id from the payload,
-      // not a synthesised `${unit_id}-Q${n}` that no content file uses.
+    await waitFor(() =>
       expect(mockSubmitAnswer).toHaveBeenCalledWith(
         expect.objectContaining({
           session_id: MOCK_SESSION_ID,
           question_id: MOCK_QUIZ.questions[0].question_id,
           answer_index: MOCK_CORRECT_INDEXES[0],
         }),
-      );
-    });
+      ),
+    );
+  });
+
+  it("renders no error initially", () => {
+    renderQuiz();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("surfaces a save error when the answer submission fails", async () => {
+    mockSubmitAnswer.mockRejectedValue(new Error("network"));
+    renderQuiz();
+    fireEvent.click(optionButton(MOCK_QUIZ.questions[0].options[0]));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(KEY.saveError),
+    );
   });
 });

--- a/web/tests/unit/quiz-player-scoring.test.tsx
+++ b/web/tests/unit/quiz-player-scoring.test.tsx
@@ -1,25 +1,18 @@
 /**
- * Unit tests for QuizPlayer scoring (#504).
+ * Unit tests for QuizPlayer scoring (#504, #506) under the #532 defer-results flow.
  *
- * Two regressions live here:
- *
- * 1. The final question was counted twice when answered correctly: `correctCount`
- *    had already been incremented by the REVIEWED reducer before `handleNext`
- *    added `answerResult.correct` again. A student who got 3/5 right (last one
- *    correct) saw 4/5. At full marks it sent score=6 for a 5-question quiz, which
- *    the clamps quietly rewrote to 5 — that was the real cause of #460.
- *
- * 2. Scoring was client-side entirely. The quiz payload shipped the answer key and
- *    the browser told the backend both `correct` per answer and the final `score`.
- *    Grading is now the server's job: the player sends only the picked option, and
- *    the result screen renders the score the server reports.
+ * The contract these pin: scoring is the SERVER's job. The quiz payload never
+ * ships the answer key; the player sends only the picked option and renders the
+ * score the server reports at the end — it never counts locally (which is also
+ * why the old local double-count that caused #460 can't recur: there is no local
+ * tally to inflate). The per-answer reveal is withheld until the summary.
  *
  * Run with:
  *   npm test -- quiz-player-scoring
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { QuizPlayer } from "@/components/content/QuizPlayer";
 import type { QuizContent } from "@/lib/types/api";
 
@@ -72,19 +65,16 @@ const WRONG = 1;
 /** Server-side grading, simulated: option 0 is the correct one. */
 const SERVER_CORRECT_INDEX = 0;
 
+// #532 flow: pick an option (it submits in the background, no Submit button),
+// move with "Next", and "Finish" at the end. Labels are the i18n keys under the
+// mock above.
 async function playQuiz(answers: number[]) {
   for (let i = 0; i < answers.length; i++) {
     const isLast = i === answers.length - 1;
-    const nextLabel = isLast ? /see results/i : /next question/i;
-
     fireEvent.click(await screen.findByText(QUIZ.questions[i].options[answers[i]]));
-    fireEvent.click(screen.getByRole("button", { name: /submit answer/i }));
-
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: nextLabel })).toBeTruthy(),
-    );
-    fireEvent.click(screen.getByRole("button", { name: nextLabel }));
+    if (!isLast) fireEvent.click(screen.getByRole("button", { name: "next" }));
   }
+  fireEvent.click(screen.getByRole("button", { name: "finish" }));
 }
 
 // ---------------------------------------------------------------------------
@@ -108,7 +98,7 @@ describe("QuizPlayer", () => {
 
   describe("server-side grading contract", () => {
     it("submits only the picked option — never a correctness claim", async () => {
-      render(<QuizPlayer quiz={QUIZ} sessionId="s1" curriculumId="default-2026-g8" />);
+      render(<QuizPlayer quiz={QUIZ} sessionId="s1" />);
       await playQuiz([CORRECT, WRONG, WRONG, CORRECT, CORRECT]);
 
       const firstCall = mockSubmitAnswer.mock.calls[0][0];
@@ -123,7 +113,7 @@ describe("QuizPlayer", () => {
     });
 
     it("ends the session without sending a score", async () => {
-      render(<QuizPlayer quiz={QUIZ} sessionId="s1" curriculumId="default-2026-g8" />);
+      render(<QuizPlayer quiz={QUIZ} sessionId="s1" />);
       await playQuiz([CORRECT, WRONG, WRONG, CORRECT, CORRECT]);
 
       await waitFor(() => expect(mockEndSession).toHaveBeenCalledTimes(1));
@@ -139,7 +129,7 @@ describe("QuizPlayer", () => {
         attempt_number: 1,
       });
 
-      render(<QuizPlayer quiz={QUIZ} sessionId="s1" curriculumId="default-2026-g8" />);
+      render(<QuizPlayer quiz={QUIZ} sessionId="s1" />);
       await playQuiz([CORRECT, WRONG, WRONG, CORRECT, CORRECT]);
 
       expect(await screen.findByText(/"score":2/)).toBeTruthy();
@@ -147,13 +137,24 @@ describe("QuizPlayer", () => {
   });
 
   describe("reveal comes from the server response", () => {
-    it("shows the explanation returned with the verdict", async () => {
-      render(<QuizPlayer quiz={QUIZ} sessionId="s1" curriculumId="default-2026-g8" />);
+    it("shows the explanation (from the server) on the end-of-quiz summary, not mid-quiz", async () => {
+      render(<QuizPlayer quiz={QUIZ} sessionId="s1" />);
 
+      // Answer one question; the verdict/explanation must NOT appear yet.
       fireEvent.click(await screen.findByText("Wrong A"));
-      fireEvent.click(screen.getByRole("button", { name: /submit answer/i }));
+      await waitFor(() => expect(mockSubmitAnswer).toHaveBeenCalled());
+      expect(screen.queryByText("Because that is the right one.")).toBeNull();
 
-      expect(await screen.findByText("Because that is the right one.")).toBeTruthy();
+      // Finish (with the rest blank → confirm), then the summary reveals it.
+      fireEvent.click(screen.getByRole("button", { name: "finish" }));
+      const dialog = await screen.findByRole("alertdialog");
+      fireEvent.click(
+        within(dialog).getByRole("button", { name: "blank_warning_confirm" }),
+      );
+
+      expect(
+        (await screen.findAllByText("Because that is the right one.")).length,
+      ).toBeGreaterThan(0);
     });
   });
 });


### PR DESCRIPTION
Implements Venki's approved quiz shape (#532): *answer everything at your own pace, then see how you did.*

## What
- **QuizPlayer rebuilt** — one question at a time with **Back/Next** and a tappable **question-number row** (answered vs blank). Answers submit as they're picked but the **verdict is withheld** until the end. Finishing with blanks prompts a **confirmation** (they score wrong). An **end-of-quiz summary** lists every question with the student's choice, the correct option, and the explanation, score at the top.
- **Backend tally fix (the blocker)** — the Redis score is now a per-question **hash** (`quizanswers:{session_id}`), so re-answering (which skip-and-return enables) overwrites a question's verdict instead of double-counting. The DB fallback (`count_correct_answers`) now takes the **latest row per question** (`DISTINCT ON … ORDER BY recorded_at DESC`) since answers are append-only. New key string avoids WRONGTYPE across deploy.
- **`quiz_screen` i18n** block added to en/fr/es.
- **e2e webServer env** in `playwright.config.ts` corrected to the `@auth0/nextjs-auth0` **v4** names (`AUTH0_DOMAIN`/`APP_BASE_URL`) — same drift as #535 — so local `npx playwright test` boots the dev server.

## Why
Skip-and-return is meaningless without deferred results; they're one feature. The tally had to become idempotent *before* revisiting could be exposed, or a 3/4 run could present as 3/3.

## Scope decision (experience, not anti-cheat)
Per the issue, answers are still submitted per pick and the client withholds the verdict — server-side withholding can be layered later without rework. **Skipped questions** show as "not answered" on the summary without revealing the correct option (the client only holds correct answers for questions it actually submitted; no contract change, no answer leak for never-attempted questions).

## Test plan
- **Backend unit** (`test_progress_server_side_grading.py`): revisiting a correct answer keeps score at 3/4; changing an answer takes only the latest verdict; all-wrong = 0; none-when-absent.
- **Live anticheat** (`quiz_suite/test_anticheat.py`): new test — re-submitting a correct answer within a session doesn't inflate the end score.
- **Mocked e2e** (`student_flow.spec.ts`): rewritten to the new flow — pick options, no mid-quiz reveal, Finish → summary shows 3/3 + revealed explanations.
- **Live browser** (`quiz-suite/*.spec.ts`): journey + failure specs updated to submit-on-pick / Finish / summary.

### Verified locally
- Backend tally **algorithm** validated standalone (all cases pass); `py_compile` clean.
- Frontend **typecheck + ESLint + Prettier** all clean.
- Dev server **boots** with the fixed playwright.config env (no Auth0 crash).

### Not run locally (needs environments I don't have here) → **relying on CI / a live-stack run**
- `pytest` (no DB/containers in my shell) → CI **Backend — Tests** covers the unit tally tests.
- Playwright browser tier: the `chrome-headless-shell` binary wouldn't install in my sandbox → CI **Playwright — Student Flow** covers `student_flow.spec.ts`. The **live quiz-suite** tier (`./scripts/quiz_suite.sh`) still needs a run against the live stack before Venki retests.

Closes #532
Related: #524 (dead-button bug in the same screen), #506 (server-side grading — not weakened), #535 (the e2e Auth0 env drift this also touches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)