### PR TITLE
fix(demo): actually unpublish api/web host ports

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -107,7 +107,7 @@ services:
       # Two workers for a 2 vCPU box — gunicorn formula (2*N+1) without overcommitting RAM
       GUNICORN_WORKERS: "2"
     # No host-port mapping on demo — Nginx fronts everything.
-    ports: []
+    ports: !override []
     # Drop pgbouncer (disabled in demo) and migrate (one-shot dependency is
     # satisfied at compose-up time anyway).
     depends_on: !override
@@ -208,7 +208,7 @@ services:
       # browser ends up on a non-routable address.
       NEXT_PUBLIC_APP_URL: https://demo.usestudybuddy.com
     # Internal port only — Nginx fronts it.
-    ports: []
+    ports: !override []
     # Base compose bind-mounts ./web:/app for dev hot-reload, which overlays
     # the image's built server.js. Reset that, then mount only the operator-
     # synced tutorial MP4s at the path Next.js serves them from.


### PR DESCRIPTION
## Problem

`docker-compose.demo.yml` already declared `ports: []` for `api` and `web`, with comments saying nginx fronts everything. **It never took effect.** Compose merges the `ports` sequence across override files by *appending*, so an empty list is a no-op and the base compose's `"8000:8000"` / `"3000:3000"` survived into the demo deployment.

Those mappings carry no bind address, so Docker published them on `0.0.0.0`. Docker writes its own iptables `DOCKER` chain, evaluated **before** ufw — so the host firewall's "only 22/80/443" policy did not apply. Both ports were reachable from the public internet on the origin IP, bypassing nginx, TLS and Cloudflare, and exposing the origin address behind the proxied DNS record.

## Fix

`ports: !override []` makes the reset explicit. This file already uses `!override` for `depends_on` in the same service block, so the mechanism was known — it just wasn't applied to `ports`.

## Verification on the demo host

| | before | after |
|---|---|---|
| `studybuddy-api-1` | `0.0.0.0:8000->8000/tcp` | `8000/tcp` |
| `studybuddy-web-1` | `0.0.0.0:3000->3000/tcp` | `3000/tcp` |

From outside the network:

```
curl http://<origin>:8000/   -> connect timeout   (was 404)
curl http://<origin>:3000/   -> connect timeout   (was 200)
https://demo.usestudybuddy.com/              -> 200
https://demo.usestudybuddy.com/api/v1/health -> 200
```

Already applied to the running demo host; this PR keeps it from being reverted by the next `git pull`.

## Why public serving is unaffected

Traffic reaches the app as `demo.usestudybuddy.com` → host nginx → `127.0.0.1:8443` → compose nginx → `api`/`web` over the compose network. `NEXT_PUBLIC_API_URL` already points at the public domain and `INTERNAL_API_URL` uses compose DNS (`http://api:8000`), so neither depends on a host port publish.

## Not included

`db` (line 46) and `redis` (line 54) carry the same no-op `ports: []` and remain published on `127.0.0.1`. Loopback-only, so a correctness wart rather than an exposure — and fixing them means restarting the database. Worth a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)