### PR TITLE
fix(stats): label Subject Breakdown as quiz attempts, not "Lessons" (#525)

### DIFF
--- a/backend/src/analytics/router.py
+++ b/backend/src/analytics/router.py
@@ -263,7 +263,7 @@ async def student_stats(
         unit_subj_rows = await conn.fetch(
             f"""
             SELECT unit_id, subject,
-                   COUNT(*) AS lessons,
+                   COUNT(*) AS attempts,
                    SUM(CASE WHEN passed THEN 1 ELSE 0 END) AS passed_count
             FROM progress_sessions
             WHERE student_id = $1
@@ -311,18 +311,20 @@ async def student_stats(
 
     vr = dict(view_rows[0]) if view_rows else {}
 
-    # Aggregate the per-unit rows into per-(display)-subject totals.
+    # Aggregate the per-unit rows into per-(display)-subject totals. This counts
+    # QUIZ ATTEMPTS (progress_sessions), not lessons — it was mislabelled "lessons"
+    # end to end, which read as the lessons-viewed tile and looked wrong (#525).
     breakdown: dict[str, dict[str, int]] = {}
     for r in unit_subj_rows:
         label = display_subject(subject_labels, r["unit_id"], r["subject"])
-        agg = breakdown.setdefault(label, {"lessons": 0, "passed": 0})
-        agg["lessons"] += int(r["lessons"])
+        agg = breakdown.setdefault(label, {"attempts": 0, "passed": 0})
+        agg["attempts"] += int(r["attempts"])
         agg["passed"] += int(r["passed_count"] or 0)
     subject_breakdown = [
         {
             "subject": label,
-            "lessons": agg["lessons"],
-            "pass_rate": round(agg["passed"] / agg["lessons"], 4) if agg["lessons"] else 0.0,
+            "attempts": agg["attempts"],
+            "pass_rate": round(agg["passed"] / agg["attempts"], 4) if agg["attempts"] else 0.0,
         }
         for label, agg in sorted(breakdown.items())
     ]

--- a/backend/tests/test_feedback_473.py
+++ b/backend/tests/test_feedback_473.py
@@ -66,9 +66,17 @@ async def test_subject_breakdown_resolves_names_and_respects_period(client, db_c
     # period=all → both sessions; subjects resolved from unit_id, never "Unknown".
     r = await client.get("/api/v1/analytics/student/stats?period=all", headers=_auth(token))
     assert r.status_code == 200, r.text
-    subjects = {b["subject"] for b in r.json()["subject_breakdown"]}
+    breakdown = r.json()["subject_breakdown"]
+    subjects = {b["subject"] for b in breakdown}
     assert subjects == {"Science", "Mathematics"}
     assert "Unknown" not in subjects
+    # The bars count QUIZ ATTEMPTS and the field is named accordingly (#525) — it
+    # was mislabelled "lessons", which read as the lessons-viewed tile. One session
+    # per subject here → one attempt each.
+    by_subject = {b["subject"]: b for b in breakdown}
+    assert "lessons" not in by_subject["Science"]
+    assert by_subject["Science"]["attempts"] == 1
+    assert by_subject["Mathematics"]["attempts"] == 1
 
     # period=7d → only the recent (1-day-old) Science session is in scope.
     r = await client.get("/api/v1/analytics/student/stats?period=7d", headers=_auth(token))

--- a/web/app/(student)/stats/page.tsx
+++ b/web/app/(student)/stats/page.tsx
@@ -129,10 +129,13 @@ export default function StatsPage() {
             {/* Subject breakdown chart */}
             {stats.subject_breakdown && stats.subject_breakdown.length > 0 && (
               <section>
-                <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold text-gray-800">
+                <h2 className="mb-1 flex items-center gap-2 text-lg font-semibold text-gray-800">
                   <BarChart3 className="h-4 w-4" />
                   Subject Breakdown
                 </h2>
+                {/* State the unit of measure so the chart isn't misread as the
+                    "lessons viewed" tile — it counts quiz attempts (#525). */}
+                <p className="mb-4 text-sm text-gray-500">Quiz attempts per subject</p>
                 <div className="rounded-lg border bg-white p-4 shadow-sm">
                   <ResponsiveContainer width="100%" height={200}>
                     <BarChart
@@ -140,14 +143,14 @@ export default function StatsPage() {
                       margin={{ top: 0, right: 0, bottom: 0, left: -20 }}
                     >
                       <XAxis dataKey="subject" tick={{ fontSize: 11 }} />
-                      <YAxis tick={{ fontSize: 11 }} />
+                      <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
                       <Tooltip
-                        formatter={(value) => [Number(value ?? 0), "Lessons"]}
+                        formatter={(value) => [Number(value ?? 0), "Quiz attempts"]}
                         labelStyle={{ fontSize: 12 }}
                       />
                       {/* Cap width so a single subject renders as a normal bar
                           rather than one block spanning the whole chart (#473). */}
-                      <Bar dataKey="lessons" radius={[4, 4, 0, 0]} maxBarSize={64}>
+                      <Bar dataKey="attempts" radius={[4, 4, 0, 0]} maxBarSize={64}>
                         {stats.subject_breakdown.map((_, i) => (
                           <Cell
                             key={i}

--- a/web/lib/types/api.ts
+++ b/web/lib/types/api.ts
@@ -174,7 +174,7 @@ export interface StudentStats {
   avg_score: number;
   audio_sessions: number;
   session_dates: string[];
-  subject_breakdown: { subject: string; lessons: number; pass_rate: number }[];
+  subject_breakdown: { subject: string; attempts: number; pass_rate: number }[];
 }
 
 // ─── Feedback ────────────────────────────────────────────────────────────────

--- a/web/tests/e2e/data/stats-page.ts
+++ b/web/tests/e2e/data/stats-page.ts
@@ -24,9 +24,9 @@ export const MOCK_STUDENT_STATS: StudentStats = {
   audio_sessions: 4,
   session_dates: ["2026-03-28", "2026-03-27", "2026-03-26", "2026-03-25", "2026-03-24"],
   subject_breakdown: [
-    { subject: "Science", lessons: 6, pass_rate: 0.83 },
-    { subject: "Mathematics", lessons: 4, pass_rate: 0.75 },
-    { subject: "English", lessons: 2, pass_rate: 0.5 },
+    { subject: "Science", attempts: 6, pass_rate: 0.83 },
+    { subject: "Mathematics", attempts: 4, pass_rate: 0.75 },
+    { subject: "English", attempts: 2, pass_rate: 0.5 },
   ],
 };
 

--- a/web/tests/e2e/data/student-dashboard.ts
+++ b/web/tests/e2e/data/student-dashboard.ts
@@ -31,8 +31,8 @@ export const MOCK_STATS: StudentStats = {
   audio_sessions: 5,
   session_dates: [today, yesterday],
   subject_breakdown: [
-    { subject: "Mathematics", lessons: 6, pass_rate: 80 },
-    { subject: "Science", lessons: 6, pass_rate: 70 },
+    { subject: "Mathematics", attempts: 6, pass_rate: 80 },
+    { subject: "Science", attempts: 6, pass_rate: 70 },
   ],
 };
 


### PR DESCRIPTION
The student stats "Subject Breakdown" chart counted **quiz sessions** (`COUNT(*)` over `progress_sessions`) but was named `lessons` end to end with a "Lessons" tooltip — so it read as the separate **"Lessons viewed"** tile above it and looked wrong (17 lessons viewed / 9 quizzes → bars summing to ~9 under a "Lessons" label). Reported in the 07-31 QA round.

## Fix — rename the concept to what it counts
- **`analytics/router.py`**: alias `COUNT(*) AS attempts`; the aggregation and response field are `attempts`.
- **`stats/page.tsx`**: Bar `dataKey` + tooltip now **"Quiz attempts"**, plus a visible **"Quiz attempts per subject"** subtitle so the unit is clear without hovering; `YAxis allowDecimals={false}` (attempts are integers).
- Frontend type (`lib/types/api.ts`) + e2e mock data renamed `lessons → attempts`.

**No OpenAPI/types regen** — the endpoint returns a plain dict (no `response_model`) and the field is hand-typed in `lib/types/api.ts`. Confirmed `subject_breakdown` isn't in `openapi.json`.

## Test (fails against `main`)
`test_feedback_473` now asserts the item field is `attempts` (not `lessons`) and equals the session count.

## Acceptance ↔ this PR
- ✅ The chart's label states what it counts (**Quiz attempts per subject** + tooltip), and matches the query.
- ✅ A student who viewed lessons but took no quizzes sees an empty/consistent chart (the section only renders when `subject_breakdown` is non-empty; it never claimed "lessons").

## Follow-up (product call, noted in #525)
Whether to show **quiz attempts** or **lessons viewed** per subject is a design choice; this PR makes the label honest either way. The 0% pass-rate/score in the original screenshot were the separate grading bug (fixed in #537), not this.

Ran on the real local stack (`test_feedback_473` green) + web unit suite 839.

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)