### PR TITLE
fix(reports): alert thresholds load and display saved values (#526)

### DIFF
--- a/backend/src/reports/router.py
+++ b/backend/src/reports/router.py
@@ -52,6 +52,7 @@ from src.reports.schemas import (
     UnitReport,
 )
 from src.reports.service import (
+    get_alert_settings,
     get_alerts,
     get_at_risk_students,
     get_curriculum_health,
@@ -375,6 +376,23 @@ async def list_alerts(
     async with get_db(request) as conn:
         result = await get_alerts(conn, school_id)
     return AlertListResponse(**result)
+
+
+@router.get("/reports/school/{school_id}/alerts/settings", response_model=AlertSettingsResponse)
+async def get_alert_settings_endpoint(
+    school_id: str,
+    request: Request,
+    teacher: Annotated[dict, Depends(get_current_teacher)],
+) -> AlertSettingsResponse:
+    """Return the school's saved alert thresholds (or server defaults if unset).
+
+    Without this the settings form redrew hardcoded client defaults every visit,
+    so saved values looked lost even though the PUT persisted them (#526).
+    """
+    _check_school(teacher, school_id, request)
+    async with get_db(request) as conn:
+        result = await get_alert_settings(conn, school_id)
+    return AlertSettingsResponse(**result)
 
 
 @router.put("/reports/school/{school_id}/alerts/settings", response_model=AlertSettingsResponse)

--- a/backend/src/reports/schemas.py
+++ b/backend/src/reports/schemas.py
@@ -221,7 +221,8 @@ class AlertSettingsResponse(BaseModel):
     inactive_days_threshold: int
     score_drop_threshold: float
     new_feedback_immediate: bool
-    updated_at: datetime
+    # None when the school has never saved settings and the GET returns defaults (#526).
+    updated_at: datetime | None = None
 
 
 # ── Digest ────────────────────────────────────────────────────────────────────

--- a/backend/src/reports/service.py
+++ b/backend/src/reports/service.py
@@ -990,6 +990,39 @@ async def get_alerts(
     }
 
 
+# Server-owned defaults for a school that has never saved its thresholds. The
+# client no longer keeps its own copy (#526) — these are the single source.
+ALERT_SETTINGS_DEFAULTS = {
+    "pass_rate_threshold": 50.0,
+    "feedback_count_threshold": 3,
+    "inactive_days_threshold": 14,
+    "score_drop_threshold": 10.0,
+    "new_feedback_immediate": True,
+}
+
+
+async def get_alert_settings(
+    conn: asyncpg.Connection,
+    school_id: str,
+) -> dict:
+    """Return the school's saved alert thresholds, or the server defaults if it has
+    never saved any. The write existed but nothing read it back, so the form always
+    redrew hardcoded defaults and saved values looked lost (#526)."""
+    row = await conn.fetchrow(
+        """
+        SELECT school_id::text, pass_rate_threshold, feedback_count_threshold,
+               inactive_days_threshold, score_drop_threshold,
+               new_feedback_immediate, updated_at
+        FROM report_alert_settings
+        WHERE school_id = $1
+        """,
+        uuid.UUID(school_id),
+    )
+    if row is not None:
+        return dict(row)
+    return {"school_id": school_id, **ALERT_SETTINGS_DEFAULTS, "updated_at": None}
+
+
 async def save_alert_settings(
     conn: asyncpg.Connection,
     school_id: str,
@@ -1014,11 +1047,13 @@ async def save_alert_settings(
                   new_feedback_immediate, updated_at
         """,
         uuid.UUID(school_id),
-        settings.get("pass_rate_threshold", 50.0),
-        settings.get("feedback_count_threshold", 3),
-        settings.get("inactive_days_threshold", 14),
-        settings.get("score_drop_threshold", 10.0),
-        settings.get("new_feedback_immediate", True),
+        settings.get("pass_rate_threshold", ALERT_SETTINGS_DEFAULTS["pass_rate_threshold"]),
+        settings.get(
+            "feedback_count_threshold", ALERT_SETTINGS_DEFAULTS["feedback_count_threshold"]
+        ),
+        settings.get("inactive_days_threshold", ALERT_SETTINGS_DEFAULTS["inactive_days_threshold"]),
+        settings.get("score_drop_threshold", ALERT_SETTINGS_DEFAULTS["score_drop_threshold"]),
+        settings.get("new_feedback_immediate", ALERT_SETTINGS_DEFAULTS["new_feedback_immediate"]),
     )
     return dict(row)
 

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -578,6 +578,58 @@ async def test_save_alert_settings_returns_200(client, db_conn):
     assert r2.json()["pass_rate_threshold"] == 45.0
 
 
+@pytest.mark.asyncio
+async def test_get_alert_settings_returns_defaults_when_unset(client, db_conn):
+    """GET returns server-owned defaults for a school that never saved (#526)."""
+    school = await _register_school(client, "_alsget")
+    r = await client.get(
+        f"/api/v1/reports/school/{school['school_id']}/alerts/settings",
+        headers={"Authorization": f"Bearer {school['access_token']}"},
+    )
+    assert r.status_code == 200, r.text
+    d = r.json()
+    assert d["pass_rate_threshold"] == 50.0
+    assert d["inactive_days_threshold"] == 14
+    assert d["feedback_count_threshold"] == 3
+    assert d["new_feedback_immediate"] is True
+    assert d["updated_at"] is None  # nothing saved yet
+
+
+@pytest.mark.asyncio
+async def test_get_alert_settings_reads_back_saved_values(client, db_conn):
+    """The #526 round-trip: save, then read back. Before the GET existed, the form
+    redrew hardcoded defaults and saved values looked lost."""
+    school = await _register_school(client, "_alsrt")
+    school_id = school["school_id"]
+    token = school["access_token"]
+
+    await client.put(
+        f"/api/v1/reports/school/{school_id}/alerts/settings",
+        json={"pass_rate_threshold": 63.0, "inactive_days_threshold": 9},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    r = await client.get(
+        f"/api/v1/reports/school/{school_id}/alerts/settings",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    d = r.json()
+    assert d["pass_rate_threshold"] == 63.0
+    assert d["inactive_days_threshold"] == 9
+    assert d["updated_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_get_alert_settings_wrong_school_returns_403(client, db_conn):
+    """A school admin cannot read another school's alert settings."""
+    school = await _register_school(client, "_alsxs")
+    r = await client.get(
+        f"/api/v1/reports/school/{uuid.uuid4()}/alerts/settings",
+        headers={"Authorization": f"Bearer {school['access_token']}"},
+    )
+    assert r.status_code == 403
+
+
 # ── Digest subscription ────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio

--- a/web/app/(school)/school/reports/alerts/settings/page.tsx
+++ b/web/app/(school)/school/reports/alerts/settings/page.tsx
@@ -1,37 +1,50 @@
 "use client";
 
-import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useTeacher } from "@/lib/hooks/useTeacher";
-import { updateAlertSettings, type AlertSettings } from "@/lib/api/reports";
+import {
+  getAlertSettings,
+  updateAlertSettings,
+  type AlertSettings,
+} from "@/lib/api/reports";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
 import { ArrowLeft, Check } from "lucide-react";
-
-// The backend has no GET for current settings yet, so the form starts from the
-// same defaults the server applies (src/reports/service.py::save_alert_settings).
-const DEFAULTS: AlertSettings = {
-  pass_rate_threshold: 50,
-  feedback_count_threshold: 3,
-  inactive_days_threshold: 14,
-  score_drop_threshold: 10,
-  new_feedback_immediate: true,
-};
 
 export default function AlertSettingsPage() {
   const teacher = useTeacher();
   const schoolId = teacher?.school_id ?? "";
-  const [settings, setSettings] = useState<AlertSettings>(DEFAULTS);
+  const queryClient = useQueryClient();
+
+  // The server owns the defaults now (#526): load the saved thresholds and seed
+  // the form from them, so a saved value is shown on return instead of a
+  // hardcoded placeholder that made saves look lost.
+  const { data: loaded, isLoading } = useQuery({
+    queryKey: ["alert-settings", schoolId],
+    queryFn: () => getAlertSettings(schoolId),
+    enabled: !!schoolId,
+    staleTime: 60_000,
+  });
+
+  const [settings, setSettings] = useState<AlertSettings | null>(null);
+  useEffect(() => {
+    if (loaded) setSettings(loaded);
+  }, [loaded]);
 
   const { mutate, isPending, isSuccess, isError } = useMutation({
-    mutationFn: () => updateAlertSettings(schoolId, settings),
+    mutationFn: () => updateAlertSettings(schoolId, settings as AlertSettings),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["alert-settings", schoolId] });
+    },
   });
 
   function num(key: keyof AlertSettings, value: string) {
-    setSettings((s) => ({ ...s, [key]: Number(value) }));
+    setSettings((s) => (s ? { ...s, [key]: Number(value) } : s));
   }
 
   return (
@@ -49,88 +62,94 @@ export default function AlertSettingsPage() {
           Alerts fire when these limits are crossed. Changes apply to future alerts.
         </p>
       </div>
-      <Card className="border shadow-sm">
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base">Thresholds</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-1.5">
-            <Label htmlFor="pass_rate">Low pass-rate alert below (%)</Label>
-            <Input
-              id="pass_rate"
-              type="number"
-              min={0}
-              max={100}
-              value={settings.pass_rate_threshold}
-              onChange={(e) => num("pass_rate_threshold", e.target.value)}
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="inactive_days">Inactive-student alert after (days)</Label>
-            <Input
-              id="inactive_days"
-              type="number"
-              min={1}
-              value={settings.inactive_days_threshold}
-              onChange={(e) => num("inactive_days_threshold", e.target.value)}
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="feedback_count">Feedback-spike alert at (count)</Label>
-            <Input
-              id="feedback_count"
-              type="number"
-              min={1}
-              value={settings.feedback_count_threshold}
-              onChange={(e) => num("feedback_count_threshold", e.target.value)}
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="score_drop">Score-drop alert at (% drop)</Label>
-            <Input
-              id="score_drop"
-              type="number"
-              min={0}
-              max={100}
-              value={settings.score_drop_threshold}
-              onChange={(e) => num("score_drop_threshold", e.target.value)}
-            />
-          </div>
-          <label className="flex items-center gap-2 pt-1 text-sm text-gray-700">
-            <input
-              type="checkbox"
-              className="h-4 w-4 rounded border-gray-300"
-              checked={settings.new_feedback_immediate}
-              onChange={(e) =>
-                setSettings((s) => ({
-                  ...s,
-                  new_feedback_immediate: e.target.checked,
-                }))
-              }
-            />
-            Notify immediately on new feedback
-          </label>
-        </CardContent>
-      </Card>
-      {isError && (
-        <p className="text-sm text-red-600">Could not save settings. Please try again.</p>
+      {(isLoading || !settings) && <Skeleton className="h-72 rounded-lg" />}
+      {settings && (
+        <>
+          <Card className="border shadow-sm">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Thresholds</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="pass_rate">Low pass-rate alert below (%)</Label>
+                <Input
+                  id="pass_rate"
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={settings.pass_rate_threshold}
+                  onChange={(e) => num("pass_rate_threshold", e.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="inactive_days">Inactive-student alert after (days)</Label>
+                <Input
+                  id="inactive_days"
+                  type="number"
+                  min={1}
+                  value={settings.inactive_days_threshold}
+                  onChange={(e) => num("inactive_days_threshold", e.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="feedback_count">Feedback-spike alert at (count)</Label>
+                <Input
+                  id="feedback_count"
+                  type="number"
+                  min={1}
+                  value={settings.feedback_count_threshold}
+                  onChange={(e) => num("feedback_count_threshold", e.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="score_drop">Score-drop alert at (% drop)</Label>
+                <Input
+                  id="score_drop"
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={settings.score_drop_threshold}
+                  onChange={(e) => num("score_drop_threshold", e.target.value)}
+                />
+              </div>
+              <label className="flex items-center gap-2 pt-1 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-gray-300"
+                  checked={settings.new_feedback_immediate}
+                  onChange={(e) =>
+                    setSettings((s) =>
+                      s ? { ...s, new_feedback_immediate: e.target.checked } : s,
+                    )
+                  }
+                />
+                Notify immediately on new feedback
+              </label>
+            </CardContent>
+          </Card>
+          {isError && (
+            <p className="text-sm text-red-600">
+              Could not save settings. Please try again.
+            </p>
+          )}
+          <Button
+            onClick={() => mutate()}
+            disabled={isPending || !schoolId || !settings}
+            className="gap-2"
+          >
+            {isPending ? (
+              "Saving…"
+            ) : isSuccess ? (
+              <>
+                <Check className="h-4 w-4" />
+                Saved
+              </>
+            ) : (
+              "Save thresholds"
+            )}
+          </Button>
+        </>
       )}
-      <Button
-        onClick={() => mutate()}
-        disabled={isPending || !schoolId}
-        className="gap-2"
-      >
-        {isPending ? (
-          "Saving…"
-        ) : isSuccess ? (
-          <>
-            <Check className="h-4 w-4" />
-            Saved
-          </>
-        ) : (
-          "Save thresholds"
-        )}
-      </Button>
     </div>
   );
 }

--- a/web/lib/api/reports.ts
+++ b/web/lib/api/reports.ts
@@ -256,6 +256,28 @@ export interface AlertSettings {
   new_feedback_immediate: boolean;
 }
 
+/** Load the school's saved alert thresholds (or server defaults if never saved).
+ *  The threshold fields are read back for the settings form (#526). */
+export async function getAlertSettings(schoolId: string): Promise<AlertSettings> {
+  const res = await schoolApi.get<
+    AlertSettings & { school_id: string; updated_at: string | null }
+  >(`/reports/school/${schoolId}/alerts/settings`);
+  const {
+    pass_rate_threshold,
+    feedback_count_threshold,
+    inactive_days_threshold,
+    score_drop_threshold,
+    new_feedback_immediate,
+  } = res.data;
+  return {
+    pass_rate_threshold,
+    feedback_count_threshold,
+    inactive_days_threshold,
+    score_drop_threshold,
+    new_feedback_immediate,
+  };
+}
+
 export async function updateAlertSettings(
   schoolId: string,
   settings: AlertSettings,

--- a/web/lib/api/types.gen.ts
+++ b/web/lib/api/types.gen.ts
@@ -4753,7 +4753,14 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * Get Alert Settings Endpoint
+         * @description Return the school's saved alert thresholds (or server defaults if unset).
+         *
+         *     Without this the settings form redrew hardcoded client defaults every visit,
+         *     so saved values looked lost even though the PUT persisted them (#526).
+         */
+        get: operations["get_alert_settings_endpoint_api_v1_reports_school__school_id__alerts_settings_get"];
         /**
          * Update Alert Settings
          * @description Configure alert thresholds for the school.
@@ -6232,11 +6239,8 @@ export interface components {
             score_drop_threshold: number;
             /** New Feedback Immediate */
             new_feedback_immediate: boolean;
-            /**
-             * Updated At
-             * Format: date-time
-             */
-            updated_at: string;
+            /** Updated At */
+            updated_at?: string | null;
         };
         /** AnalyzeResponse */
         AnalyzeResponse: {
@@ -18437,6 +18441,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AlertListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_alert_settings_endpoint_api_v1_reports_school__school_id__alerts_settings_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                school_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertSettingsResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -12923,6 +12923,52 @@
       }
     },
     "/api/v1/reports/school/{school_id}/alerts/settings": {
+      "get": {
+        "tags": [
+          "reports"
+        ],
+        "summary": "Get Alert Settings Endpoint",
+        "description": "Return the school's saved alert thresholds (or server defaults if unset).\n\nWithout this the settings form redrew hardcoded client defaults every visit,\nso saved values looked lost even though the PUT persisted them (#526).",
+        "operationId": "get_alert_settings_endpoint_api_v1_reports_school__school_id__alerts_settings_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "school_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "School Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertSettingsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
       "put": {
         "tags": [
           "reports"
@@ -16571,8 +16617,15 @@
             "title": "New Feedback Immediate"
           },
           "updated_at": {
-            "type": "string",
-            "format": "date-time",
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Updated At"
           }
         },
@@ -16583,8 +16636,7 @@
           "feedback_count_threshold",
           "inactive_days_threshold",
           "score_drop_threshold",
-          "new_feedback_immediate",
-          "updated_at"
+          "new_feedback_immediate"
         ],
         "title": "AlertSettingsResponse"
       },

--- a/web/tests/unit/alert-settings-page.test.tsx
+++ b/web/tests/unit/alert-settings-page.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for /school/reports/alerts/settings — the #526 fix.
+ *
+ * The bug: the form seeded from a hardcoded DEFAULTS const on every visit, so a
+ * saved threshold was never shown and saves looked lost. These pin that the form
+ * now seeds from the server-loaded settings and saves the edited values.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AlertSettingsPage from "@/app/(school)/school/reports/alerts/settings/page";
+
+vi.mock("@/lib/hooks/useTeacher", () => ({
+  useTeacher: () => ({ school_id: "school-1", role: "school_admin" }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const mockGet = vi.fn();
+const mockUpdate = vi.fn();
+vi.mock("@/lib/api/reports", () => ({
+  getAlertSettings: (...args: unknown[]) => mockGet(...args),
+  updateAlertSettings: (...args: unknown[]) => mockUpdate(...args),
+}));
+
+const SAVED = {
+  pass_rate_threshold: 63,
+  feedback_count_threshold: 3,
+  inactive_days_threshold: 9,
+  score_drop_threshold: 10,
+  new_feedback_immediate: false,
+};
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <AlertSettingsPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("Alert settings page (#526)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(SAVED);
+    mockUpdate.mockResolvedValue(undefined);
+  });
+
+  it("seeds the form from the saved settings, not hardcoded defaults", async () => {
+    renderPage();
+    // 63 is the saved value; the old bug always showed the hardcoded 50.
+    const input = (await screen.findByLabelText(/Low pass-rate/i)) as HTMLInputElement;
+    expect(input.value).toBe("63");
+    const days = screen.getByLabelText(/Inactive-student/i) as HTMLInputElement;
+    expect(days.value).toBe("9");
+  });
+
+  it("saves the (edited) values to the school-scoped endpoint", async () => {
+    renderPage();
+    const input = (await screen.findByLabelText(/Low pass-rate/i)) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "42" } });
+    fireEvent.click(screen.getByRole("button", { name: /Save thresholds/i }));
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith(
+        "school-1",
+        expect.objectContaining({ pass_rate_threshold: 42 }),
+      ),
+    );
+  });
+});


### PR DESCRIPTION
Saving alert thresholds looked like a no-op (07-31 QA report). The **write worked**; the **read didn't exist**, so the form redrew a hardcoded client `DEFAULTS` const on every visit and saved values were invisible.

## Fix
**Backend** — add `GET /reports/school/{school_id}/alerts/settings` (same `_check_school` guard as the PUT):
- Returns the stored row, or **server-owned defaults** when the school has never saved (`updated_at: null` in that case).
- Defaults centralised in `ALERT_SETTINGS_DEFAULTS`; `save_alert_settings` reuses them. `AlertSettingsResponse.updated_at` is now optional.
- Regenerated `openapi.json` + `types.gen.ts`.

**Frontend** — `getAlertSettings()` client fn; the page loads it with `useQuery`, seeds the form from the result, invalidates on successful save, and **drops the hardcoded `DEFAULTS` const** (server owns defaults now).

## Tests (fail against `main` today)
- **Backend** (`test_reports.py`): GET returns defaults when unset (`updated_at` null); the **save → read-back round-trip** returns the saved values; cross-school GET → 403.
- **Web** (`alert-settings-page.test.tsx`): the form seeds from the loaded settings (63, not the old hardcoded 50) and saves the edited value to the school-scoped endpoint.

Ran on the real local stack — `test_reports.py` 23/23; web unit suite 839.

## Acceptance ↔ this PR
- ✅ Change a threshold, save, return → the changed value is displayed (round-trip test + `useQuery` seeding).
- ✅ A school that never saved sees the server's defaults, sourced from the server.
- ✅ Per-school scoped; another school's admin gets 403.

## Note
Diagnosis assumed the PUT already returns 2xx for a school_admin — confirmed by the existing `test_save_alert_settings_returns_200` (still green). No second defect.

Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)