### PR TITLE
feat(backup): honour per-school backup_cron schedules (#527)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,7 @@ pydantic[email]>=2.3.0
 httpx==0.28.1
 celery[redis]==5.6.3
 celery-redbeat==2.2.0
+croniter==6.2.4  # per-school backup schedule evaluation (#527)
 cachetools==7.0.5
 prometheus-client==0.20.0
 prometheus-fastapi-instrumentator==7.1.0

--- a/backend/src/backup/tasks.py
+++ b/backend/src/backup/tasks.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import asyncpg
@@ -929,30 +929,57 @@ def execute_restore_task(request_id: str) -> None:
 # ── Scheduled backup coordinator ──────────────────────────────────────────────
 
 
+def _backup_due(cron_expr: str, now: datetime) -> bool:
+    """True if `cron_expr` fired in the hour ending at `now`.
+
+    The coordinator runs hourly (Beat), so each run dispatches the schools whose
+    cron fired in the last hour. Basing get_prev at now+1min makes an on-the-hour
+    fire (e.g. `0 3 * * *` at 03:00) count for the 03:00 run rather than being
+    excluded — get_prev is strict-before-base. A malformed cron returns False
+    (skip that school) rather than breaking the whole coordinator (#527).
+    """
+    from croniter import CroniterError, croniter
+
+    try:
+        prev_fire = croniter(cron_expr, now + timedelta(minutes=1)).get_prev(datetime)
+    except (CroniterError, ValueError, TypeError):
+        log.warning("backup_cron_invalid cron=%r", cron_expr)
+        return False
+    return prev_fire > now - timedelta(hours=1)
+
+
 @celery_app.task(name="src.backup.tasks.dispatch_scheduled_backups", bind=False)
 def dispatch_scheduled_backups() -> None:
     """
-    Nightly coordinator: query all schools with a non-null backup_cron and
-    dispatch backup_school_task for each.
+    Hourly coordinator (Beat, every hour on the hour): dispatch a full backup for
+    each school whose `schools.backup_cron` fired in the last hour (#527).
 
-    The per-school cron expression is stored in schools.backup_cron but the
-    nightly dispatch is triggered by this single Beat entry at 02:30 UTC.
-    Individual per-school scheduling (respecting the actual cron expression)
-    is a future enhancement; for now every school with backup_cron set gets
-    a nightly full backup triggered by this task.
+    Previously this ran once nightly and backed up EVERY school with a non-empty
+    backup_cron, ignoring the expression's value — so a school that set `0 18 * * *`
+    still got backed up at the fixed coordinator time. Now the per-school schedule
+    is honoured: the column's value selects the hour, evaluated via `_backup_due`.
     """
 
     async def _do() -> None:
+        now = datetime.now(UTC)
         pool = await _get_pool()
         try:
             async with pool.acquire() as conn:
                 await _bypass(conn)
-                schools = await conn.fetch(
+                candidate_rows = await conn.fetch(
                     """
-                    SELECT school_id FROM schools
+                    SELECT school_id, backup_cron FROM schools
                     WHERE backup_cron IS NOT NULL AND backup_cron != ''
                     """
                 )
+
+            # Only the schools whose cron fired in the hour ending now.
+            schools = [r for r in candidate_rows if _backup_due(r["backup_cron"], now)]
+            log.info(
+                "backup_coordinator_run candidates=%d due=%d",
+                len(candidate_rows),
+                len(schools),
+            )
 
             for school_row in schools:
                 sid = str(school_row["school_id"])

--- a/backend/src/core/celery_app.py
+++ b/backend/src/core/celery_app.py
@@ -191,10 +191,12 @@ celery_app.conf.update(
             "task": "src.auth.tasks.check_teacher_seat_quotas",
             "schedule": crontab(hour=7, minute=0),
         },
-        # Nightly backup coordinator at 02:30 UTC — dispatches per-school backups.
-        "dispatch-scheduled-backups-nightly": {
+        # Backup coordinator runs HOURLY (on the hour): each run dispatches the
+        # schools whose schools.backup_cron fired in the last hour, so per-school
+        # schedules are honoured instead of a single fixed nightly time (#527).
+        "dispatch-scheduled-backups-hourly": {
             "task": "src.backup.tasks.dispatch_scheduled_backups",
-            "schedule": crontab(hour=2, minute=30),
+            "schedule": crontab(minute=0),
         },
     },
 )

--- a/backend/tests/test_backup.py
+++ b/backend/tests/test_backup.py
@@ -838,3 +838,49 @@ def test_backup_notification_no_internal_leak(event):
     assert event not in blob  # internal event name not surfaced
     assert "notified" in captured["text"].lower()  # reassuring message present
     assert captured["to_email"] == "admin@example.com"
+
+
+# ── #527: per-school backup schedule (_backup_due) ────────────────────────────
+#
+# The hourly coordinator dispatches a school only when its schools.backup_cron
+# fired in the last hour. Before this, backup_cron was stored and editable but
+# ignored — every school backed up at the fixed nightly coordinator time.
+
+from datetime import datetime  # noqa: E402
+
+from src.backup.tasks import _backup_due  # noqa: E402
+
+
+def _at(hour: int, minute: int = 0, day: int = 5) -> datetime:
+    # 2026-08-05 is a Wednesday; 2026-08-09 is a Sunday.
+    return datetime(2026, 8, day, hour, minute, 0, tzinfo=UTC)
+
+
+def test_backup_due_matches_on_the_hour_cron():
+    assert _backup_due("0 3 * * *", _at(3))
+    assert not _backup_due("0 3 * * *", _at(2))
+    assert not _backup_due("0 3 * * *", _at(4))
+
+
+def test_backup_due_catches_half_past_cron_on_the_following_run():
+    # 02:30 fire is picked up by the 03:00 run (within the last hour), once.
+    assert _backup_due("30 2 * * *", _at(3))
+    assert not _backup_due("30 2 * * *", _at(2))
+
+
+def test_backup_due_each_daily_cron_matches_exactly_one_hour():
+    for cron, hour in [("0 0 * * *", 0), ("0 18 * * *", 18), ("0 2 * * *", 2)]:
+        due_hours = [h for h in range(24) if _backup_due(cron, _at(h))]
+        assert due_hours == [hour], (cron, due_hours)
+
+
+def test_backup_due_honours_day_of_week():
+    # Sundays only → never due on Wednesday 2026-08-05 …
+    assert not any(_backup_due("0 3 * * 0", _at(h)) for h in range(24))
+    # … but due at 03:00 on Sunday 2026-08-09.
+    assert _backup_due("0 3 * * 0", _at(3, day=9))
+
+
+def test_backup_due_invalid_cron_is_skipped_not_fatal():
+    assert not _backup_due("not a cron", _at(3))
+    assert not _backup_due("", _at(3))


### PR DESCRIPTION
`schools.backup_cron` was stored, editable, and **ignored**: a single nightly Beat entry at 02:30 UTC backed up *every* school with a non-empty cron, so a school that set `0 18 * * *` still ran at 02:30. (Chosen direction: **honour it**.)

## Change
- **Coordinator runs hourly** now (`crontab(minute=0)`); each run dispatches only the schools whose `backup_cron` fired in the last hour.
- **New pure helper `_backup_due(cron, now)`** — evaluates a school's cron with `croniter`, basing `get_prev` at `now + 1min` so an on-the-hour fire (e.g. `0 3 * * *` at 03:00) counts for the 03:00 run rather than being excluded (`get_prev` is strict-before-base). A malformed cron is logged and skipped, not fatal to the whole coordinator.
- Add `croniter==6.2.4`.

Each daily cron matches **exactly one** hourly run → one backup/day; day-of-week is honoured. The old default-time inconsistency (column default `0 2` = 02:00 vs beat 02:30) is resolved by honouring the value — the default now simply means 02:00.

## Tests (fail against `main`)
`_backup_due` unit tests: on-the-hour and half-past crons, **exactly-one-hour per daily cron across all 24h**, day-of-week (Sundays-only cron not due on a Wednesday, due on the Sunday), invalid/empty cron skipped. Ran on the real local stack — `test_backup` 38/38.

## Acceptance ↔ this PR
- ✅ A school's configured schedule is honoured (e.g. `0 18 * * *` runs in the 18:00 hour, not 02:30).
- ✅ The coordinator runs often enough (hourly) for per-school times to be meaningful.
- ✅ Column default aligned with actual behaviour (default `0 2` = honoured 02:00).

## Scope note
There's no **school-facing** editor for `backup_cron` today (it's admin-managed via the backup router — `web/` only references it in generated types). Letting schools self-serve their schedule and see the next run time in the portal is a natural follow-up; this PR makes the stored value actually take effect.

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)