### PR TITLE
fix(quiz): grade forks/overrides the way they're served (#529)

### DIFF
--- a/backend/src/content/router.py
+++ b/backend/src/content/router.py
@@ -50,7 +50,6 @@ from src.content.service import (
     get_content_file,
     get_entitlement,
     get_next_quiz_set,
-    get_unit_subject,
     increment_lessons_accessed,
     resolve_curriculum_id,
 )
@@ -145,7 +144,7 @@ async def _get_curriculum_and_check_published(
     curriculum_units and content_subject_versions lookups work correctly.
     Raises HTTPException 404 if not published, 403 if blocked.
     """
-    from src.content.service import get_fork_source_curriculum as _gfsc
+    from src.content.service import resolve_content_curriculum as _rcc
 
     redis = get_redis(request)
     pool = request.app.state.pool
@@ -157,17 +156,11 @@ async def _get_curriculum_and_check_published(
         student_id, grade, pool, redis, school_id=school_id
     )
 
-    subject = await get_unit_subject(unit_id, curriculum_id, pool)
-
     # Fork→OOB fallback: school fork curricula have no rows in curriculum_units
-    # (those live under the source OOB curriculum_id). Swap to the OOB id so
-    # that the published check and content store reads work correctly.
-    if subject is None and school_id:
-        source_id = await _gfsc(curriculum_id, school_id, pool)
-        if source_id:
-            subject = await get_unit_subject(unit_id, source_id, pool)
-            if subject is not None:
-                curriculum_id = source_id
+    # (those live under the source OOB curriculum_id). Swap to the OOB id so that
+    # the published check and content store reads work. This is the SAME helper the
+    # quiz grading path uses, so the two can no longer drift (#529).
+    curriculum_id, subject = await _rcc(unit_id, curriculum_id, school_id, pool)
 
     if subject is None:
         raise HTTPException(

--- a/backend/src/content/service.py
+++ b/backend/src/content/service.py
@@ -574,6 +574,18 @@ async def get_quiz_answer_key(
             curriculum_id, unit_id, f"quiz_set_{set_number}_en.json", redis, storage
         )
 
+    return _parse_quiz_answer_key(data, curriculum_id, unit_id, set_number)
+
+
+def _parse_quiz_answer_key(
+    data: dict, curriculum_id: str, unit_id: str, set_number: int
+) -> dict[str, dict]:
+    """Build {question_id: {index, explanation}} from a quiz-set body.
+
+    Shared by the content-store path (`get_quiz_answer_key`) and the teacher-override
+    path (`resolve_quiz_answer_key`) so both grade a question the same way — by the
+    correct option's position in its OWN options list, matched by `option_id`.
+    """
     key: dict[str, dict] = {}
     for question in data.get("questions", []):
         qid = question.get("question_id")
@@ -604,3 +616,64 @@ async def get_quiz_answer_key(
             "explanation": question.get("explanation", ""),
         }
     return key
+
+
+async def resolve_content_curriculum(
+    unit_id: str,
+    curriculum_id: str,
+    school_id: str | None,
+    pool: asyncpg.Pool,
+) -> tuple[str, str | None]:
+    """Resolve the curriculum_id + subject to SERVE/GRADE store content under.
+
+    School fork curricula have no rows in `curriculum_units` (those live under the
+    source OOB curriculum_id), so for a fork we swap to the source. Returns the
+    (possibly swapped) curriculum_id and the unit's subject, or (curriculum_id,
+    None) when the unit resolves nowhere.
+
+    This is the single source of truth for the fork→OOB swap that both the content
+    serving path and the quiz grading path depend on. They drifted before
+    (grading skipped the swap → every answer 404'd for fork-adopting schools, #529).
+    """
+    subject = await get_unit_subject(unit_id, curriculum_id, pool)
+    if subject is None and school_id:
+        source_id = await get_fork_source_curriculum(curriculum_id, school_id, pool)
+        if source_id:
+            src_subject = await get_unit_subject(unit_id, source_id, pool)
+            if src_subject is not None:
+                return source_id, src_subject
+    return curriculum_id, subject
+
+
+async def resolve_quiz_answer_key(
+    school_id: str | None,
+    curriculum_id: str,
+    unit_id: str,
+    set_number: int,
+    lang: str,
+    pool: asyncpg.Pool,
+    redis,
+    storage: StorageBackend,
+) -> dict[str, dict]:
+    """Grading-side answer key that mirrors exactly what the student was SERVED.
+
+    Serving a quiz to a school student (content/router.py) resolves it in this
+    order: an active teacher override (keyed by the school's own/fork curriculum_id)
+    wins; otherwise store content under the fork's OOB source. Grading has to follow
+    the same order or it grades against the wrong key:
+
+    - override present  → grade against the override body (its `q1…qN` differ from
+      the store's — the pitfall #35 collision that misgrades silently, #529);
+    - fork, no override → swap to the OOB source and read the store (the fork has no
+      store content of its own → a raw lookup 404s, #529).
+
+    Raises FileNotFoundError only when the store content is genuinely absent.
+    """
+    if school_id:
+        override = await get_active_override(
+            school_id, curriculum_id, unit_id, lang, f"quiz_set_{set_number}", pool, redis
+        )
+        if override:
+            return _parse_quiz_answer_key(override, curriculum_id, unit_id, set_number)
+        curriculum_id, _ = await resolve_content_curriculum(unit_id, curriculum_id, school_id, pool)
+    return await get_quiz_answer_key(curriculum_id, unit_id, set_number, lang, redis, storage)

--- a/backend/src/progress/router.py
+++ b/backend/src/progress/router.py
@@ -28,7 +28,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from src.auth.dependencies import get_current_student
-from src.content.service import get_quiz_answer_key, resolve_curriculum_id
+from src.content.service import resolve_curriculum_id, resolve_quiz_answer_key
 from src.core.db import get_db
 from src.core.storage import StorageBackend, get_storage
 from src.progress.schemas import (
@@ -178,11 +178,16 @@ async def record_answer(
         set_number = await resolve_session_quiz_set(
             redis, session_id=session_id, student_id=student_id, unit_id=session["unit_id"]
         )
-        answer_key = await get_quiz_answer_key(
+        # Mirror the serving path: teacher override wins, else swap a school fork to
+        # its OOB source before reading the store. Grading against session's raw
+        # curriculum_id 404'd for forks and misgraded overrides (#529).
+        answer_key = await resolve_quiz_answer_key(
+            school_id=student.get("school_id"),
             curriculum_id=session["curriculum_id"],
             unit_id=session["unit_id"],
             set_number=set_number,
             lang=student.get("locale", "en"),
+            pool=request.app.state.pool,
             redis=redis,
             storage=storage,
         )
@@ -334,11 +339,15 @@ async def end_session_endpoint(
                 student_id=student_id,
                 unit_id=session_row["unit_id"],
             )
-            answer_key = await get_quiz_answer_key(
+            # Same override→fork-swap resolution as the answer path (#529), so the
+            # denominator matches the set the student was actually graded against.
+            answer_key = await resolve_quiz_answer_key(
+                school_id=student.get("school_id"),
                 curriculum_id=session_row["curriculum_id"],
                 unit_id=session_row["unit_id"],
                 set_number=set_number,
                 lang=student.get("locale", "en"),
+                pool=request.app.state.pool,
                 redis=redis,
                 storage=storage,
             )

--- a/backend/tests/test_content.py
+++ b/backend/tests/test_content.py
@@ -78,7 +78,11 @@ def _published_mocks(unit_id: str = "G8-SCI-001", subject: str = "G8-SCI"):
     """Return the standard stack of mocks for a published, unblocked unit."""
     return [
         patch("src.content.router.resolve_curriculum_id", new_callable=AsyncMock, return_value="default-2026-g8"),
-        patch("src.content.router.get_unit_subject", new_callable=AsyncMock, return_value=subject),
+        patch(
+            "src.content.service.resolve_content_curriculum",
+            new_callable=AsyncMock,
+            side_effect=lambda _u, _c, _s, _p, _v=subject: (_c, _v),
+        ),
         patch("src.content.router.check_content_published", new_callable=AsyncMock, return_value=True),
         patch("src.content.router.check_content_block", new_callable=AsyncMock, return_value=False),
     ]
@@ -95,7 +99,11 @@ async def test_lesson_returns_content(client: AsyncClient, fake_redis):
 
     with (
         patch("src.content.router.resolve_curriculum_id", new_callable=AsyncMock, return_value="default-2026-g8"),
-        patch("src.content.router.get_unit_subject", new_callable=AsyncMock, return_value="G8-SCI"),
+        patch(
+            "src.content.service.resolve_content_curriculum",
+            new_callable=AsyncMock,
+            side_effect=lambda _u, _c, _s, _p, _v="G8-SCI": (_c, _v),
+        ),
         patch("src.content.router.check_content_published", new_callable=AsyncMock, return_value=True),
         patch("src.content.router.check_content_block", new_callable=AsyncMock, return_value=False),
         patch("src.content.router.get_entitlement", new_callable=AsyncMock,
@@ -125,7 +133,11 @@ async def test_lesson_unpublished_returns_404(client: AsyncClient, fake_redis):
 
     with (
         patch("src.content.router.resolve_curriculum_id", new_callable=AsyncMock, return_value="default-2026-g8"),
-        patch("src.content.router.get_unit_subject", new_callable=AsyncMock, return_value="G8-SCI"),
+        patch(
+            "src.content.service.resolve_content_curriculum",
+            new_callable=AsyncMock,
+            side_effect=lambda _u, _c, _s, _p, _v="G8-SCI": (_c, _v),
+        ),
         # Content not published
         patch("src.content.router.check_content_published", new_callable=AsyncMock, return_value=False),
         patch("src.content.router.check_content_block", new_callable=AsyncMock, return_value=False),
@@ -147,7 +159,11 @@ async def test_lesson_free_tier_limit(client: AsyncClient, fake_redis):
 
     with (
         patch("src.content.router.resolve_curriculum_id", new_callable=AsyncMock, return_value="default-2026-g8"),
-        patch("src.content.router.get_unit_subject", new_callable=AsyncMock, return_value="G8-SCI"),
+        patch(
+            "src.content.service.resolve_content_curriculum",
+            new_callable=AsyncMock,
+            side_effect=lambda _u, _c, _s, _p, _v="G8-SCI": (_c, _v),
+        ),
         patch("src.content.router.check_content_published", new_callable=AsyncMock, return_value=True),
         patch("src.content.router.check_content_block", new_callable=AsyncMock, return_value=False),
         # Student has already accessed 2 lessons on the free tier
@@ -184,7 +200,11 @@ async def test_quiz_rotates_sets(client: AsyncClient, fake_redis):
 
     with (
         patch("src.content.router.resolve_curriculum_id", new_callable=AsyncMock, return_value="default-2026-g8"),
-        patch("src.content.router.get_unit_subject", new_callable=AsyncMock, return_value="G8-SCI"),
+        patch(
+            "src.content.service.resolve_content_curriculum",
+            new_callable=AsyncMock,
+            side_effect=lambda _u, _c, _s, _p, _v="G8-SCI": (_c, _v),
+        ),
         patch("src.content.router.check_content_published", new_callable=AsyncMock, return_value=True),
         patch("src.content.router.check_content_block", new_callable=AsyncMock, return_value=False),
         patch("src.content.router.get_content_file", side_effect=_mock_get_content_file),
@@ -211,7 +231,11 @@ async def test_experiment_not_found_for_non_lab_unit(client: AsyncClient, fake_r
 
     with (
         patch("src.content.router.resolve_curriculum_id", new_callable=AsyncMock, return_value="default-2026-g8"),
-        patch("src.content.router.get_unit_subject", new_callable=AsyncMock, return_value="G8-MATH"),
+        patch(
+            "src.content.service.resolve_content_curriculum",
+            new_callable=AsyncMock,
+            side_effect=lambda _u, _c, _s, _p, _v="G8-MATH": (_c, _v),
+        ),
         patch("src.content.router.check_content_published", new_callable=AsyncMock, return_value=True),
         patch("src.content.router.check_content_block", new_callable=AsyncMock, return_value=False),
         # No experiment file exists for this unit
@@ -251,7 +275,11 @@ async def test_experiment_returns_200_for_lab_unit(client: AsyncClient, fake_red
 
     with (
         patch("src.content.router.resolve_curriculum_id", new_callable=AsyncMock, return_value="default-2026-g8"),
-        patch("src.content.router.get_unit_subject", new_callable=AsyncMock, return_value="G8-SCI"),
+        patch(
+            "src.content.service.resolve_content_curriculum",
+            new_callable=AsyncMock,
+            side_effect=lambda _u, _c, _s, _p, _v="G8-SCI": (_c, _v),
+        ),
         patch("src.content.router.check_content_published", new_callable=AsyncMock, return_value=True),
         patch("src.content.router.check_content_block", new_callable=AsyncMock, return_value=False),
         patch("src.content.router.get_content_file", new_callable=AsyncMock, return_value=fake_experiment),
@@ -375,7 +403,11 @@ async def test_audio_returns_url(client: AsyncClient, fake_redis):
 
     with (
         patch("src.content.router.resolve_curriculum_id", new_callable=AsyncMock, return_value="default-2026-g8"),
-        patch("src.content.router.get_unit_subject", new_callable=AsyncMock, return_value="G8-SCI"),
+        patch(
+            "src.content.service.resolve_content_curriculum",
+            new_callable=AsyncMock,
+            side_effect=lambda _u, _c, _s, _p, _v="G8-SCI": (_c, _v),
+        ),
         patch("src.content.router.check_content_published", new_callable=AsyncMock, return_value=True),
         patch("src.content.router.check_content_block", new_callable=AsyncMock, return_value=False),
     ):
@@ -413,7 +445,11 @@ async def test_demo_student_bypasses_free_tier_lesson_limit(client: AsyncClient,
 
     with (
         patch("src.content.router.resolve_curriculum_id", new_callable=AsyncMock, return_value="default-2026-g8"),
-        patch("src.content.router.get_unit_subject", new_callable=AsyncMock, return_value="G8-SCI"),
+        patch(
+            "src.content.service.resolve_content_curriculum",
+            new_callable=AsyncMock,
+            side_effect=lambda _u, _c, _s, _p, _v="G8-SCI": (_c, _v),
+        ),
         patch("src.content.router.check_content_published", new_callable=AsyncMock, return_value=True),
         patch("src.content.router.check_content_block", new_callable=AsyncMock, return_value=False),
         # get_entitlement should NOT be called for demo students — assert it is never reached
@@ -443,7 +479,11 @@ async def test_regular_student_still_hits_free_tier_limit(client: AsyncClient, f
 
     with (
         patch("src.content.router.resolve_curriculum_id", new_callable=AsyncMock, return_value="default-2026-g8"),
-        patch("src.content.router.get_unit_subject", new_callable=AsyncMock, return_value="G8-SCI"),
+        patch(
+            "src.content.service.resolve_content_curriculum",
+            new_callable=AsyncMock,
+            side_effect=lambda _u, _c, _s, _p, _v="G8-SCI": (_c, _v),
+        ),
         patch("src.content.router.check_content_published", new_callable=AsyncMock, return_value=True),
         patch("src.content.router.check_content_block", new_callable=AsyncMock, return_value=False),
         patch("src.content.router.get_entitlement", new_callable=AsyncMock,

--- a/backend/tests/test_progress.py
+++ b/backend/tests/test_progress.py
@@ -140,7 +140,7 @@ async def test_record_answer_returns_200(client, db_conn, student_token):
     await _insert_student(client, student_id)
 
     with patch("src.auth.tasks.celery_app.send_task", return_value=None), \
-         patch("src.progress.router.get_quiz_answer_key", new_callable=AsyncMock,
+         patch("src.progress.router.resolve_quiz_answer_key", new_callable=AsyncMock,
                return_value=_ANSWER_KEY_8Q):
         session = await _start_session(client, student_token)
         r = await client.post(
@@ -211,7 +211,7 @@ async def test_end_session_computes_passed(client, db_conn, student_token):
     await _insert_student(client, student_id)
 
     with patch("src.auth.tasks.celery_app.send_task", return_value=None), \
-         patch("src.progress.router.get_quiz_answer_key", new_callable=AsyncMock,
+         patch("src.progress.router.resolve_quiz_answer_key", new_callable=AsyncMock,
                return_value=_ANSWER_KEY_8Q):
         session = await _start_session(client, student_token)
         await _answer_all(client, student_token, session["session_id"], correct_count=6)
@@ -240,7 +240,7 @@ async def test_client_cannot_inflate_its_own_score(client, db_conn, student_toke
     await _insert_student(client, payload["student_id"])
 
     with patch("src.auth.tasks.celery_app.send_task", return_value=None), \
-         patch("src.progress.router.get_quiz_answer_key", new_callable=AsyncMock,
+         patch("src.progress.router.resolve_quiz_answer_key", new_callable=AsyncMock,
                return_value=_ANSWER_KEY_8Q):
         session = await _start_session(client, student_token)
 
@@ -321,7 +321,7 @@ async def test_grading_uses_the_resolved_curriculum_not_the_clients(client, db_c
         return _ANSWER_KEY_8Q
 
     with patch("src.auth.tasks.celery_app.send_task", return_value=None), \
-         patch("src.progress.router.get_quiz_answer_key", new=_capture):
+         patch("src.progress.router.resolve_quiz_answer_key", new=_capture):
         r = await client.post(
             "/api/v1/progress/session",
             json={"unit_id": "G8-MATH-001", "curriculum_id": "default"},
@@ -368,7 +368,7 @@ async def test_end_session_not_passed_below_threshold(client, db_conn, student_t
     await _insert_student(client, student_id)
 
     with patch("src.auth.tasks.celery_app.send_task", return_value=None), \
-         patch("src.progress.router.get_quiz_answer_key", new_callable=AsyncMock,
+         patch("src.progress.router.resolve_quiz_answer_key", new_callable=AsyncMock,
                return_value=_ANSWER_KEY_8Q):
         session = await _start_session(client, student_token)
         await _answer_all(client, student_token, session["session_id"], correct_count=4)

--- a/backend/tests/test_quiz_fork_grading_529.py
+++ b/backend/tests/test_quiz_fork_grading_529.py
@@ -1,0 +1,136 @@
+"""
+#529 — quiz grading must resolve content the SAME way serving does.
+
+Before this fix the grading path graded against `session.curriculum_id` verbatim.
+For a school on a FORKED curriculum that id has no store content (it lives under
+the OOB source) → every answer 404'd. And a teacher OVERRIDE was served but graded
+against the store file → silent misgrade (pitfall #35: q1…qN are identical ids
+across sets/bodies).
+
+These pin the two collaborators the grading path now shares with serving:
+`resolve_content_curriculum` (the fork→OOB swap) and `resolve_quiz_answer_key`
+(override-first, then fork-swap + store). Pure unit tests — the DB/store/redis
+collaborators are mocked, so the resolution ORDER is what's asserted.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import src.content.service as svc
+
+# A teacher-override quiz body: same shape as a store quiz set. "B" is correct →
+# index 1 in this A,B list. Deliberately different from STORE_KEY's index 0 so a
+# test can tell which source was used.
+OVERRIDE_BODY = {
+    "questions": [
+        {
+            "question_id": "q1",
+            "options": [{"option_id": "A"}, {"option_id": "B"}],
+            "correct_option": "B",
+            "explanation": "override says B",
+        }
+    ]
+}
+STORE_KEY = {"q1": {"index": 0, "explanation": "store says A"}}
+
+
+# ── resolve_content_curriculum — the fork→OOB swap ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_plain_curriculum_is_not_swapped():
+    with patch.object(svc, "get_unit_subject", AsyncMock(return_value="Mathematics")) as gus:
+        cid, subject = await svc.resolve_content_curriculum(
+            "G8-MATH-001", "curr-A", "school-1", pool=object()
+        )
+    assert cid == "curr-A"
+    assert subject == "Mathematics"
+    gus.assert_awaited_once()  # unit resolved directly; no fork lookup needed
+
+
+@pytest.mark.asyncio
+async def test_fork_swaps_to_oob_source():
+    async def subject_by_curriculum(unit_id, curriculum_id, pool):
+        # The fork has no units of its own; the source does.
+        return None if curriculum_id == "fork-1" else "Science"
+
+    with (
+        patch.object(svc, "get_unit_subject", AsyncMock(side_effect=subject_by_curriculum)),
+        patch.object(svc, "get_fork_source_curriculum", AsyncMock(return_value="default-2026-g8")),
+    ):
+        cid, subject = await svc.resolve_content_curriculum(
+            "G8-SCI-001", "fork-1", "school-1", pool=object()
+        )
+    assert cid == "default-2026-g8"  # swapped
+    assert subject == "Science"
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_unit_returns_none_subject():
+    with (
+        patch.object(svc, "get_unit_subject", AsyncMock(return_value=None)),
+        patch.object(svc, "get_fork_source_curriculum", AsyncMock(return_value=None)),
+    ):
+        cid, subject = await svc.resolve_content_curriculum(
+            "nope", "fork-1", "school-1", pool=object()
+        )
+    assert subject is None
+    assert cid == "fork-1"
+
+
+# ── resolve_quiz_answer_key — override-first, then fork-swap + store ───────────
+
+
+@pytest.mark.asyncio
+async def test_override_wins_and_store_is_not_read():
+    with (
+        patch.object(svc, "get_active_override", AsyncMock(return_value=OVERRIDE_BODY)),
+        patch.object(svc, "get_quiz_answer_key", AsyncMock(return_value=STORE_KEY)) as gk,
+        patch.object(svc, "resolve_content_curriculum", AsyncMock()) as rcc,
+    ):
+        key = await svc.resolve_quiz_answer_key(
+            "school-1", "fork-1", "G8-SCI-001", 1, "en", object(), object(), object()
+        )
+    assert key == {"q1": {"index": 1, "explanation": "override says B"}}  # from override
+    gk.assert_not_awaited()  # store never read
+    rcc.assert_not_awaited()  # no swap when the override answers
+
+
+@pytest.mark.asyncio
+async def test_fork_without_override_swaps_then_reads_store_under_source():
+    with (
+        patch.object(svc, "get_active_override", AsyncMock(return_value=None)),
+        patch.object(
+            svc,
+            "resolve_content_curriculum",
+            AsyncMock(return_value=("default-2026-g8", "Science")),
+        ) as rcc,
+        patch.object(svc, "get_quiz_answer_key", AsyncMock(return_value=STORE_KEY)) as gk,
+    ):
+        key = await svc.resolve_quiz_answer_key(
+            "school-1", "fork-1", "G8-SCI-001", 2, "en", object(), object(), object()
+        )
+    assert key == STORE_KEY
+    rcc.assert_awaited_once()
+    # The store was read under the SWAPPED source id, not the fork (curriculum_id is
+    # the first positional arg to get_quiz_answer_key).
+    assert gk.await_args.args[0] == "default-2026-g8"
+
+
+@pytest.mark.asyncio
+async def test_non_school_student_reads_store_directly():
+    with (
+        patch.object(svc, "get_active_override", AsyncMock()) as gao,
+        patch.object(svc, "resolve_content_curriculum", AsyncMock()) as rcc,
+        patch.object(svc, "get_quiz_answer_key", AsyncMock(return_value=STORE_KEY)) as gk,
+    ):
+        key = await svc.resolve_quiz_answer_key(
+            None, "default-2026-g8", "G8-SCI-001", 1, "en", object(), object(), object()
+        )
+    assert key == STORE_KEY
+    gao.assert_not_awaited()  # no school → no override lookup
+    rcc.assert_not_awaited()  # no school → no fork swap
+    assert gk.await_args.args[0] == "default-2026-g8"


### PR DESCRIPTION
Fixes the high-priority grading/serving drift: for a school on a **forked** curriculum, quizzes were **served** from the OOB source but **graded** against the fork id (which has no store content) → every answer 404'd. And a **teacher-overridden** quiz was served from the override but graded against the store file → silent misgrade (q1…qN are identical ids across bodies, pitfall #35).

## Root cause
The serving path (`content/router.py`) resolved → fork→OOB swap → override check. The grading path (`progress/router.py`) only resolved and graded against `session.curriculum_id`. The two reimplemented overlapping logic and drifted by construction.

## Fix — one shared resolution, used by both paths
In `content/service.py`:
- **`resolve_content_curriculum(unit_id, curriculum_id, school_id, pool)`** — the fork→OOB swap, now the single source of truth. `content/router.py`'s serving helper calls it instead of its own inline copy.
- **`resolve_quiz_answer_key(...)`** — grading-side key that mirrors serving exactly: active teacher override wins (parsed from the override body), else swap a fork to its OOB source and read the store. Both `/answer` and `/end` call it.
- **`_parse_quiz_answer_key`** extracted so store and override bodies grade identically.

Result: a fork-adopting school grades against the OOB source (no more 404), and an overridden quiz grades against the override's own key.

## Verification (ran against a real local docker stack)
- **6 new unit tests** (`test_quiz_fork_grading_529.py`) pin the resolution order: override-first, fork-swap-then-store, non-school passthrough, unresolvable. All pass.
- Existing content/progress tests retargeted to the new seam.
- **Full backend suite: 1186 passed** locally. (The only 2 failures — `test_multi_provider_pipeline.py` — are a local `ANTHROPIC_API_KEY` env gap, unrelated; they pass in CI.)
- **Quiz-suite API tier still 24/24** — the plain school-owned path grades correctly through the new resolver.

## Not reproduced against a live forked school
The issue flagged it as statically-traced, not reproduced. I confirmed the drift in code and pinned both variants with deterministic unit tests, but did not stand up a live fork+override scenario (needs the Epic-12 adopt→import flow). See follow-up.

## Follow-up
Extend the quiz suite (`backend/quiz_suite/seed.py`) with a forked-curriculum + override fixture so the case is covered by the live harness, not only unit tests.

Closes #529
Related: #524 (the same serving/grading drift), #506 (server-side grading), pitfall #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)