### PR TITLE
fix(school): working billing portal button (#521)

### DIFF
--- a/backend/src/school/subscription_router.py
+++ b/backend/src/school/subscription_router.py
@@ -37,6 +37,7 @@ from src.core.db import get_db
 from src.core.redis_client import get_redis
 from src.school.subscription_service import (
     cancel_school_stripe_subscription,
+    create_billing_portal_session,
     create_credits_bundle_checkout_session,
     create_extra_build_checkout_session,
     create_renewal_checkout_session,
@@ -127,6 +128,10 @@ class SchoolSubscriptionStatusResponse(BaseModel):
 class SchoolSubscriptionCancelResponse(BaseModel):
     status: str
     current_period_end: str | None = None
+
+
+class BillingPortalResponse(BaseModel):
+    url: str
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -231,6 +236,95 @@ async def school_subscription_status(
         data = await get_school_subscription_status(conn, school_id)
 
     return SchoolSubscriptionStatusResponse(**data)
+
+
+# ── GET /schools/{school_id}/billing-portal ───────────────────────────────────
+
+
+@router.get(
+    "/schools/{school_id}/billing-portal",
+    response_model=BillingPortalResponse,
+    status_code=200,
+)
+async def school_billing_portal(
+    school_id: str,
+    request: Request,
+    teacher: Annotated[dict, Depends(get_current_teacher)],
+    return_url: str | None = None,
+) -> BillingPortalResponse:
+    """
+    Create a Stripe Billing Portal session and return its URL (#521).
+
+    The school admin manages the subscription, payment method, and invoices in the
+    Stripe-hosted portal. `return_url` is where Stripe sends them back; it defaults
+    to the school settings page. 404 if the school has no Stripe customer yet
+    (i.e. never subscribed) — there is nothing to manage.
+    """
+    _assert_school_match(teacher, school_id, request)
+
+    if teacher.get("role") != "school_admin":
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "forbidden",
+                "detail": "Only school_admin can open the billing portal.",
+                "correlation_id": _cid(request),
+            },
+        )
+
+    import uuid as _uuid
+
+    async with get_db(request) as conn:
+        row = await conn.fetchrow(
+            "SELECT stripe_customer_id FROM school_subscriptions WHERE school_id = $1",
+            _uuid.UUID(school_id),
+        )
+
+    if row is None or not row["stripe_customer_id"]:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": "no_billing_account",
+                "detail": "This school has no billing account yet. Start a subscription first.",
+                "correlation_id": _cid(request),
+            },
+        )
+
+    from config import settings
+
+    default_return = f"{settings.FRONTEND_URL.rstrip('/')}/school/settings"
+    # Only honour a client-supplied return_url if it is an absolute http(s) URL;
+    # otherwise fall back to the configured settings page. Prevents a malformed or
+    # relative value from producing a broken Stripe return.
+    dest = (
+        return_url
+        if (return_url and return_url.startswith(("http://", "https://")))
+        else default_return
+    )
+
+    try:
+        url = await create_billing_portal_session(row["stripe_customer_id"], dest)
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": "payment_unavailable",
+                "detail": str(exc),
+                "correlation_id": _cid(request),
+            },
+        )
+    except Exception as exc:
+        log.error("billing_portal_error school_id=%s error=%s", school_id, exc)
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error": "stripe_error",
+                "detail": "Could not open the billing portal.",
+                "correlation_id": _cid(request),
+            },
+        )
+
+    return BillingPortalResponse(url=url)
 
 
 # ── DELETE /schools/{school_id}/subscription ──────────────────────────────────

--- a/backend/src/school/subscription_service.py
+++ b/backend/src/school/subscription_service.py
@@ -378,6 +378,25 @@ async def cancel_school_stripe_subscription(stripe_subscription_id: str) -> None
     log.info("school_stripe_subscription_cancel_at_period_end sub_id=%s", stripe_subscription_id)
 
 
+async def create_billing_portal_session(stripe_customer_id: str, return_url: str) -> str:
+    """Create a Stripe Billing Portal session for a school's customer.
+
+    Returns the Stripe-hosted portal URL where the school admin can update payment
+    details, download invoices, and manage the subscription. `return_url` is where
+    Stripe sends them back when they close the portal. The customer id is fetched
+    by the router from school_subscriptions — mirroring the cancel endpoint, which
+    takes the subscription id the same way.
+    """
+    stripe = _get_stripe()
+    stripe.api_key = _stripe_key()
+    session = await run_stripe(
+        stripe.billing_portal.Session.create,
+        customer=stripe_customer_id,
+        return_url=return_url,
+    )
+    return session.url
+
+
 # ── Entitlement cache ─────────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_school_subscription.py
+++ b/backend/tests/test_school_subscription.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import AsyncClient
@@ -135,6 +135,91 @@ async def test_school_subscription_status_wrong_school_returns_403(client: Async
 @pytest.mark.asyncio
 async def test_school_subscription_status_requires_auth(client: AsyncClient):
     r = await client.get(f"/api/v1/schools/{uuid.uuid4()}/subscription")
+    assert r.status_code == 401
+
+
+# ── GET /schools/{school_id}/billing-portal (#521) ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_billing_portal_returns_url(client: AsyncClient):
+    """A school with a Stripe customer gets a portal URL. Fails on main today: the
+    endpoint did not exist (the frontend called a non-existent /subscription route)."""
+    reg = await _register_school(client)
+    school_id = reg["school_id"]
+    await _insert_school_subscription(client, school_id)  # sets stripe_customer_id='cus_test'
+    token = make_teacher_token(
+        teacher_id=reg["teacher_id"], school_id=school_id, role="school_admin"
+    )
+
+    portal_mock = AsyncMock(return_value="https://billing.stripe.com/session/test_123")
+    with patch("src.school.subscription_router.create_billing_portal_session", portal_mock):
+        r = await client.get(
+            f"/api/v1/schools/{school_id}/billing-portal?return_url=https://app.example.com/school/settings",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert r.status_code == 200, r.text
+    assert r.json()["url"].startswith("https://billing.stripe.com")
+    # The school's Stripe customer id and the caller's return_url are passed through.
+    portal_mock.assert_awaited_once()
+    customer_id, return_url = portal_mock.await_args.args
+    assert customer_id == "cus_test"
+    assert return_url == "https://app.example.com/school/settings"
+
+
+@pytest.mark.asyncio
+async def test_billing_portal_no_customer_returns_404(client: AsyncClient):
+    """A school that never subscribed has no Stripe customer → 404, not a silent no-op."""
+    reg = await _register_school(client)
+    school_id = reg["school_id"]
+    token = make_teacher_token(
+        teacher_id=reg["teacher_id"], school_id=school_id, role="school_admin"
+    )
+
+    r = await client.get(
+        f"/api/v1/schools/{school_id}/billing-portal",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 404, r.text
+    # The app's exception handler flattens HTTPException.detail to the top level.
+    assert r.json()["error"] == "no_billing_account"
+
+
+@pytest.mark.asyncio
+async def test_billing_portal_wrong_school_returns_403(client: AsyncClient):
+    """A school_admin cannot open the billing portal of a different school."""
+    reg = await _register_school(client)
+    token = make_teacher_token(
+        teacher_id=reg["teacher_id"], school_id=reg["school_id"], role="school_admin"
+    )
+
+    r = await client.get(
+        f"/api/v1/schools/{uuid.uuid4()}/billing-portal",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 403, r.text
+
+
+@pytest.mark.asyncio
+async def test_billing_portal_not_school_admin_returns_403(client: AsyncClient):
+    """A plain teacher (not school_admin) cannot open the billing portal."""
+    reg = await _register_school(client)
+    school_id = reg["school_id"]
+    token = make_teacher_token(
+        teacher_id=reg["teacher_id"], school_id=school_id, role="teacher"
+    )
+
+    r = await client.get(
+        f"/api/v1/schools/{school_id}/billing-portal",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 403, r.text
+
+
+@pytest.mark.asyncio
+async def test_billing_portal_requires_auth(client: AsyncClient):
+    r = await client.get(f"/api/v1/schools/{uuid.uuid4()}/billing-portal")
     assert r.status_code == 401
 
 

--- a/web/app/(school)/school/settings/page.tsx
+++ b/web/app/(school)/school/settings/page.tsx
@@ -2,8 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useTeacher } from "@/lib/hooks/useTeacher";
-import { getSchoolProfile } from "@/lib/api/school-admin";
-import { getBillingPortalUrl } from "@/lib/api/subscription";
+import { getSchoolProfile, getSchoolBillingPortalUrl } from "@/lib/api/school-admin";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -25,6 +24,7 @@ export default function SchoolSettingsPage() {
 
   const [copiedCode, setCopiedCode] = useState(false);
   const [loadingBilling, setLoadingBilling] = useState(false);
+  const [billingError, setBillingError] = useState<string | null>(null);
 
   function copyEnrolmentCode() {
     if (!profile?.enrolment_code) return;
@@ -36,10 +36,23 @@ export default function SchoolSettingsPage() {
 
   async function openBillingPortal() {
     setLoadingBilling(true);
+    setBillingError(null);
     try {
-      const url = await getBillingPortalUrl();
+      const url = await getSchoolBillingPortalUrl(schoolId, window.location.href);
       window.location.href = url;
-    } catch {
+    } catch (err: unknown) {
+      // Surface the failure instead of a silent no-op (#521). A school that has
+      // never subscribed has no billing account yet; anything else is a generic,
+      // non-technical message (Content Rule #5).
+      const status =
+        typeof err === "object" && err !== null && "response" in err
+          ? (err as { response?: { status?: number } }).response?.status
+          : undefined;
+      setBillingError(
+        status === 404
+          ? "Your school doesn't have a billing account yet. Start a subscription first."
+          : "We couldn't open the billing portal. Please try again in a moment.",
+      );
       setLoadingBilling(false);
     }
   }
@@ -168,6 +181,11 @@ export default function SchoolSettingsPage() {
                   <CreditCard className="h-4 w-4" />
                   {loadingBilling ? "Opening portal…" : "Open billing portal"}
                 </Button>
+                {billingError && (
+                  <p role="alert" className="mt-3 text-sm text-red-600">
+                    {billingError}
+                  </p>
+                )}
               </CardContent>
             </Card>
           )}

--- a/web/lib/api/school-admin.ts
+++ b/web/lib/api/school-admin.ts
@@ -17,6 +17,30 @@ export async function getSchoolProfile(schoolId: string): Promise<SchoolProfile>
   return res.data;
 }
 
+// ── Billing portal (#521) ─────────────────────────────────────────────────────
+
+/**
+ * Get a Stripe Billing Portal URL for the school. Uses the TEACHER instance
+ * (`sb_teacher_token`) and the school-scoped endpoint — the old
+ * `getBillingPortalUrl()` in subscription.ts used the student instance and a
+ * route that never existed, so this button silently 404'd (#521).
+ *
+ * `returnUrl` is where Stripe sends the admin back; pass the current page.
+ * Throws on a school with no Stripe customer (404) — the caller surfaces it.
+ */
+export async function getSchoolBillingPortalUrl(
+  schoolId: string,
+  returnUrl?: string,
+): Promise<string> {
+  const res = await schoolApi.get<{ url: string }>(
+    `/schools/${schoolId}/billing-portal`,
+    {
+      params: returnUrl ? { return_url: returnUrl } : undefined,
+    },
+  );
+  return res.data.url;
+}
+
 // ── Roster ────────────────────────────────────────────────────────────────────
 
 export interface RosterItem {

--- a/web/lib/api/types.gen.ts
+++ b/web/lib/api/types.gen.ts
@@ -3736,6 +3736,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/schools/{school_id}/billing-portal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * School Billing Portal
+         * @description Create a Stripe Billing Portal session and return its URL (#521).
+         *
+         *     The school admin manages the subscription, payment method, and invoices in the
+         *     Stripe-hosted portal. `return_url` is where Stripe sends them back; it defaults
+         *     to the school settings page. 404 if the school has no Stripe customer yet
+         *     (i.e. never subscribed) — there is nothing to manage.
+         */
+        get: operations["school_billing_portal_api_v1_schools__school_id__billing_portal_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/schools/{school_id}/curriculum/versions/{curriculum_id}/renewal-checkout": {
         parameters: {
             query?: never;
@@ -6524,6 +6549,11 @@ export interface components {
             version_ids: string[];
             /** Skipped */
             skipped: components["schemas"]["SkippedVersion"][];
+        };
+        /** BillingPortalResponse */
+        BillingPortalResponse: {
+            /** Url */
+            url: string;
         };
         /** BlockRequest */
         BlockRequest: {
@@ -16909,6 +16939,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SchoolSubscriptionCancelResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    school_billing_portal_api_v1_schools__school_id__billing_portal_get: {
+        parameters: {
+            query?: {
+                return_url?: string | null;
+            };
+            header?: never;
+            path: {
+                school_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BillingPortalResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -10226,6 +10226,70 @@
         }
       }
     },
+    "/api/v1/schools/{school_id}/billing-portal": {
+      "get": {
+        "tags": [
+          "school-subscription"
+        ],
+        "summary": "School Billing Portal",
+        "description": "Create a Stripe Billing Portal session and return its URL (#521).\n\nThe school admin manages the subscription, payment method, and invoices in the\nStripe-hosted portal. `return_url` is where Stripe sends them back; it defaults\nto the school settings page. 404 if the school has no Stripe customer yet\n(i.e. never subscribed) \u2014 there is nothing to manage.",
+        "operationId": "school_billing_portal_api_v1_schools__school_id__billing_portal_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "school_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "School Id"
+            }
+          },
+          {
+            "name": "return_url",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Return Url"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingPortalResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/schools/{school_id}/curriculum/versions/{curriculum_id}/renewal-checkout": {
       "post": {
         "tags": [
@@ -17398,6 +17462,19 @@
           "skipped"
         ],
         "title": "BatchApproveResponse"
+      },
+      "BillingPortalResponse": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "title": "BillingPortalResponse"
       },
       "BlockRequest": {
         "properties": {

--- a/web/tests/unit/settings-page.test.tsx
+++ b/web/tests/unit/settings-page.test.tsx
@@ -31,8 +31,10 @@ vi.mock("@tanstack/react-query", async (importOriginal) => {
   return { ...actual, useQuery: vi.fn((opts) => mockUseQuery(opts)) };
 });
 
-vi.mock("@/lib/api/subscription", () => ({
-  getBillingPortalUrl: vi.fn(),
+const mockBillingPortal = vi.fn();
+vi.mock("@/lib/api/school-admin", () => ({
+  getSchoolProfile: vi.fn(),
+  getSchoolBillingPortalUrl: (...args: unknown[]) => mockBillingPortal(...args),
 }));
 
 // Mock clipboard
@@ -175,5 +177,45 @@ describe("SCH-48 — Billing section hidden for non-admin teacher", () => {
   it("shows the contact admin message for non-admin teacher", () => {
     render(<SchoolSettingsPage />);
     expect(screen.getByText(SETTINGS_STRINGS.contactAdmin)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SCH-49 — Billing portal failure is surfaced, not swallowed (#521)
+// ---------------------------------------------------------------------------
+
+describe("SCH-49 — Billing portal failure is surfaced (#521)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseTeacher.mockReturnValue(MOCK_ADMIN);
+    mockUseQuery.mockReturnValue({ data: MOCK_PROFILE, isLoading: false });
+  });
+
+  it("calls the school-scoped portal endpoint with the school id", async () => {
+    mockBillingPortal.mockResolvedValue("https://billing.stripe.com/session/x");
+    render(<SchoolSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Open billing portal/ }));
+    // window.location.href is set on success; assert the API was called correctly.
+    expect(mockBillingPortal).toHaveBeenCalledWith(
+      MOCK_ADMIN.school_id,
+      expect.any(String),
+    );
+  });
+
+  it("shows a 404 message when the school has no billing account", async () => {
+    mockBillingPortal.mockRejectedValue({ response: { status: 404 } });
+    render(<SchoolSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Open billing portal/ }));
+    // The old bare catch showed nothing — this alert fails against main.
+    expect(await screen.findByRole("alert")).toHaveTextContent(/billing account/i);
+  });
+
+  it("shows a generic message on any other failure", async () => {
+    mockBillingPortal.mockRejectedValue({ response: { status: 502 } });
+    render(<SchoolSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Open billing portal/ }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /couldn't open the billing portal/i,
+    );
   });
 });


### PR DESCRIPTION
"Open billing portal" in School Settings silently did nothing. Three stacked defects (from the 07-11 QA report): the endpoint didn't exist, the failure was swallowed by a bare `catch {}`, and the call used the student axios instance.

## Fix
**Backend** — new `GET /schools/{school_id}/billing-portal` in `school/subscription_router.py`:
- `school_admin` JWT; path `school_id` must match the JWT (403 otherwise).
- Returns `{url}` from a Stripe billing-portal session for the school's `stripe_customer_id`; **404** if the school has no customer yet (never subscribed).
- `return_url` query param (validated http(s), defaults to the settings page).
- Service helper `create_billing_portal_session` mirrors the existing checkout/cancel Stripe pattern.

**Frontend**:
- New `getSchoolBillingPortalUrl()` on the **teacher** instance (`school-client`, `sb_teacher_token`) pointed at the new path.
- Settings page calls it with the current URL as `return_url` and now **surfaces failures** — 404 → "no billing account yet", anything else → a generic, non-technical message (Content Rule #5) — instead of a silent no-op.
- Regenerated `openapi.json` + `types.gen.ts`.

## Tests (fail against `main` today)
- **Backend** (`test_school_subscription.py`): portal returns url (asserts the customer id + `return_url` are passed through), 404 no-customer, 403 wrong-school, 403 non-admin, 401 unauthenticated.
- **Web** (`settings-page.test.tsx`, SCH-49): the page surfaces the 404 and the generic error (the old bare catch showed nothing), and calls the school-scoped endpoint with the school id.

Ran the backend tests against a **real local stack** (5/5) and the full web unit suite (837 passed).

## Acceptance ↔ this PR
- ✅ School admin clicks → lands on Stripe portal (happy path returns the URL; page navigates).
- ✅ No Stripe customer → plain-language message, not a silent no-op.
- ✅ Student token → 401 (get_current_teacher); different-school admin → 403.
- ✅ Tests added that fail against main.

## Out of scope
The student-scoped `getBillingPortalUrl()` in `subscription.ts` (still used by the student subscription page) is left as-is — that path is a separate ADR-001 concern.

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)